### PR TITLE
Feature/request header allowlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3>=1.39.7",
-    "botocore>=1.39.7",
+    "boto3>=1.40.35",
+    "botocore>=1.40.35",
     "pydantic>=2.0.0,<3.0.0",
     "urllib3>=1.26.0",
     "starlette>=0.46.2",

--- a/src/bedrock_agentcore/runtime/context.py
+++ b/src/bedrock_agentcore/runtime/context.py
@@ -4,7 +4,7 @@ Contains metadata extracted from HTTP requests that handlers can optionally acce
 """
 
 from contextvars import ContextVar
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
@@ -13,6 +13,7 @@ class RequestContext(BaseModel):
     """Request context containing metadata from HTTP requests."""
 
     session_id: Optional[str] = Field(None)
+    request_headers: Optional[Dict[str, str]] = Field(None)
 
 
 class BedrockAgentCoreContext:
@@ -21,6 +22,7 @@ class BedrockAgentCoreContext:
     _workload_access_token: ContextVar[Optional[str]] = ContextVar("workload_access_token")
     _request_id: ContextVar[Optional[str]] = ContextVar("request_id")
     _session_id: ContextVar[Optional[str]] = ContextVar("session_id")
+    _request_headers: ContextVar[Optional[Dict[str, str]]] = ContextVar("request_headers")
 
     @classmethod
     def set_workload_access_token(cls, token: str):
@@ -54,5 +56,18 @@ class BedrockAgentCoreContext:
         """Get current session ID."""
         try:
             return cls._session_id.get()
+        except LookupError:
+            return None
+
+    @classmethod
+    def set_request_headers(cls, headers: Dict[str, str]):
+        """Set request headers in the context."""
+        cls._request_headers.set(headers)
+
+    @classmethod
+    def get_request_headers(cls) -> Optional[Dict[str, str]]:
+        """Get request headers from the context."""
+        try:
+            return cls._request_headers.get()
         except LookupError:
             return None

--- a/src/bedrock_agentcore/runtime/models.py
+++ b/src/bedrock_agentcore/runtime/models.py
@@ -17,6 +17,8 @@ class PingStatus(str, Enum):
 SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
 REQUEST_ID_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Request-Id"
 ACCESS_TOKEN_HEADER = "WorkloadAccessToken"  # nosec
+AUTHORIZATION_HEADER = "Authorization"
+CUSTOM_HEADER_PREFIX = "X-Amzn-Bedrock-AgentCore-Runtime-Custom-"
 
 # Task action constants
 TASK_ACTION_PING_STATUS = "ping_status"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -79,8 +79,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.39.7" },
-    { name = "botocore", specifier = ">=1.39.7" },
+    { name = "boto3", specifier = ">=1.40.35" },
+    { name = "botocore", specifier = ">=1.40.35" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "starlette", specifier = ">=0.46.2" },
     { name = "strands-agents", marker = "extra == 'strands-agents'", specifier = ">=1.1.0" },
@@ -106,30 +106,30 @@ dev = [
 
 [[package]]
 name = "boto3"
-version = "1.39.7"
+version = "1.40.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/43/81ae62386917fa163f1d3bc59e77da56924f9824b5100fd2807e74a675fc/boto3-1.39.7.tar.gz", hash = "sha256:28daeb005e3381808e0e12995056ee8951056ddd43506c07482a15b40ae785b0", size = 111820, upload-time = "2025-07-16T16:29:52.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/d0/9082261eb9afbb88896fa2ce018fa10750f32572ab356f13f659761bc5b5/boto3-1.40.35.tar.gz", hash = "sha256:d718df3591c829bcca4c498abb7b09d64d1eecc4e5a2b6cef14b476501211b8a", size = 111563, upload-time = "2025-09-19T19:41:07.704Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/60/1d2d708f5bc125fe6fe262ea767c82020ea6deeda113e989cff5ab89a9f9/boto3-1.39.7-py3-none-any.whl", hash = "sha256:c8c0e11fff7bb85f903b860b6bfd4f509a4d749decf38bb6a409ffe5d6eb0c91", size = 139882, upload-time = "2025-07-16T16:29:51.176Z" },
+    { url = "https://files.pythonhosted.org/packages/db/26/08d814db09dc46eab747c7ebe1d4af5b5158b68e1d7de82ecc71d419eab3/boto3-1.40.35-py3-none-any.whl", hash = "sha256:f4c1b01dd61e7733b453bca38b004ce030e26ee36e7a3d4a9e45a730b67bc38d", size = 139346, upload-time = "2025-09-19T19:41:05.929Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.39.7"
+version = "1.40.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/9d/73f300c841a3c47d2baf4bf6ecb9d6de476edf91de8c3c26ceed5044e666/botocore-1.39.7.tar.gz", hash = "sha256:431e342ef97ecb387cea9df1ae8c4e0edc1b0c9c50d2e121cca77699f24f8dc1", size = 14201331, upload-time = "2025-07-16T16:29:43.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/6f/37f40da07f3cdde367f620874f76b828714409caf8466def65aede6bdf59/botocore-1.40.35.tar.gz", hash = "sha256:67e062752ff579c8cc25f30f9c3a84c72d692516a41a9ee1cf17735767ca78be", size = 14350022, upload-time = "2025-09-19T19:40:56.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/20/ab70de7441cbc4b8ffc5d6d9a8e02e4c703cc07accb7441ce54020e20950/botocore-1.39.7-py3-none-any.whl", hash = "sha256:1d11ba9f3cb46856bb541ed010db160093201a224d21ef854249513ae3af7e77", size = 13864168, upload-time = "2025-07-16T16:29:37.114Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f4/9942dfb01a8a849daac34b15d5b7ca994c52ef131db2fa3f6e6995f61e0a/botocore-1.40.35-py3-none-any.whl", hash = "sha256:c545de2cbbce161f54ca589fbb677bae14cdbfac7d5f1a27f6a620cb057c26f4", size = 14020774, upload-time = "2025-09-19T19:40:53.498Z" },
 ]
 
 [[package]]
@@ -1326,14 +1326,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.13.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/5d/9dcc100abc6711e8247af5aa561fc07c4a046f72f659c3adea9a449e191a/s3transfer-0.13.0.tar.gz", hash = "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177", size = 150232, upload-time = "2025-05-22T19:24:50.245Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/74/8d69dcb7a9efe8baa2046891735e5dfe433ad558ae23d9e3c14c633d1d58/s3transfer-0.14.0.tar.gz", hash = "sha256:eff12264e7c8b4985074ccce27a3b38a485bb7f7422cc8046fee9be4983e4125", size = 151547, upload-time = "2025-09-09T19:23:31.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/17/22bf8155aa0ea2305eefa3a6402e040df7ebe512d1310165eda1e233c3f8/s3transfer-0.13.0-py3-none-any.whl", hash = "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be", size = 85152, upload-time = "2025-05-22T19:24:48.703Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f0/ae7ca09223a81a1d890b2557186ea015f6e0502e9b8cb8e1813f1d8cfa4e/s3transfer-0.14.0-py3-none-any.whl", hash = "sha256:ea3b790c7077558ed1f02a3072fb3cb992bbbd253392f4b6e9e8976941c7d456", size = 85712, upload-time = "2025-09-09T19:23:30.041Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add support for specifying request header allowlist feature which is supported with agent core runtime with the latest release. 

This change will extract any request headers passed in which satisfies the pattern below
```
@pattern("^(Authorization|X-Amzn-Bedrock-AgentCore-Runtime-Custom-[a-zA-Z0-9_-]+)$")
```

These headers are set in BedrockAgentCoreContext and passed via RequestContext. Sample agent code on how to use this.
```
@app.entrypoint
def agent_invocation(payload, context: RequestContext):
    """Handler for agent invocation"""
    user_message = payload.get(
        "prompt", "No prompt found in input, please guide customer to create a json payload with prompt key"
    )
    app.logger.info("invoking agent with user message: %s", payload)
    response = agent(user_message)
    print("=== REQUEST CONTEXT ===")
    print(f"RequestContext: {context}")
    print(f"  session_id: {context.session_id}")
    print(f"  session_id: {context.request_headers}")
    app.logger.info("response payload session_id: {context.session_id}: %s", response)
    return response
```

### Related change
* https://github.com/aws/bedrock-agentcore-starter-toolkit/pull/189 - Starter toolkit change to allow specifying the allowlist configuration


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing

- [X] Unit tests pass locally
- [ ] Integration tests pass (if applicable)
- [X] Test coverage remains above 80%
- [X] Manual testing completed

## Checklist

- [ ] My code follows the project's style guidelines (ruff/pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Security Checklist

- [X] No hardcoded secrets or credentials
- [X] No new security warnings from bandit
- [X] Dependencies are from trusted sources
- [X] No sensitive data logged

## Breaking Changes

List any breaking changes and migration instructions:

N/A

## Additional Notes

Add any additional notes or context about the PR here.
