### PR TITLE
fix: swap event_timestamp with branch in add_turns

### DIFF
--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -819,7 +819,7 @@ class MemorySession(DictWrapper):
         event_timestamp: Optional[datetime] = None,
     ) -> Event:
         """Delegates to manager.add_turns."""
-        return self._manager.add_turns(self._actor_id, self._session_id, messages, event_timestamp, branch)
+        return self._manager.add_turns(self._actor_id, self._session_id, messages, branch, event_timestamp)
 
     def fork_conversation(
         self,

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -1560,8 +1560,8 @@ class TestEdgeCases:
                     "user-123",
                     "session-456",
                     [ConversationalMessage("Hello", MessageRole.USER)],
-                    custom_timestamp,
                     branch,
+                    custom_timestamp,
                 )
 
     def test_comprehensive_error_coverage(self):
@@ -1803,13 +1803,13 @@ class TestEdgeCases:
                     event_timestamp=custom_timestamp,
                 )
 
-                # Verify the exact parameter order: actor_id, session_id, messages, event_timestamp, branch
+                # Verify the exact parameter order: actor_id, session_id, messages, branch, event_timestamp
                 mock_add_turns.assert_called_once_with(
                     "user-123",
                     "session-456",
                     [ConversationalMessage("Hello", MessageRole.USER)],
-                    custom_timestamp,
                     branch,
+                    custom_timestamp,
                 )
 
 


### PR DESCRIPTION
fix: swap event_timestamp with branch in add_turns
- Updated unit tests to reflect the proper logic

Ran the precommit hook locally. 
The existing tests will fail because the behaviour has changed but thats the same tests I've updated

```
uv run pre-commit run --all-files
uv-lock..................................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check toml...............................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for added large files..............................................Passed
debug statements (python)................................................Passed
bandit...................................................................Passed
pytest with coverage.....................................................Passed

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
