### PR TITLE
fix: fixing get_last_k_turns to return most recent turns

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -974,7 +974,7 @@ class MemoryClient:
 
             # Return the last k turns
             if len(turns) > k:
-                result = turns[-k:]  # Get last k turns
+                result = turns[:k]  # Get last k turns
             else:
                 result = turns
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently the `get_last_k_turns` function is returning the k oldest events as ListEvents by default returns events in reverse-chronological order. This small change will make it so we get the k most recent turns as desired.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
