### PR TITLE
feat(memory): Add passthrough for gmdp and gmcp operations for Memory

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -38,6 +38,28 @@ logger = logging.getLogger(__name__)
 class MemoryClient:
     """High-level Bedrock AgentCore Memory client with essential operations."""
 
+    # AgentCore Memory data plane methods
+    _ALLOWED_GMDP_METHODS = {
+        "retrieve_memory_records",
+        "get_memory_record",
+        "delete_memory_record",
+        "list_memory_records",
+        "create_event",
+        "get_event",
+        "delete_event",
+        "list_events",
+    }
+
+    # AgentCore Memory control plane methods
+    _ALLOWED_GMCP_METHODS = {
+        "create_memory",
+        "get_memory",
+        "list_memories",
+        "update_memory",
+        "delete_memory",
+        "list_memory_strategies",
+    }
+
     def __init__(self, region_name: Optional[str] = None):
         """Initialize the Memory client."""
         self.region_name = region_name or boto3.Session().region_name or "us-west-2"
@@ -49,6 +71,49 @@ class MemoryClient:
             "Initialized MemoryClient for control plane: %s, data plane: %s",
             self.gmcp_client.meta.region_name,
             self.gmdp_client.meta.region_name,
+        )
+
+    def __getattr__(self, name: str):
+        """Dynamically forward method calls to the appropriate boto3 client.
+
+        This method enables access to all boto3 client methods without explicitly
+        defining them. Methods are looked up in the following order:
+        1. gmdp_client (bedrock-agentcore) - for data plane operations
+        2. gmcp_client (bedrock-agentcore-control) - for control plane operations
+
+        Args:
+            name: The method name being accessed
+
+        Returns:
+            A callable method from the appropriate boto3 client
+
+        Raises:
+            AttributeError: If the method doesn't exist on either client
+
+        Example:
+            # Access any boto3 method directly
+            client = MemoryClient()
+
+            # These calls are forwarded to the appropriate boto3 client
+            response = client.list_memory_records(memoryId="mem-123", namespace="test")
+            metadata = client.get_memory_metadata(memoryId="mem-123")
+        """
+        if name in self._ALLOWED_GMDP_METHODS and hasattr(self.gmdp_client, name):
+            method = getattr(self.gmdp_client, name)
+            logger.debug("Forwarding method '%s' to gmdp_client", name)
+            return method
+
+        if name in self._ALLOWED_GMCP_METHODS and hasattr(self.gmcp_client, name):
+            method = getattr(self.gmcp_client, name)
+            logger.debug("Forwarding method '%s' to gmcp_client", name)
+            return method
+
+        # Method not found on either client
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'. "
+            f"Method not found on gmdp_client or gmcp_client. "
+            f"Available methods can be found in the boto3 documentation for "
+            f"'bedrock-agentcore' and 'bedrock-agentcore-control' services."
         )
 
     def create_memory(
@@ -434,236 +499,6 @@ class MemoryClient:
         except ClientError as e:
             logger.error("Failed to create blob event: %s", e)
             raise
-
-    def get_event(
-        self,
-        memory_id: str,
-        actor_id: str,
-        session_id: str,
-        event_id: str,
-    ) -> Dict[str, Any]:
-        """Retrieves information about a specific event in an AgentCore Memory resource.
-
-        Args:
-            memory_id: Memory resource ID
-            actor_id: Actor identifier
-            session_id: Session identifier
-            event_id: Event identifier to retrieve
-
-        Returns:
-            Dictionary containing the event information
-
-        Example:
-            event = client.get_event(
-                memory_id="mem-xyz",
-                actor_id="user-123",
-                session_id="session-456",
-                event_id="123#abc123"
-            )
-        """
-        try:
-            response = self.gmdp_client.get_event(
-                memoryId=memory_id,
-                actorId=actor_id,
-                sessionId=session_id,
-                eventId=event_id,
-            )
-
-            logger.info("Retrieved event: %s", event_id)
-            return response["event"]
-
-        except ClientError as e:
-            logger.error("Failed to get event: %s", e)
-            raise
-
-    def delete_event(
-        self,
-        memory_id: str,
-        actor_id: str,
-        session_id: str,
-        event_id: str,
-    ) -> None:
-        """Deletes an event from an AgentCore Memory resource.
-
-        When you delete an event, it is permanently removed.
-
-        Args:
-            memory_id: Memory resource ID
-            actor_id: Actor identifier
-            session_id: Session identifier
-            event_id: Event identifier to delete
-
-        Returns:
-            None
-
-        Example:
-            client.delete_event(
-                memory_id="mem-xyz",
-                actor_id="user-123",
-                session_id="session-456",
-                event_id="123#abc123"
-            )
-        """
-        try:
-            self.gmdp_client.delete_event(
-                memoryId=memory_id,
-                actorId=actor_id,
-                sessionId=session_id,
-                eventId=event_id,
-            )
-
-            logger.info("Deleted event: %s", event_id)
-
-        except ClientError as e:
-            logger.error("Failed to delete event: %s", e)
-            raise
-
-    def get_memory_record(
-        self,
-        memory_id: str,
-        memory_record_id: str,
-    ) -> Dict[str, Any]:
-        """Retrieves a specific memory record from an AgentCore Memory resource.
-
-        Args:
-            memory_id: Memory resource ID
-            memory_record_id: The identifier of the memory record to retrieve
-
-        Returns:
-            Dictionary containing the memory record information
-
-        Example:
-            memory_record = client.get_memory_record(
-                memory_id="mem-xyz",
-                memory_record_id="rec-123"
-            )
-        """
-        try:
-            response = self.gmdp_client.get_memory_record(
-                memoryId=memory_id,
-                memoryRecordId=memory_record_id,
-            )
-
-            logger.info("Retrieved memory record: %s", memory_record_id)
-            return response["memoryRecord"]
-
-        except ClientError as e:
-            logger.error("Failed to get memory record: %s", e)
-            raise
-
-    def delete_memory_record(
-        self,
-        memory_id: str,
-        memory_record_id: str,
-    ) -> str:
-        """Deletes a memory record from an AgentCore Memory resource.
-
-        When you delete a memory record, it is permanently removed.
-
-        Args:
-            memory_id: Memory resource ID
-            memory_record_id: The identifier of the memory record to delete
-
-        Returns:
-            The identifier of the memory record that was deleted
-
-        Example:
-            memory_record_id = client.delete_memory_record(
-                memory_id="mem-xyz",
-                memory_record_id="rec-123"
-            )
-        """
-        try:
-            response = self.gmdp_client.delete_memory_record(
-                memoryId=memory_id,
-                memoryRecordId=memory_record_id,
-            )
-
-            logger.info("Deleted memory record: %s", memory_record_id)
-            return response["memoryRecordId"]
-
-        except ClientError as e:
-            logger.error("Failed to delete memory record: %s", e)
-            raise
-
-    def list_memory_records(
-        self,
-        memory_id: str,
-        namespace: str,
-        memory_strategy_id: Optional[str] = None,
-        max_results: int = 20,
-        next_token: Optional[str] = None,
-    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
-        """Lists memory records in an AgentCore Memory resource based on specified criteria.
-
-        Args:
-            memory_id: Memory resource ID
-            namespace: The namespace to filter memory records by
-            memory_strategy_id: Optional memory strategy identifier to filter memory records by
-            max_results: Maximum number of results to return (default: 20, max: 100)
-            next_token: Optional pagination token from a previous request
-
-        Returns:
-            Tuple containing (list of memory record summaries, next pagination token or None)
-
-        Example:
-            records, next_token = client.list_memory_records(
-                memory_id="mem-xyz",
-                namespace="user/preferences",
-                max_results=50
-            )
-
-            # Fetch next page if available
-            if next_token:
-                more_records, _ = client.list_memory_records(
-                    memory_id="mem-xyz",
-                    namespace="user/preferences",
-                    max_results=50,
-                    next_token=next_token
-                )
-        """
-        try:
-            # Build request parameters
-            params = {
-                "memoryId": memory_id,
-                "namespace": namespace,
-            }
-
-            if max_results is not None:
-                params["maxResults"] = min(max_results, 100)  # API limit is 100
-
-            if memory_strategy_id is not None:
-                params["memoryStrategyId"] = memory_strategy_id
-
-            if next_token is not None:
-                params["nextToken"] = next_token
-
-            response = self.gmdp_client.list_memory_records(**params)
-
-            memory_records = response.get("memoryRecordSummaries", [])
-            next_token = response.get("nextToken")
-
-            logger.info("Retrieved %d memory records from namespace: %s", len(memory_records), namespace)
-            return memory_records, next_token
-
-        except ClientError as e:
-            error_code = e.response["Error"]["Code"]
-            error_msg = e.response["Error"]["Message"]
-
-            if error_code == "ResourceNotFoundException":
-                logger.warning(
-                    "Memory or namespace not found. Ensure memory %s exists and namespace '%s' is configured",
-                    memory_id,
-                    namespace,
-                )
-            elif error_code == "ValidationException":
-                logger.warning("Invalid parameters: %s", error_msg)
-            elif error_code == "ServiceException":
-                logger.warning("Service error: %s. This may be temporary - try again later", error_msg)
-            else:
-                logger.warning("Memory record listing failed (%s): %s", error_code, error_msg)
-
-            return [], None
 
     def save_conversation(
         self,

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -2147,19 +2147,19 @@ def test_get_event():
         }
 
         # Test get_event
-        event = client.get_event(
-            memory_id="mem-123",
-            actor_id="user-123",
-            session_id="session-456",
-            event_id="123#abc123",
+        response = client.get_event(
+            memoryId="mem-123",
+            actorId="user-123",
+            sessionId="session-456",
+            eventId="123#abc123",
         )
 
-        assert event["eventId"] == "123#abc123"
-        assert event["memoryId"] == "mem-123"
-        assert event["actorId"] == "user-123"
-        assert event["sessionId"] == "session-456"
-        assert len(event["payload"]) == 1
-        assert event["payload"][0]["conversational"]["role"] == "USER"
+        assert response["event"]["eventId"] == "123#abc123"
+        assert response["event"]["memoryId"] == "mem-123"
+        assert response["event"]["actorId"] == "user-123"
+        assert response["event"]["sessionId"] == "session-456"
+        assert len(response["event"]["payload"]) == 1
+        assert response["event"]["payload"][0]["conversational"]["role"] == "USER"
 
         # Verify API call
         args, kwargs = mock_gmdp.get_event.call_args
@@ -2205,10 +2205,10 @@ def test_delete_event():
 
         # Test delete_event
         client.delete_event(
-            memory_id="mem-123",
-            actor_id="user-123",
-            session_id="session-456",
-            event_id="123#abc123",
+            memoryId="mem-123",
+            actorId="user-123",
+            sessionId="session-456",
+            eventId="123#abc123",
         )
 
         # Verify API call
@@ -2265,16 +2265,16 @@ def test_get_memory_record():
         }
 
         # Test get_memory_record
-        memory_record = client.get_memory_record(
-            memory_id="mem-123",
-            memory_record_id="rec-123",
+        response = client.get_memory_record(
+            memoryId="mem-123",
+            memoryRecordId="rec-123",
         )
 
-        assert memory_record["memoryRecordId"] == "rec-123"
-        assert memory_record["memoryStrategyId"] == "strat-456"
-        assert memory_record["content"]["text"] == "Memory record content"
-        assert "createdAt" in memory_record
-        assert memory_record["namespaces"] == ["test/namespace"]
+        assert response["memoryRecord"]["memoryRecordId"] == "rec-123"
+        assert response["memoryRecord"]["memoryStrategyId"] == "strat-456"
+        assert response["memoryRecord"]["content"]["text"] == "Memory record content"
+        assert "createdAt" in response["memoryRecord"]
+        assert response["memoryRecord"]["namespaces"] == ["test/namespace"]
 
         # Verify API call
         args, kwargs = mock_gmdp.get_memory_record.call_args
@@ -2318,12 +2318,12 @@ def test_delete_memory_record():
         mock_gmdp.delete_memory_record.return_value = {"memoryRecordId": "rec-123"}
 
         # Test delete_memory_record
-        memory_record_id = client.delete_memory_record(
-            memory_id="mem-123",
-            memory_record_id="rec-123",
+        response = client.delete_memory_record(
+            memoryId="mem-123",
+            memoryRecordId="rec-123",
         )
 
-        assert memory_record_id == "rec-123"
+        assert response == {"memoryRecordId": "rec-123"}
 
         # Verify API call
         args, kwargs = mock_gmdp.delete_memory_record.call_args
@@ -2387,16 +2387,15 @@ def test_list_memory_records():
         }
 
         # Test list_memory_records
-        memory_records, next_token = client.list_memory_records(
-            memory_id="mem-123", namespace="test/namespace", max_results=10
-        )
+        response = client.list_memory_records(memoryId="mem-123", namespace="test/namespace", maxResults=10)
 
-        assert len(memory_records) == 2
-        assert memory_records[0]["memoryRecordId"] == "rec-1"
-        assert memory_records[1]["memoryRecordId"] == "rec-2"
-        assert memory_records[0]["score"] == 0.95
-        assert memory_records[1]["score"] == 0.85
-        assert next_token == "next-page-token"
+        assert response["memoryRecordSummaries"]
+        assert len(response["memoryRecordSummaries"]) == 2
+        assert response["memoryRecordSummaries"][0]["memoryRecordId"] == "rec-1"
+        assert response["memoryRecordSummaries"][1]["memoryRecordId"] == "rec-2"
+        assert response["memoryRecordSummaries"][0]["score"] == 0.95
+        assert response["memoryRecordSummaries"][1]["score"] == 0.85
+        assert response["nextToken"] == "next-page-token"
 
         # Verify API call
         args, kwargs = mock_gmdp.list_memory_records.call_args
@@ -2429,14 +2428,15 @@ def test_list_memory_records_with_strategy_filter():
         }
 
         # Test list_memory_records with strategy filter
-        memory_records, next_token = client.list_memory_records(
-            memory_id="mem-123", namespace="test/namespace", memory_strategy_id="strat-123", max_results=10
+        response = client.list_memory_records(
+            memoryId="mem-123", namespace="test/namespace", memoryStrategyId="strat-123", maxResults=10
         )
 
-        assert len(memory_records) == 1
-        assert memory_records[0]["memoryRecordId"] == "rec-1"
-        assert memory_records[0]["memoryStrategyId"] == "strat-123"
-        assert next_token is None
+        assert response["memoryRecordSummaries"]
+        assert len(response["memoryRecordSummaries"]) == 1
+        assert response["memoryRecordSummaries"][0]["memoryRecordId"] == "rec-1"
+        assert response["memoryRecordSummaries"][0]["memoryStrategyId"] == "strat-123"
+        assert response["nextToken"] is None
 
         # Verify API call
         args, kwargs = mock_gmdp.list_memory_records.call_args
@@ -2462,20 +2462,20 @@ def test_list_memory_records_pagination():
         ]
 
         # Get first page
-        records1, next_token = client.list_memory_records(memory_id="mem-123", namespace="test/namespace")
+        response1 = client.list_memory_records(memoryId="mem-123", namespace="test/namespace")
 
-        assert len(records1) == 1
-        assert records1[0]["memoryRecordId"] == "rec-1"
-        assert next_token == "page2-token"
+        assert len(response1["memoryRecordSummaries"]) == 1
+        assert response1["memoryRecordSummaries"][0]["memoryRecordId"] == "rec-1"
+        assert response1["nextToken"] == "page2-token"
 
         # Get second page
-        records2, next_token2 = client.list_memory_records(
-            memory_id="mem-123", namespace="test/namespace", next_token=next_token
+        response2 = client.list_memory_records(
+            memoryId="mem-123", namespace="test/namespace", nextToken=response1["nextToken"]
         )
 
-        assert len(records2) == 1
-        assert records2[0]["memoryRecordId"] == "rec-2"
-        assert next_token2 is None
+        assert len(response2["memoryRecordSummaries"]) == 1
+        assert response2["memoryRecordSummaries"][0]["memoryRecordId"] == "rec-2"
+        assert response2["nextToken"] is None
 
         # Verify API calls
         assert mock_gmdp.list_memory_records.call_count == 2
@@ -2506,11 +2506,11 @@ def test_list_memory_records_client_error():
             mock_gmdp.list_memory_records.side_effect = ClientError(error_response, "ListMemoryRecords")
 
             # Test error handling
-            records, token = client.list_memory_records(memory_id="mem-123", namespace="test/namespace")
-
-            # Should return empty list without raising exception
-            assert records == []
-            assert token is None
+            try:
+                client.list_memory_records(memoryId="mem-123", namespace="test/namespace")
+                raise AssertionError("ClientError was not raised")
+            except ClientError as e:
+                assert error["code"] in str(e)
 
 
 def test_get_last_k_turns_client_error():

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -1,5 +1,6 @@
 """Unit tests for Memory Client - no external connections."""
 
+import time
 import uuid
 import warnings
 from datetime import datetime
@@ -2122,6 +2123,394 @@ def test_get_conversation_tree_client_error():
             raise AssertionError("ClientError was not raised")
         except ClientError as e:
             assert "ValidationException" in str(e)
+
+
+def test_get_event():
+    """Test get_event functionality."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response
+        mock_gmdp.get_event.return_value = {
+            "event": {
+                "eventId": "123#abc123",
+                "memoryId": "mem-123",
+                "actorId": "user-123",
+                "sessionId": "session-456",
+                "eventTimestamp": datetime.now(),
+                "payload": [{"conversational": {"role": "USER", "content": {"text": "Hello"}}}],
+            }
+        }
+
+        # Test get_event
+        event = client.get_event(
+            memory_id="mem-123",
+            actor_id="user-123",
+            session_id="session-456",
+            event_id="123#abc123",
+        )
+
+        assert event["eventId"] == "123#abc123"
+        assert event["memoryId"] == "mem-123"
+        assert event["actorId"] == "user-123"
+        assert event["sessionId"] == "session-456"
+        assert len(event["payload"]) == 1
+        assert event["payload"][0]["conversational"]["role"] == "USER"
+
+        # Verify API call
+        args, kwargs = mock_gmdp.get_event.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["actorId"] == "user-123"
+        assert kwargs["sessionId"] == "session-456"
+        assert kwargs["eventId"] == "123#abc123"
+
+
+def test_get_event_client_error():
+    """Test get_event with ClientError."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock ClientError
+        error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Event not found"}}
+        mock_gmdp.get_event.side_effect = ClientError(error_response, "GetEvent")
+
+        try:
+            client.get_event(
+                memory_id="mem-123",
+                actor_id="user-123",
+                session_id="session-456",
+                event_id="invalid-event",
+            )
+            raise AssertionError("ClientError was not raised")
+        except ClientError as e:
+            assert "ResourceNotFoundException" in str(e)
+
+
+def test_delete_event():
+    """Test delete_event functionality."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Test delete_event
+        client.delete_event(
+            memory_id="mem-123",
+            actor_id="user-123",
+            session_id="session-456",
+            event_id="123#abc123",
+        )
+
+        # Verify API call
+        args, kwargs = mock_gmdp.delete_event.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["actorId"] == "user-123"
+        assert kwargs["sessionId"] == "session-456"
+        assert kwargs["eventId"] == "123#abc123"
+
+
+def test_delete_event_client_error():
+    """Test delete_event with ClientError."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock ClientError
+        error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Event not found"}}
+        mock_gmdp.delete_event.side_effect = ClientError(error_response, "DeleteEvent")
+
+        try:
+            client.delete_event(
+                memory_id="mem-123",
+                actor_id="user-123",
+                session_id="session-456",
+                event_id="invalid-event",
+            )
+            raise AssertionError("ClientError was not raised")
+        except ClientError as e:
+            assert "ResourceNotFoundException" in str(e)
+
+
+def test_get_memory_record():
+    """Test get_memory_record functionality."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response
+        mock_gmdp.get_memory_record.return_value = {
+            "memoryRecord": {
+                "memoryRecordId": "rec-123",
+                "memoryStrategyId": "strat-456",
+                "content": {"text": "Memory record content"},
+                "createdAt": int(time.time()),
+                "namespaces": ["test/namespace"],
+            }
+        }
+
+        # Test get_memory_record
+        memory_record = client.get_memory_record(
+            memory_id="mem-123",
+            memory_record_id="rec-123",
+        )
+
+        assert memory_record["memoryRecordId"] == "rec-123"
+        assert memory_record["memoryStrategyId"] == "strat-456"
+        assert memory_record["content"]["text"] == "Memory record content"
+        assert "createdAt" in memory_record
+        assert memory_record["namespaces"] == ["test/namespace"]
+
+        # Verify API call
+        args, kwargs = mock_gmdp.get_memory_record.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["memoryRecordId"] == "rec-123"
+
+
+def test_get_memory_record_client_error():
+    """Test get_memory_record with ClientError."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock ClientError
+        error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Memory record not found"}}
+        mock_gmdp.get_memory_record.side_effect = ClientError(error_response, "GetMemoryRecord")
+
+        try:
+            client.get_memory_record(
+                memory_id="mem-123",
+                memory_record_id="invalid-record",
+            )
+            raise AssertionError("ClientError was not raised")
+        except ClientError as e:
+            assert "ResourceNotFoundException" in str(e)
+
+
+def test_delete_memory_record():
+    """Test delete_memory_record functionality."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response
+        mock_gmdp.delete_memory_record.return_value = {"memoryRecordId": "rec-123"}
+
+        # Test delete_memory_record
+        memory_record_id = client.delete_memory_record(
+            memory_id="mem-123",
+            memory_record_id="rec-123",
+        )
+
+        assert memory_record_id == "rec-123"
+
+        # Verify API call
+        args, kwargs = mock_gmdp.delete_memory_record.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["memoryRecordId"] == "rec-123"
+
+
+def test_delete_memory_record_client_error():
+    """Test delete_memory_record with ClientError."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock ClientError
+        error_response = {"Error": {"Code": "ResourceNotFoundException", "Message": "Memory record not found"}}
+        mock_gmdp.delete_memory_record.side_effect = ClientError(error_response, "DeleteMemoryRecord")
+
+        try:
+            client.delete_memory_record(
+                memory_id="mem-123",
+                memory_record_id="invalid-record",
+            )
+            raise AssertionError("ClientError was not raised")
+        except ClientError as e:
+            assert "ResourceNotFoundException" in str(e)
+
+
+def test_list_memory_records():
+    """Test list_memory_records functionality."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response
+        mock_gmdp.list_memory_records.return_value = {
+            "memoryRecordSummaries": [
+                {
+                    "memoryRecordId": "rec-1",
+                    "memoryStrategyId": "strat-456",
+                    "content": {"text": "Memory record 1"},
+                    "createdAt": int(time.time()),
+                    "namespaces": ["test/namespace"],
+                    "score": 0.95,
+                },
+                {
+                    "memoryRecordId": "rec-2",
+                    "memoryStrategyId": "strat-456",
+                    "content": {"text": "Memory record 2"},
+                    "createdAt": int(time.time()),
+                    "namespaces": ["test/namespace"],
+                    "score": 0.85,
+                },
+            ],
+            "nextToken": "next-page-token",
+        }
+
+        # Test list_memory_records
+        memory_records, next_token = client.list_memory_records(
+            memory_id="mem-123", namespace="test/namespace", max_results=10
+        )
+
+        assert len(memory_records) == 2
+        assert memory_records[0]["memoryRecordId"] == "rec-1"
+        assert memory_records[1]["memoryRecordId"] == "rec-2"
+        assert memory_records[0]["score"] == 0.95
+        assert memory_records[1]["score"] == 0.85
+        assert next_token == "next-page-token"
+
+        # Verify API call
+        args, kwargs = mock_gmdp.list_memory_records.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["namespace"] == "test/namespace"
+        assert kwargs["maxResults"] == 10
+
+
+def test_list_memory_records_with_strategy_filter():
+    """Test list_memory_records with strategy filter."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response
+        mock_gmdp.list_memory_records.return_value = {
+            "memoryRecordSummaries": [
+                {
+                    "memoryRecordId": "rec-1",
+                    "memoryStrategyId": "strat-123",
+                    "content": {"text": "Memory record 1"},
+                    "createdAt": int(time.time()),
+                    "namespaces": ["test/namespace"],
+                }
+            ],
+            "nextToken": None,
+        }
+
+        # Test list_memory_records with strategy filter
+        memory_records, next_token = client.list_memory_records(
+            memory_id="mem-123", namespace="test/namespace", memory_strategy_id="strat-123", max_results=10
+        )
+
+        assert len(memory_records) == 1
+        assert memory_records[0]["memoryRecordId"] == "rec-1"
+        assert memory_records[0]["memoryStrategyId"] == "strat-123"
+        assert next_token is None
+
+        # Verify API call
+        args, kwargs = mock_gmdp.list_memory_records.call_args
+        assert kwargs["memoryId"] == "mem-123"
+        assert kwargs["namespace"] == "test/namespace"
+        assert kwargs["memoryStrategyId"] == "strat-123"
+        assert kwargs["maxResults"] == 10
+
+
+def test_list_memory_records_pagination():
+    """Test list_memory_records pagination."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Mock response for first page
+        mock_gmdp.list_memory_records.side_effect = [
+            {"memoryRecordSummaries": [{"memoryRecordId": "rec-1"}], "nextToken": "page2-token"},
+            {"memoryRecordSummaries": [{"memoryRecordId": "rec-2"}], "nextToken": None},
+        ]
+
+        # Get first page
+        records1, next_token = client.list_memory_records(memory_id="mem-123", namespace="test/namespace")
+
+        assert len(records1) == 1
+        assert records1[0]["memoryRecordId"] == "rec-1"
+        assert next_token == "page2-token"
+
+        # Get second page
+        records2, next_token2 = client.list_memory_records(
+            memory_id="mem-123", namespace="test/namespace", next_token=next_token
+        )
+
+        assert len(records2) == 1
+        assert records2[0]["memoryRecordId"] == "rec-2"
+        assert next_token2 is None
+
+        # Verify API calls
+        assert mock_gmdp.list_memory_records.call_count == 2
+        second_call = mock_gmdp.list_memory_records.call_args_list[1]
+        assert second_call[1]["nextToken"] == "page2-token"
+
+
+def test_list_memory_records_client_error():
+    """Test list_memory_records with ClientError."""
+    with patch("boto3.client"):
+        client = MemoryClient()
+
+        # Mock the client
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        # Test various error types
+        error_cases = [
+            {"code": "ResourceNotFoundException", "message": "Memory not found"},
+            {"code": "ValidationException", "message": "Invalid parameters"},
+            {"code": "ServiceException", "message": "Internal service error"},
+            {"code": "UnknownException", "message": "Unknown error"},
+        ]
+
+        for error in error_cases:
+            # Mock ClientError
+            error_response = {"Error": {"Code": error["code"], "Message": error["message"]}}
+            mock_gmdp.list_memory_records.side_effect = ClientError(error_response, "ListMemoryRecords")
+
+            # Test error handling
+            records, token = client.list_memory_records(memory_id="mem-123", namespace="test/namespace")
+
+            # Should return empty list without raising exception
+            assert records == []
+            assert token is None
 
 
 def test_get_last_k_turns_client_error():


### PR DESCRIPTION
Many of the LangChain/Crew/Llamaindex integrations require individual event management and listing of memory records in addition to just searching.

## Features
  - Added `__get_attr__` method to the Memory Client to dynamically forward the request to either the data plane or the control plane depending on the operation
  - Added a filter for methods that are supported on the memory client

## Testing
Added unit tests to cover GetEvent, DeleteEvent, ListMemoryRecords, and a few other operations.