### PR TITLE
use json to manage local workload identity and user id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ cython_debug/
 # macOS
 .DS_Store
 .agentcore.yaml
+.agentcore.json
 .AppleDouble
 .LSOverride
 

--- a/src/bedrock_agentcore/identity/auth.py
+++ b/src/bedrock_agentcore/identity/auth.py
@@ -157,18 +157,17 @@ async def _get_workload_access_token(client: IdentityClient) -> str:
 
 
 async def _set_up_local_auth(client: IdentityClient) -> str:
+    import json
     import uuid
     from pathlib import Path
 
-    import yaml
-
-    config_path = Path(".agentcore.yaml")
+    config_path = Path(".agentcore.json")
     workload_identity_name = None
     config = {}
     if config_path.exists():
         try:
             with open(config_path, "r", encoding="utf-8") as file:
-                config = yaml.safe_load(file) or {}
+                config = json.load(file) or {}
         except Exception:
             print("Could not find existing workload identity and user id")
 
@@ -189,7 +188,7 @@ async def _set_up_local_auth(client: IdentityClient) -> str:
     try:
         config = {"workload_identity_name": workload_identity_name, "user_id": user_id}
         with open(config_path, "w", encoding="utf-8") as file:
-            yaml.dump(config, file, default_flow_style=False, indent=2)
+            json.dump(config, file, indent=2)
     except Exception:
         print("Warning: could not write the created workload identity to file")
 

--- a/tests_integ/identity/test_auth_flows.py
+++ b/tests_integ/identity/test_auth_flows.py
@@ -30,6 +30,7 @@ async def need_api_key(*, api_key: str):
     print(f"received api key for async func: {api_key}")
 
 
-asyncio.run(need_api_key(api_key=""))
-asyncio.run(need_token_2LO_async(access_token=""))
-asyncio.run(need_token_3LO_async(access_token=""))
+if __name__ == "__main__":
+    asyncio.run(need_api_key(api_key=""))
+    asyncio.run(need_token_2LO_async(access_token=""))
+    asyncio.run(need_token_3LO_async(access_token=""))


### PR DESCRIPTION
*Issue #, if available:*
the sdk is using yaml to manage the workload identity and user id when running locally, but there is currently no yaml dependency

*Description of changes:*
- use json instead of yaml to manage workload identity and user id

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
