### PR TITLE
Fix get_last_k_turns ordering issues and add robust event sorting

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -35,10 +35,13 @@ from .constants import (
 
 logger = logging.getLogger(__name__)
 
+
 class EventOrdering(Enum):
     """Ordering of events."""
+
     CHRONOLOGICAL = 1
     REVERSE_CHRONOLOGICAL = 2
+
 
 class MemoryClient:
     """High-level Bedrock AgentCore Memory client with essential operations."""
@@ -759,7 +762,7 @@ class MemoryClient:
 
         logger.info("Completed full conversation turn with LLM")
         return retrieved_memories, agent_response, event
-    
+
     def list_events(
         self,
         memory_id: str,
@@ -830,16 +833,13 @@ class MemoryClient:
 
             logger.info("Retrieved total of %d events", len(all_events))
 
-            # Return the first max_results events
-            result = all_events[:max_results]
-
             # Sort events in chronological order
             result = sorted(
-                result, 
-                key=lambda x: x["eventTimestamp"], 
-                reverse=order == EventOrdering.REVERSE_CHRONOLOGICAL
+                all_events, key=lambda x: x["eventTimestamp"], reverse=order == EventOrdering.REVERSE_CHRONOLOGICAL
             )
-            return result
+
+            # Return the latest max_results events
+            return result[:max_results]
 
         except ClientError as e:
             logger.error("Failed to list events: %s", e)

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -472,11 +472,11 @@ def test_list_events_chronological():
     """Test list_events returns the events in chronological order by default."""
     with patch("boto3.client"):
         client = MemoryClient()
-        
+
         # Mock the MemoryClient's internal boto3 client
         mock_gmdp = MagicMock()
         client.gmdp_client = mock_gmdp
-        
+
         # Mock boto3 response in no particular order
         mock_events = [
             {"eventId": "event-2", "eventTimestamp": datetime(2023, 1, 1, 10, 2, 0)},
@@ -499,11 +499,11 @@ def test_list_events_reverse_chronological():
     """Test list_events returns the events in reverse chronological order."""
     with patch("boto3.client"):
         client = MemoryClient()
-        
+
         # Mock the MemoryClient's internal boto3 client
         mock_gmdp = MagicMock()
         client.gmdp_client = mock_gmdp
-        
+
         # Mock boto3 response in no particular order
         mock_events = [
             {"eventId": "event-2", "eventTimestamp": datetime(2023, 1, 1, 10, 2, 0)},
@@ -517,7 +517,7 @@ def test_list_events_reverse_chronological():
             memory_id="mem-123",
             actor_id="user-123",
             session_id="session-456",
-            order=EventOrdering.REVERSE_CHRONOLOGICAL
+            order=EventOrdering.REVERSE_CHRONOLOGICAL,
         )
 
         assert events == [
@@ -539,12 +539,12 @@ def test_list_events_with_pagination():
         # Mock paginated responses - simulate API returning pages in reverse chronological order
         # Page 1: newest events first (event-149 down to event-50) - 100 items
         first_batch = [
-            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 11, (i - 50) // 60, (i - 50) % 60)} 
+            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 11, (i - 50) // 60, (i - 50) % 60)}
             for i in range(149, 49, -1)  # 149, 148, ..., 50 (100 items)
         ]
         # Page 2: older events first (event-49 down to event-0) - 50 items
         second_batch = [
-            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 10, i // 60, i % 60)} 
+            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 10, i // 60, i % 60)}
             for i in range(49, -1, -1)  # 49, 48, ..., 0 (50 items)
         ]
 
@@ -627,7 +627,8 @@ def test_list_events_max_results_limit():
 
         # Mock response with more events than requested
         large_batch = [
-            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 10, 0, i % 60)} for i in range(100)
+            {"eventId": f"event-{i}", "eventTimestamp": datetime(2023, 1, 1, 11, (i) // 60, (i) % 60)}
+            for i in range(100)
         ]
         mock_gmdp.list_events.return_value = {"events": large_batch, "nextToken": "has-more"}
 
@@ -1040,7 +1041,7 @@ def test_get_last_k_turns():
         # Mock the client
         mock_gmdp = MagicMock()
         client.gmdp_client = mock_gmdp
-        
+
         # We only want the last 2 turns
         k = 2
 
@@ -1061,8 +1062,8 @@ def test_get_last_k_turns():
                 "eventTimestamp": datetime(2023, 1, 1, 10, 2, 0),
                 "payload": [
                     {"conversational": {"role": "USER", "content": {"text": "Message 3"}}},
-                    {"conversational": {"role": "ASSISTANT", "content": {"text": "Message 4"}}}
-                ]
+                    {"conversational": {"role": "ASSISTANT", "content": {"text": "Message 4"}}},
+                ],
             },
             # Third turn, user message in a separate event
             {
@@ -1089,12 +1090,12 @@ def test_get_last_k_turns():
         # Should only return the last 2 turns, in the correct order
         assert turns == [
             [
-                {"role": "USER", "content": {"text": "Message 3"}}, 
-                {"role": "ASSISTANT", "content": {"text": "Message 4"}}
+                {"role": "USER", "content": {"text": "Message 3"}},
+                {"role": "ASSISTANT", "content": {"text": "Message 4"}},
             ],
             [
-                {"role": "USER", "content": {"text": "Message 5"}}, 
-                {"role": "ASSISTANT", "content": {"text": "Message 6"}}
+                {"role": "USER", "content": {"text": "Message 5"}},
+                {"role": "ASSISTANT", "content": {"text": "Message 6"}},
             ],
         ]
 


### PR DESCRIPTION
### Root Cause
The original implementation had a fundamental misunderstanding of the boto3 `list_events` API behavior. The code mistakenly assumed that `list_events` returns events in chronological order, when it actually returns them in *reverse chronological order* (newest first). This incorrect assumption caused cascading issues throughout `MemoryClient.list_events()` and `MemoryClient.get_last_k_turns()`. The problems were never caught because all tests mocked the boto3 `list_events` behavior based on mistaken assumptions.

### Problems Caused by Root Cause

1. **Incorrect event ordering**: Code assumed chronological order but received reverse chronological
2. **Mixed message ordering**: Messages within single events are in chronological order, but events themselves were in reverse chronological order, creating inconsistent ordering logic
3. **Pagination issues**: When using pagination, the reverse chronological order from boto3 meant that older events (which should be processed first) were returned later, causing incorrect turn grouping
4. **Test coverage gap**: All tests mocked `list_events`, so the real API behavior was never validated

### Solution

#### 1. Fixed MemoryClient's list_events Method
- **Added robust timestamp-based sorting** in the `list_events` method to ensure events are always returned in the correct chronological order regardless of what boto3 returns
- **Made ordering independent of boto3 behavior** by sorting events by `eventTimestamp` after retrieval
- **Fixed pagination handling** to work correctly with the new sorting approach

#### 2. Refactored get_last_k_turns Method
- **Changed event ordering** from `REVERSE_CHRONOLOGICAL` to `CHRONOLOGICAL` (now that we guarantee correct order)
- **Implemented flatten-then-group approach**: 
  - Flatten all messages from events into a single list
  - Reverse the message list to process from newest to oldest
  - Group consecutive USER-ASSISTANT message pairs into turns
- **Added efficiency improvements** by stopping once k turns are collected
- **Handles mixed scenarios correctly**: Works whether turns are within single events or span multiple events

### Key Changes

**MemoryClient.list_events:**
- Added timestamp-based sorting to ensure chronological order regardless of boto3 behavior
- Added optional parameter `order` with an Enum `EventOrdering.CHRONOLOGICAL|REVERSE_CHRONOLOGICAL`, with `CHRONOLOGICAL` as default
- Made the method robust against irregularities or future changes in boto3 API ordering

**MemoryClient.get_last_k_turns:**
- Replaced incremental turn building with flatten-then-group approach to maintain ordering inside and across events
- Added proper message ordering logic for all scenarios
- Maintained efficiency through early termination when k turns are collected

### Test Coverage
- Added comprehensive test case covering mixed scenarios (turns within single events and across multiple events)
- Verified correct chronological ordering of messages within turns
- Fixed test cases for event pagination
- **Note**: Tests still mock boto3, but now the implementation is robust against real API behavior

### Impact
This fix ensures that `list_events` and `get_last_k_turns` works correctly with the actual boto3 API behavior, handles pagination properly, and provides consistent results regardless of how events are distributed across API responses. The robust sorting approach also makes the code more resilient to potential future changes in the boto3 API.