### PR TITLE
Pass boto3 session to the MemoryClient constructor

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -60,12 +60,14 @@ class MemoryClient:
         "list_memory_strategies",
     }
 
-    def __init__(self, region_name: Optional[str] = None):
+    def __init__(self, region_name: Optional[str] = None, session: Optional[boto3.Session] = None ):
         """Initialize the Memory client."""
-        self.region_name = region_name or boto3.Session().region_name or "us-west-2"
+        if session is None:
+            session = boto3.Session()
+        self.region_name = region_name or session.region_name or "us-west-2"
 
-        self.gmcp_client = boto3.client("bedrock-agentcore-control", region_name=self.region_name)
-        self.gmdp_client = boto3.client("bedrock-agentcore", region_name=self.region_name)
+        self.gmcp_client = session.client("bedrock-agentcore-control", region_name=self.region_name)
+        self.gmdp_client = session.client("bedrock-agentcore", region_name=self.region_name)
 
         logger.info(
             "Initialized MemoryClient for control plane: %s, data plane: %s",

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -14,59 +14,64 @@ from bedrock_agentcore.memory.constants import StrategyType
 
 def test_client_initialization():
     """Test client initialization."""
-    with patch("boto3.client") as mock_boto_client:
+    with patch("boto3.Session") as mock_session_class:
         # Setup the mock to return a consistent region_name
-        mock_client_instance = MagicMock()
-        mock_client_instance.meta.region_name = "us-west-2"
-        mock_boto_client.return_value = mock_client_instance
+        mock_session = MagicMock()
+        mock_session.region_name = None
+        mock_session_class.return_value = mock_session
 
         client = MemoryClient(region_name="us-west-2")
 
         # Check that the region was set correctly and boto3.client was called twice
         assert client.region_name == "us-west-2"
-        assert mock_boto_client.call_count == 2
+        assert mock_session.client.call_count == 2
+
+
+def test_client_initialization_session():
+    """Test client initialization with session passed."""
+    #with patch("boto3.Session") as mock_boto_session:
+    # Setup the mock to return a consistent region_name
+    mock_session_instance = MagicMock()
+    mock_session_instance.region_name = "us-west-2"
+    #mock_boto_session.return_value = mock_session_instance
+
+    client = MemoryClient(region_name="us-east-1", session=mock_session_instance)
+    # Check that the region was set correctly and session.client was called twice
+    assert client.region_name == "us-east-1"
+    assert mock_session_instance.client.call_count == 2
 
 
 def test_client_initialization_region_mismatch():
     """Test client initialization with region mismatch warning."""
 
-    with patch("boto3.client") as mock_boto_client:
-        # First test - environment variable takes precedence
-        with patch("boto3.Session") as mock_session:
-            # Mock the session instance to simulate AWS_REGION=us-east-1
-            mock_session_instance = MagicMock()
-            mock_session_instance.region_name = "us-east-1"
-            mock_session.return_value = mock_session_instance
+    #with patch("boto3.client") as mock_boto_client:
+    # First test - environment variable takes precedence
+    with patch("boto3.Session") as mock_session:
+        # Mock the session instance to simulate AWS_REGION=us-east-1
+        mock_session_instance = MagicMock()
+        mock_session_instance.region_name = "us-east-1"
+        mock_session.return_value = mock_session_instance
 
-            # Mock the boto client
-            mock_client_instance = MagicMock()
-            mock_client_instance.meta.region_name = "us-east-1"
-            mock_boto_client.return_value = mock_client_instance
+        # When region_name is provided, environment variable should still take precedence
+        client1 = MemoryClient(region_name="us-west-2")
+        assert client1.region_name == "us-west-2"
 
-            # When region_name is provided, environment variable should still take precedence
-            client1 = MemoryClient(region_name="us-west-2")
-            assert client1.region_name == "us-west-2"
+    # Second test - no environment variable, explicit param is used
+    with patch("boto3.Session") as mock_session:
+        # Mock the session instance to simulate no AWS_REGION set
+        mock_session_instance = MagicMock()
+        mock_session_instance.region_name = None
+        mock_session.return_value = mock_session_instance
 
-        # Second test - no environment variable, explicit param is used
-        with patch("boto3.Session") as mock_session:
-            # Mock the session instance to simulate no AWS_REGION set
-            mock_session_instance = MagicMock()
-            mock_session_instance.region_name = None
-            mock_session.return_value = mock_session_instance
-
-            # Mock the boto client
-            mock_client_instance = MagicMock()
-            mock_client_instance.meta.region_name = "us-west-2"
-            mock_boto_client.return_value = mock_client_instance
-
-            # When AWS_REGION is not set, explicitly provided region should be used
-            client2 = MemoryClient(region_name="us-west-2")
-            assert client2.region_name == "us-west-2"
+        # When AWS_REGION is not set, explicitly provided region should be used
+        client2 = MemoryClient(region_name="us-west-2")
+        assert client2.region_name == "us-west-2"
 
 
 def test_namespace_defaults():
     """Test namespace defaults."""
-    with patch("boto3.client"):
+    print("testing name space defaults")
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test strategy without namespace
@@ -74,11 +79,12 @@ def test_namespace_defaults():
         processed = client._add_default_namespaces(strategies)
 
         assert "namespaces" in processed[0][StrategyType.SEMANTIC.value]
+        print("ended name space defaults")
 
 
 def test_create_memory():
     """Test create_memory."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock UUID generation to ensure deterministic test
@@ -104,7 +110,7 @@ def test_create_memory():
 
 def test_save_conversation_and_retrieve_memories():
     """Test save_conversation and retrieve_memories."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the clients
@@ -145,7 +151,7 @@ def test_save_conversation_and_retrieve_memories():
 
 def test_error_handling():
     """Test error handling."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client to raise an error
@@ -164,7 +170,7 @@ def test_error_handling():
 
 def test_branch_operations():
     """Test branch operations."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the clients
@@ -210,7 +216,7 @@ def test_branch_operations():
 
 def test_memory_strategy_management():
     """Test memory strategy management."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the clients
@@ -248,7 +254,7 @@ def test_memory_strategy_management():
 
 def test_timestamp_and_advanced_message_handling():
     """Test timestamp and advanced message handling."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
         mock_gmdp = MagicMock()
         client.gmdp_client = mock_gmdp
@@ -274,7 +280,7 @@ def test_timestamp_and_advanced_message_handling():
 
 def test_deprecated_methods():
     """Test deprecated methods with warnings."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
         mock_gmdp = MagicMock()
         client.gmdp_client = mock_gmdp
@@ -313,7 +319,7 @@ def test_deprecated_methods():
 
 def test_create_memory_and_wait_success():
     """Test successful create_memory_and_wait scenario."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock both clients
@@ -344,7 +350,7 @@ def test_create_memory_and_wait_success():
 
 def test_create_memory_and_wait_timeout():
     """Test timeout scenario for create_memory_and_wait."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock both clients
@@ -375,7 +381,7 @@ def test_create_memory_and_wait_timeout():
 
 def test_create_memory_and_wait_failure():
     """Test failure scenario for create_memory_and_wait."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock both clients
@@ -407,7 +413,7 @@ def test_create_memory_and_wait_failure():
 
 def test_process_turn_with_llm_success_with_retrieval():
     """Test successful process_turn_with_llm with memory retrieval."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the clients
@@ -469,7 +475,7 @@ def test_process_turn_with_llm_success_with_retrieval():
 
 def test_list_events_with_pagination():
     """Test list_events with pagination support."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -515,7 +521,7 @@ def test_list_events_with_pagination():
 
 def test_list_events_with_branch_filter():
     """Test list_events with branch filtering."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -555,7 +561,7 @@ def test_list_events_with_branch_filter():
 
 def test_list_events_max_results_limit():
     """Test list_events respects max_results limit."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -586,7 +592,7 @@ def test_list_events_max_results_limit():
 
 def test_get_conversation_tree():
     """Test get_conversation_tree functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -621,7 +627,7 @@ def test_get_conversation_tree():
 
 def test_list_memories():
     """Test list_memories functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -649,7 +655,7 @@ def test_list_memories():
 
 def test_list_memories_with_pagination():
     """Test list_memories with pagination support."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -697,7 +703,7 @@ def test_list_memories_with_pagination():
 
 def test_delete_memory():
     """Test delete_memory functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -721,7 +727,7 @@ def test_delete_memory():
 
 def test_get_memory_status():
     """Test get_memory_status functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -743,7 +749,7 @@ def test_get_memory_status():
 
 def test_add_summary_strategy():
     """Test add_summary_strategy functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -769,7 +775,7 @@ def test_add_summary_strategy():
 
 def test_add_user_preference_strategy():
     """Test add_user_preference_strategy functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -814,7 +820,7 @@ def test_add_user_preference_strategy():
 
 def test_add_custom_semantic_strategy():
     """Test add_custom_semantic_strategy functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -888,7 +894,7 @@ def test_add_custom_semantic_strategy():
 
 def test_merge_branch_context():
     """Test merge_branch_context functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -924,7 +930,7 @@ def test_merge_branch_context():
 
 def test_wait_for_memories():
     """Test wait_for_memories functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -951,7 +957,7 @@ def test_wait_for_memories():
 
 def test_wait_for_memories_wildcard_namespace():
     """Test wait_for_memories rejects wildcard namespaces."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client (shouldn't be called)
@@ -971,7 +977,7 @@ def test_wait_for_memories_wildcard_namespace():
 
 def test_get_last_k_turns():
     """Test get_last_k_turns functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1010,7 +1016,7 @@ def test_get_last_k_turns():
 
 def test_delete_memory_and_wait():
     """Test delete_memory_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1040,7 +1046,7 @@ def test_delete_memory_and_wait():
 
 def test_update_memory_strategies():
     """Test update_memory_strategies functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1066,7 +1072,7 @@ def test_update_memory_strategies():
 
 def test_update_memory_strategies_modify():
     """Test update_memory_strategies with modify_strategies."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1108,7 +1114,7 @@ def test_update_memory_strategies_modify():
 
 def test_normalize_memory_response():
     """Test _normalize_memory_response functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test memory with new field names only
@@ -1137,7 +1143,7 @@ def test_normalize_memory_response():
 
 def test_wait_for_memory_active():
     """Test _wait_for_memory_active functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1163,7 +1169,7 @@ def test_wait_for_memory_active():
 
 def test_wait_for_memory_active_failed_status():
     """Test _wait_for_memory_active when memory status becomes FAILED."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1190,7 +1196,7 @@ def test_wait_for_memory_active_failed_status():
 
 def test_wait_for_memory_active_client_error():
     """Test _wait_for_memory_active when ClientError is raised."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1216,7 +1222,7 @@ def test_wait_for_memory_active_client_error():
 
 def test_wrap_configuration():
     """Test _wrap_configuration functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test basic configuration wrapping
@@ -1235,7 +1241,7 @@ def test_wrap_configuration():
 
 def test_wrap_configuration_basic():
     """Test _wrap_configuration with basic config."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test config that doesn't need wrapping
@@ -1250,7 +1256,7 @@ def test_wrap_configuration_basic():
 
 def test_wrap_configuration_semantic_strategy():
     """Test _wrap_configuration with SEMANTIC strategy type."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test extraction configuration that needs wrapping
@@ -1270,7 +1276,7 @@ def test_wrap_configuration_semantic_strategy():
 
 def test_wrap_configuration_user_preference_strategy():
     """Test _wrap_configuration with USER_PREFERENCE strategy type."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test extraction configuration that needs wrapping for user preferences
@@ -1290,7 +1296,7 @@ def test_wrap_configuration_user_preference_strategy():
 
 def test_wrap_configuration_custom_semantic_override():
     """Test _wrap_configuration with CUSTOM strategy and SEMANTIC_OVERRIDE."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test custom semantic override configuration
@@ -1331,7 +1337,7 @@ def test_wrap_configuration_custom_semantic_override():
 
 def test_list_branch_events_pagination():
     """Test list_branch_events with pagination."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1387,7 +1393,7 @@ def test_list_branch_events_pagination():
 
 def test_modify_strategy():
     """Test modify_strategy convenience method."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1434,7 +1440,7 @@ def test_modify_strategy():
 
 def test_retrieve_memories_resource_not_found_error():
     """Test retrieve_memories with ResourceNotFoundException."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1463,7 +1469,7 @@ def test_retrieve_memories_resource_not_found_error():
 
 def test_retrieve_memories_validation_error():
     """Test retrieve_memories with ValidationException."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1491,7 +1497,7 @@ def test_retrieve_memories_validation_error():
 
 def test_retrieve_memories_service_error():
     """Test retrieve_memories with ServiceException."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1518,7 +1524,7 @@ def test_retrieve_memories_service_error():
 
 def test_retrieve_memories_unknown_error():
     """Test retrieve_memories with unknown ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1541,7 +1547,7 @@ def test_retrieve_memories_unknown_error():
 
 def test_retrieve_memories_wildcard_namespace():
     """Test retrieve_memories rejects wildcard namespaces."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client (shouldn't be called)
@@ -1562,7 +1568,7 @@ def test_retrieve_memories_wildcard_namespace():
 
 def test_add_semantic_strategy_and_wait():
     """Test add_semantic_strategy_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1595,7 +1601,7 @@ def test_add_semantic_strategy_and_wait():
 
 def test_add_summary_strategy_and_wait():
     """Test add_summary_strategy_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1628,7 +1634,7 @@ def test_add_summary_strategy_and_wait():
 
 def test_add_user_preference_strategy_and_wait():
     """Test add_user_preference_strategy_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1661,7 +1667,7 @@ def test_add_user_preference_strategy_and_wait():
 
 def test_add_custom_semantic_strategy_and_wait():
     """Test add_custom_semantic_strategy_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1701,7 +1707,7 @@ def test_add_custom_semantic_strategy_and_wait():
 
 def test_update_memory_strategies_and_wait():
     """Test update_memory_strategies_and_wait functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1739,7 +1745,7 @@ def test_update_memory_strategies_and_wait():
 
 def test_fork_conversation():
     """Test fork_conversation functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1775,7 +1781,7 @@ def test_fork_conversation():
 
 def test_delete_strategy():
     """Test delete_strategy functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1803,7 +1809,7 @@ def test_delete_strategy():
 
 def test_add_strategy_warning():
     """Test add_strategy shows deprecation warning."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1834,7 +1840,7 @@ def test_add_strategy_warning():
 
 def test_create_event():
     """Test create_event functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1866,7 +1872,7 @@ def test_create_event():
 
 def test_create_event_with_branch():
     """Test create_event with branch parameter."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1895,7 +1901,7 @@ def test_create_event_with_branch():
 
 def test_create_memory_and_wait_client_error():
     """Test create_memory_and_wait with ClientError during status check."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock both clients
@@ -1926,7 +1932,7 @@ def test_create_memory_and_wait_client_error():
 
 def test_create_event_client_error():
     """Test create_event with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -1951,7 +1957,7 @@ def test_create_event_client_error():
 
 def test_create_event_no_messages_error():
     """Test create_event with no messages raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         try:
@@ -1968,7 +1974,7 @@ def test_create_event_no_messages_error():
 
 def test_create_event_invalid_message_format_error():
     """Test create_event with invalid message format raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test with message that doesn't have exactly 2 elements
@@ -1998,7 +2004,7 @@ def test_create_event_invalid_message_format_error():
 
 def test_create_event_invalid_role_error():
     """Test create_event with invalid role raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         try:
@@ -2016,7 +2022,7 @@ def test_create_event_invalid_role_error():
 
 def test_save_conversation_client_error():
     """Test save_conversation with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2041,7 +2047,7 @@ def test_save_conversation_client_error():
 
 def test_list_events_client_error():
     """Test list_events with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2061,7 +2067,7 @@ def test_list_events_client_error():
 
 def test_list_branches_client_error():
     """Test list_branches with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2081,7 +2087,7 @@ def test_list_branches_client_error():
 
 def test_list_branch_events_client_error():
     """Test list_branch_events with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2107,7 +2113,7 @@ def test_list_branch_events_client_error():
 
 def test_get_conversation_tree_client_error():
     """Test get_conversation_tree with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2127,7 +2133,7 @@ def test_get_conversation_tree_client_error():
 
 def test_get_event():
     """Test get_event functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2171,7 +2177,7 @@ def test_get_event():
 
 def test_get_event_client_error():
     """Test get_event with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2196,7 +2202,7 @@ def test_get_event_client_error():
 
 def test_delete_event():
     """Test delete_event functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2221,7 +2227,7 @@ def test_delete_event():
 
 def test_delete_event_client_error():
     """Test delete_event with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2246,7 +2252,7 @@ def test_delete_event_client_error():
 
 def test_get_memory_record():
     """Test get_memory_record functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2284,7 +2290,7 @@ def test_get_memory_record():
 
 def test_get_memory_record_client_error():
     """Test get_memory_record with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2307,7 +2313,7 @@ def test_get_memory_record_client_error():
 
 def test_delete_memory_record():
     """Test delete_memory_record functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2333,7 +2339,7 @@ def test_delete_memory_record():
 
 def test_delete_memory_record_client_error():
     """Test delete_memory_record with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2356,7 +2362,7 @@ def test_delete_memory_record_client_error():
 
 def test_list_memory_records():
     """Test list_memory_records functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2406,7 +2412,7 @@ def test_list_memory_records():
 
 def test_list_memory_records_with_strategy_filter():
     """Test list_memory_records with strategy filter."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2448,7 +2454,7 @@ def test_list_memory_records_with_strategy_filter():
 
 def test_list_memory_records_pagination():
     """Test list_memory_records pagination."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2485,7 +2491,7 @@ def test_list_memory_records_pagination():
 
 def test_list_memory_records_client_error():
     """Test list_memory_records with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2515,7 +2521,7 @@ def test_list_memory_records_client_error():
 
 def test_get_last_k_turns_client_error():
     """Test get_last_k_turns with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2535,7 +2541,7 @@ def test_get_last_k_turns_client_error():
 
 def test_fork_conversation_client_error():
     """Test fork_conversation with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2562,7 +2568,7 @@ def test_fork_conversation_client_error():
 
 def test_get_memory_strategies_client_error():
     """Test get_memory_strategies with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2582,7 +2588,7 @@ def test_get_memory_strategies_client_error():
 
 def test_list_memories_client_error():
     """Test list_memories with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2602,7 +2608,7 @@ def test_list_memories_client_error():
 
 def test_delete_memory_client_error():
     """Test delete_memory with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2623,7 +2629,7 @@ def test_delete_memory_client_error():
 
 def test_update_memory_strategies_client_error():
     """Test update_memory_strategies with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2645,7 +2651,7 @@ def test_update_memory_strategies_client_error():
 
 def test_save_conversation_no_messages_error():
     """Test save_conversation with no messages raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         try:
@@ -2662,7 +2668,7 @@ def test_save_conversation_no_messages_error():
 
 def test_save_conversation_invalid_message_format_error():
     """Test save_conversation with invalid message format raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Test with message that doesn't have exactly 2 elements
@@ -2692,7 +2698,7 @@ def test_save_conversation_invalid_message_format_error():
 
 def test_save_conversation_invalid_role_error():
     """Test save_conversation with invalid role raises ValueError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         try:
@@ -2710,7 +2716,7 @@ def test_save_conversation_invalid_role_error():
 
 def test_create_blob_event():
     """Test create_blob_event functionality."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2743,7 +2749,7 @@ def test_create_blob_event():
 
 def test_create_blob_event_with_branch():
     """Test create_blob_event with branch parameter."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2773,7 +2779,7 @@ def test_create_blob_event_with_branch():
 
 def test_create_blob_event_client_error():
     """Test create_blob_event with ClientError."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the client
@@ -2803,7 +2809,7 @@ def test_create_blob_event_client_error():
 
 def test_create_or_get_memory_creates_new():
     """Test create_or_get_memory creates new memory when it doesn't exist."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock create_memory_and_wait to return successful result
@@ -2821,7 +2827,7 @@ def test_create_or_get_memory_creates_new():
 
 def test_create_or_get_memory_gets_existing():
     """Test create_or_get_memory returns existing memory when it already exists."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the gmcp_client
@@ -2856,7 +2862,7 @@ def test_create_or_get_memory_gets_existing():
 
 def test_create_or_get_memory_other_client_error():
     """Test create_or_get_memory raises other ClientErrors."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the gmcp_client
@@ -2886,7 +2892,7 @@ def test_create_or_get_memory_other_client_error():
 
 def test_create_or_get_memory_general_exception():
     """Test create_or_get_memory raises general exceptions."""
-    with patch("boto3.client"):
+    with patch('boto3.Session', return_value=MagicMock()):
         client = MemoryClient()
 
         # Mock the gmcp_client


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/bedrock-agentcore-sdk-python/issues/44

*Description of changes:*
Currently MemoryClient doesn't have the capability to pass the boto3 session which makes it difficult to point to named profiles.

Change:
Allow MemoryClient to accept `boto3.Session` session as an optional parameter. Honor the existing `region_name` to prevent backward incompatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
