### PR TITLE
add optional session parameter to CodeInterpreter for custom credential management

### DIFF
--- a/tests/bedrock_agentcore/tools/test_code_interpreter_client.py
+++ b/tests/bedrock_agentcore/tools/test_code_interpreter_client.py
@@ -8,8 +8,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.get_data_plane_endpoint")
     def test_init(self, mock_get_endpoint, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
         mock_get_endpoint.return_value = "https://mock-endpoint.com"
         region = "us-west-2"
 
@@ -17,7 +19,28 @@ class TestCodeInterpreterClient:
         client = CodeInterpreter(region)
 
         # Assert
-        mock_boto3.client.assert_called_once_with(
+        mock_boto3.Session.assert_called_once()
+        mock_session.client.assert_called_once_with(
+            "bedrock-agentcore", region_name=region, endpoint_url="https://mock-endpoint.com"
+        )
+        assert client.client == mock_client
+        assert client.identifier is None
+        assert client.session_id is None
+
+    @patch("bedrock_agentcore.tools.code_interpreter_client.get_data_plane_endpoint")
+    def test_init_with_custom_session(self, mock_get_endpoint):
+        # Arrange
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_get_endpoint.return_value = "https://mock-endpoint.com"
+        region = "us-west-2"
+
+        # Act
+        client = CodeInterpreter(region, session=mock_session)
+
+        # Assert
+        mock_session.client.assert_called_once_with(
             "bedrock-agentcore", region_name=region, endpoint_url="https://mock-endpoint.com"
         )
         assert client.client == mock_client
@@ -27,6 +50,11 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.boto3")
     def test_property_getters_setters(self, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
+        
         client = CodeInterpreter("us-west-2")
         test_identifier = "test.identifier"
         test_session_id = "test-session-id"
@@ -43,8 +71,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.uuid.uuid4")
     def test_start_with_defaults(self, mock_uuid4, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
         mock_uuid4.return_value.hex = "12345678abcdef"
 
         client = CodeInterpreter("us-west-2")
@@ -67,8 +97,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.boto3")
     def test_start_with_custom_params(self, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
 
         client = CodeInterpreter("us-west-2")
         mock_response = {"codeInterpreterIdentifier": "custom.interpreter", "sessionId": "custom-session-123"}
@@ -94,8 +126,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.boto3")
     def test_stop_when_session_exists(self, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
 
         client = CodeInterpreter("us-west-2")
         client.identifier = "test.identifier"
@@ -114,8 +148,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.boto3")
     def test_stop_when_no_session(self, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
 
         client = CodeInterpreter("us-west-2")
         client.identifier = None
@@ -132,8 +168,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.uuid.uuid4")
     def test_invoke_with_existing_session(self, mock_uuid4, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
         mock_uuid4.return_value.hex = "12345678abcdef"
 
         client = CodeInterpreter("us-west-2")
@@ -158,8 +196,10 @@ class TestCodeInterpreterClient:
     @patch("bedrock_agentcore.tools.code_interpreter_client.boto3")
     def test_invoke_with_no_session(self, mock_boto3):
         # Arrange
+        mock_session = MagicMock()
         mock_client = MagicMock()
-        mock_boto3.client.return_value = mock_client
+        mock_session.client.return_value = mock_client
+        mock_boto3.Session.return_value = mock_session
 
         client = CodeInterpreter("us-west-2")
         client.identifier = None
@@ -195,6 +235,22 @@ class TestCodeInterpreterClient:
             pass
 
         # Assert
-        mock_client_class.assert_called_once_with("us-west-2")
+        mock_client_class.assert_called_once_with("us-west-2", session=None)
+        mock_client.start.assert_called_once()
+        mock_client.stop.assert_called_once()
+
+    @patch("bedrock_agentcore.tools.code_interpreter_client.CodeInterpreter")
+    def test_code_session_context_manager_with_session(self, mock_client_class):
+        # Arrange
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_session = MagicMock()
+
+        # Act
+        with code_session("us-west-2", session=mock_session):
+            pass
+
+        # Assert
+        mock_client_class.assert_called_once_with("us-west-2", session=mock_session)
         mock_client.start.assert_called_once()
         mock_client.stop.assert_called_once()

--- a/tests/bedrock_agentcore/tools/test_code_interpreter_client.py
+++ b/tests/bedrock_agentcore/tools/test_code_interpreter_client.py
@@ -54,7 +54,7 @@ class TestCodeInterpreterClient:
         mock_client = MagicMock()
         mock_session.client.return_value = mock_client
         mock_boto3.Session.return_value = mock_session
-        
+
         client = CodeInterpreter("us-west-2")
         test_identifier = "test.identifier"
         test_session_id = "test-session-id"


### PR DESCRIPTION
Add boto3.Session injection support to CodeInterpreter constructor to enable custom credential configurations and role assumption while maintaining full backward compatibility.

Features:
- Optional session parameter in CodeInterpreter constructor
- Support for pre-configured boto3 sessions with custom credentials
- Enable AWS role assumption and cross-account access
- Session reuse across multiple service clients
- Full backward compatibility with existing implementations

Use Cases:
- Dynamic role switching for multi-tenant applications
- Custom credential configurations beyond environment variables
- Cross-account resource access with assumed roles
- Containerized environments with temporary credentials
- Testing scenarios with mock sessions
- Fine-grained credential management and security

Configuration:
- Compatible with all existing CodeInterpreter functionality

Implementation:
- Updated CodeInterpreter.__init__() to accept optional session parameter
- Modified code_session() context manager to support session injection
- Session validation and client creation logic preserved
- Comprehensive test coverage for both default and custom session scenarios
- Updated documentation with usage examples and best practices

Benefits:
- Enhanced credential flexibility for enterprise applications
- Improved security through controlled session management
- Better testing capabilities with session mocking
- Simplified multi-account and role-based access patterns
- Maintains existing API contract and behavior

Breaking Changes: None
- Default behavior remains identical to previous implementation
- All existing code continues to work without modification
- New functionality only active when session parameter is provided

CLOSES #40