### PR TITLE
feat(runtime): add kwargs support to run method

### DIFF
--- a/tests/bedrock_agentcore/runtime/test_app.py
+++ b/tests/bedrock_agentcore/runtime/test_app.py
@@ -266,6 +266,32 @@ class TestBedrockAgentCoreApp:
                 log_level="info",  # Debug mode uses info level
             )
 
+    @patch("uvicorn.run")
+    def test_run_with_kwargs(self, mock_uvicorn):
+        """Test that kwargs are passed through to uvicorn.run."""
+        bedrock_agentcore = BedrockAgentCoreApp()
+
+        # Test with custom log_config and other uvicorn parameters
+        custom_log_config = {
+            "version": 1,
+            "formatters": {
+                "json": {"format": '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "message": "%(message)s"}'}
+            },
+        }
+
+        bedrock_agentcore.run(port=9000, host="test-host", log_config=custom_log_config, workers=4, reload=True)
+
+        mock_uvicorn.assert_called_once_with(
+            bedrock_agentcore,
+            host="test-host",
+            port=9000,
+            access_log=False,
+            log_level="warning",
+            log_config=custom_log_config,
+            workers=4,
+            reload=True,
+        )
+
     def test_invocation_with_request_id_header(self):
         """Test that request ID from header is used."""
         bedrock_agentcore = BedrockAgentCoreApp()


### PR DESCRIPTION
*Issue #, if available:*
resolve #9 

*Description of changes:*
This PR enhances the `BedrockAgentCoreApp.run()` method to accept additional keyword arguments that are passed through to `uvicorn.run()`, providing more flexibility for server configuration.

#### Example Usage

```python
# Custom logging configuration
app.run(port=8080, log_config=custom_log_config)

# Development mode with auto-reload
app.run(port=8080, reload=True)

# Production with multiple workers
app.run(port=8080, workers=4)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
