### PR TITLE
feat: add validation for browser live view URL expiry timeout

### DIFF
--- a/src/bedrock_agentcore/tools/browser_client.py
+++ b/src/bedrock_agentcore/tools/browser_client.py
@@ -25,6 +25,7 @@ from .._utils.endpoints import (
 DEFAULT_IDENTIFIER = "aws.browser.v1"
 DEFAULT_SESSION_TIMEOUT = 3600
 DEFAULT_LIVE_VIEW_PRESIGNED_URL_TIMEOUT = 300
+MAX_LIVE_VIEW_PRESIGNED_URL_TIMEOUT = 300
 
 
 class BrowserClient:
@@ -214,14 +215,21 @@ class BrowserClient:
         Args:
             expires (int, optional): The number of seconds until the pre-signed URL expires.
                 Defaults to DEFAULT_LIVE_VIEW_PRESIGNED_URL_TIMEOUT (300 seconds).
+                Maximum allowed value is MAX_LIVE_VIEW_PRESIGNED_URL_TIMEOUT seconds.
 
         Returns:
             str: The pre-signed URL for viewing the browser session.
 
         Raises:
+            ValueError: If expires exceeds MAX_LIVE_VIEW_PRESIGNED_URL_TIMEOUT seconds.
             RuntimeError: If the URL generation fails.
         """
         self.logger.info("Generating live view url...")
+
+        if expires > MAX_LIVE_VIEW_PRESIGNED_URL_TIMEOUT:
+            raise ValueError(
+                f"Expiry timeout cannot exceed {MAX_LIVE_VIEW_PRESIGNED_URL_TIMEOUT} seconds, got {expires}"
+            )
 
         if not self.identifier or not self.session_id:
             self.start()


### PR DESCRIPTION
## Summary
Add client-side validation to prevent service-side 4xx errors when generating browser live view URLs with invalid expiry timeouts.

## Changes
- Add validation in `generate_live_view_url()` to ensure `expiry_timeout_seconds` cannot exceed 300 seconds
- Raise `ValueError` with descriptive message when timeout exceeds the limit
- Add comprehensive test coverage for the new validation logic

## Why this change?
Prevents users from encountering confusing 4xx errors from the service by catching invalid timeout values early on the client side.

## Files Changed
- `src/bedrock_agentcore/tools/browser_client.py` - Added validation logic
- `tests/bedrock_agentcore/tools/test_browser_client.py` - Added test cases

## Testing
- Added unit tests to verify validation works correctly
- Tests cover both valid and invalid timeout scenarios