### PR TITLE
Fix name of GetResourceOauth2Token parameter

### DIFF
--- a/src/bedrock_agentcore/services/identity.py
+++ b/src/bedrock_agentcore/services/identity.py
@@ -152,7 +152,7 @@ class IdentityClient:
 
         # Add optional parameters
         if callback_url:
-            req["callBackUrl"] = callback_url
+            req["resourceOauth2ReturnUrl"] = callback_url
         if force_authentication:
             req["forceAuthentication"] = force_authentication
 

--- a/tests/bedrock_agentcore/services/test_identity.py
+++ b/tests/bedrock_agentcore/services/test_identity.py
@@ -258,7 +258,7 @@ class TestIdentityClient:
                 scopes=scopes,
                 oauth2Flow="USER_FEDERATION",
                 workloadIdentityToken=agent_identity_token,
-                callBackUrl=callback_url,
+                resourceOauth2ReturnUrl=callback_url,
                 forceAuthentication=force_authentication,
             )
 


### PR DESCRIPTION
Fix name of GetResourceOauth2Token parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
