### PR TITLE
fix: don't double wrap json response

### DIFF
--- a/src/bedrock_agentcore/runtime/app.py
+++ b/src/bedrock_agentcore/runtime/app.py
@@ -345,7 +345,7 @@ class BedrockAgentCoreApp(Starlette):
 
     async def _invoke_handler(self, handler, request_context, takes_context, payload):
         if self._invocation_semaphore.locked():
-            return JSONResponse({"error": "Server busy - maximum concurrent requests reached"}, status_code=503)
+            return Exception("Server busy - maximum concurrent requests reached")
 
         async with self._invocation_semaphore:
             try:


### PR DESCRIPTION
We are currently double wrapping JSONResponse when semaphore acquired limit is reached: 

```
2025-07-18 01:56:10,656 - bedrock_agentcore.app - INFO - [dbe564d2] Invocation completed successfully (0.001s)
2025-07-18 01:56:10,657 - bedrock_agentcore.app - ERROR - [dbe564d2] Invocation failed (0.001s)
Traceback (most recent call last):
File "/usr/local/lib/python3.10/site-packages/bedrock_agentcore/runtime/app.py", line 308, in _handle_invocation
    return JSONResponse(result)
File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 190, in __init__
    super().__init__(content, status_code, headers, media_type, background)
File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 47, in __init__
    self.body = self.render(content)
File "/usr/local/lib/python3.10/site-packages/starlette/responses.py", line 193, in render
    return json.dumps(
File "/usr/local/lib/python3.10/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
File "/usr/local/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
File "/usr/local/lib/python3.10/json/encoder.py", line 257, in iterencode
return _iterencode(o, 0)
File "/usr/local/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type JSONResponse is not JSON serializable
INFO:     127.0.0.1:56286 - "POST /invocations HTTP/1.1" 500 Internal Server Error
2025-07-18 01:56:11,780 - bedrock_agentcore.app - INFO - [11289783] Invocation completed successfully (62.530s)
The weather right now is sunny.INFO:     127.0.0.1:54770 - "POST /invocations HTTP/1.1" 200 OK
```