### PR TITLE
fix: rename list_events parameter include_parent_events to include_parent_branches to match the boto3 parameter

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -761,7 +761,7 @@ class MemoryClient:
         actor_id: str,
         session_id: str,
         branch_name: Optional[str] = None,
-        include_parent_events: bool = False,
+        include_parent_branches: bool = False,
         max_results: int = 100,
         include_payload: bool = True,
     ) -> List[Dict[str, Any]]:
@@ -775,7 +775,7 @@ class MemoryClient:
             actor_id: Actor identifier
             session_id: Session identifier
             branch_name: Optional branch name to filter events (None for all branches)
-            include_parent_events: Whether to include parent branch events (only applies with branch_name)
+            include_parent_branches: Whether to include parent branch events (only applies with branch_name)
             max_results: Maximum number of events to return
             include_payload: Whether to include event payloads in response
 
@@ -810,7 +810,9 @@ class MemoryClient:
 
                 # Add branch filter if specified (but not for "main")
                 if branch_name and branch_name != "main":
-                    params["filter"] = {"branch": {"name": branch_name, "includeParentBranches": include_parent_events}}
+                    params["filter"] = {
+                        "branch": {"name": branch_name, "includeParentBranches": include_parent_branches}
+                    }
 
                 response = self.gmdp_client.list_events(**params)
 
@@ -907,7 +909,7 @@ class MemoryClient:
         actor_id: str,
         session_id: str,
         branch_name: Optional[str] = None,
-        include_parent_events: bool = False,
+        include_parent_branches: bool = False,
         max_results: int = 100,
     ) -> List[Dict[str, Any]]:
         """List events in a specific branch.
@@ -923,7 +925,7 @@ class MemoryClient:
             actor_id: Actor identifier
             session_id: Session identifier
             branch_name: Branch name (None for main branch)
-            include_parent_events: Whether to include events from parent branches
+            include_parent_branches: Whether to include events from parent branches
             max_results: Maximum events to return
 
         Returns:
@@ -939,7 +941,7 @@ class MemoryClient:
 
             # Only add filter when we have a specific branch name
             if branch_name:
-                params["filter"] = {"branch": {"name": branch_name, "includeParentBranches": include_parent_events}}
+                params["filter"] = {"branch": {"name": branch_name, "includeParentBranches": include_parent_branches}}
 
             response = self.gmdp_client.list_events(**params)
             events = response.get("events", [])
@@ -1051,7 +1053,7 @@ class MemoryClient:
             actor_id=actor_id,
             session_id=session_id,
             branch_name=branch_name,
-            include_parent_events=include_parent,
+            include_parent_branches=include_parent,
             max_results=100,
         )
 
@@ -1102,7 +1104,7 @@ class MemoryClient:
                 actor_id=actor_id,
                 session_id=session_id,
                 branch_name=branch_name,
-                include_parent_events=False,
+                include_parent_branches=False,
                 max_results=max_results,
             )
 

--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -453,7 +453,7 @@ class MemorySessionManager:
         actor_id: str,
         session_id: str,
         branch_name: Optional[str] = None,
-        include_parent_events: bool = False,
+        include_parent_branches: bool = False,
         max_results: int = 100,
         include_payload: bool = True,
     ) -> List[Event]:
@@ -466,7 +466,7 @@ class MemorySessionManager:
             actor_id: Actor identifier
             session_id: Session identifier
             branch_name: Optional branch name to filter events (None for all branches)
-            include_parent_events: Whether to include parent branch events (only applies with branch_name)
+            include_parent_branches: Whether to include parent branch events (only applies with branch_name)
             max_results: Maximum number of events to return
             include_payload: Whether to include event payloads in response
 
@@ -505,7 +505,9 @@ class MemorySessionManager:
 
                 # Add branch filter if specified (but not for "main")
                 if branch_name and branch_name != "main":
-                    params["filter"] = {"branch": {"name": branch_name, "includeParentBranches": include_parent_events}}
+                    params["filter"] = {
+                        "branch": {"name": branch_name, "includeParentBranches": include_parent_branches}
+                    }
 
                 response = self._data_plane_client.list_events(**params)
 
@@ -625,7 +627,7 @@ class MemorySessionManager:
         session_id: str,
         k: int = 5,
         branch_name: Optional[str] = None,
-        include_parent_events: bool = False,
+        include_parent_branches: bool = False,
         max_results: int = 100,
     ) -> List[List[EventMessage]]:
         """Get the last K conversation turns.
@@ -641,7 +643,7 @@ class MemorySessionManager:
                 actor_id=actor_id,
                 session_id=session_id,
                 branch_name=branch_name,
-                include_parent_events=include_parent_events,
+                include_parent_branches=include_parent_branches,
                 max_results=max_results,
             )
 
@@ -924,12 +926,12 @@ class MemorySession(DictWrapper):
         self,
         k: int = 5,
         branch_name: Optional[str] = None,
-        include_parent_events: Optional[bool] = None,
+        include_parent_branches: Optional[bool] = None,
         max_results: int = 100,
     ) -> List[List[EventMessage]]:
         """Delegates to manager.get_last_k_turns."""
         return self._manager.get_last_k_turns(
-            self._actor_id, self._session_id, k, branch_name, include_parent_events, max_results
+            self._actor_id, self._session_id, k, branch_name, include_parent_branches, max_results
         )
 
     def get_event(self, event_id: str) -> Event:
@@ -972,7 +974,7 @@ class MemorySession(DictWrapper):
     def list_events(
         self,
         branch_name: Optional[str] = None,
-        include_parent_events: bool = False,
+        include_parent_branches: bool = False,
         max_results: int = 100,
         include_payload: bool = True,
     ) -> List[Event]:
@@ -981,7 +983,7 @@ class MemorySession(DictWrapper):
             actor_id=self._actor_id,
             session_id=self._session_id,
             branch_name=branch_name,
-            include_parent_events=include_parent_events,
+            include_parent_branches=include_parent_branches,
             include_payload=include_payload,
             max_results=max_results,
         )

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -539,7 +539,7 @@ def test_list_events_with_branch_filter():
             actor_id="user-123",
             session_id="session-456",
             branch_name="test-branch",
-            include_parent_events=True,
+            include_parent_branches=True,
         )
 
         assert len(events) == 1

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -772,7 +772,7 @@ class TestSessionManager:
             mock_client_instance.list_events.return_value = {"events": mock_events, "nextToken": None}
 
             result = manager.list_events(
-                actor_id="user-123", session_id="session-456", branch_name="test-branch", include_parent_events=True
+                actor_id="user-123", session_id="session-456", branch_name="test-branch", include_parent_branches=True
             )
 
             assert len(result) == 1
@@ -989,8 +989,8 @@ class TestSessionManager:
                 with pytest.raises(ClientError):
                     manager.get_last_k_turns(actor_id="user-123", session_id="session-456", k=5)
 
-    def test_get_last_k_turns_with_include_parent_events_parameter(self):
-        """Test get_last_k_turns with include_parent_events parameter to cover new functionality."""
+    def test_get_last_k_turns_with_include_parent_branches_parameter(self):
+        """Test get_last_k_turns with include_parent_branches parameter to cover new functionality."""
         with patch("boto3.Session") as mock_session_class:
             mock_session = MagicMock()
             mock_session.region_name = "us-west-2"
@@ -1024,13 +1024,13 @@ class TestSessionManager:
                 ),
             ]
             with patch.object(manager, "list_events", return_value=mock_events) as mock_list_events:
-                # Test with include_parent_events=True
+                # Test with include_parent_branches=True
                 result = manager.get_last_k_turns(
                     actor_id="user-123",
                     session_id="session-456",
                     k=3,
                     branch_name="test-branch",
-                    include_parent_events=True,
+                    include_parent_branches=True,
                     max_results=50,
                 )
 
@@ -1040,31 +1040,31 @@ class TestSessionManager:
                 assert all(isinstance(msg, EventMessage) for msg in result[0])
                 assert all(isinstance(msg, EventMessage) for msg in result[1])
 
-                # Verify list_events was called with include_parent_events=True when include_parent_events=True
+                # Verify list_events was called with include_parent_branches=True when include_parent_branches=True
                 mock_list_events.assert_called_once_with(
                     actor_id="user-123",
                     session_id="session-456",
                     branch_name="test-branch",
-                    include_parent_events=True,  # This should be True when include_parent_events=True
+                    include_parent_branches=True,  # This should be True when include_parent_branches=True
                     max_results=50,
                 )
 
-                # Test with include_parent_events=False (default behavior)
+                # Test with include_parent_branches=False (default behavior)
                 mock_list_events.reset_mock()
                 manager.get_last_k_turns(
                     actor_id="user-123",
                     session_id="session-456",
                     k=2,
                     branch_name="test-branch",
-                    include_parent_events=False,
+                    include_parent_branches=False,
                 )
 
-                # Verify list_events was called with include_parent_events=False when include_parent_events=False
+                # Verify list_events was called with include_parent_branches=False when include_parent_branches=False
                 mock_list_events.assert_called_once_with(
                     actor_id="user-123",
                     session_id="session-456",
                     branch_name="test-branch",
-                    include_parent_events=False,  # This should be False when include_parent_events=False
+                    include_parent_branches=False,  # This should be False when include_parent_branches=False
                     max_results=100,  # Default max_results
                 )
 
@@ -1613,7 +1613,7 @@ class TestSession:
                 result = session.get_last_k_turns(k=3)
 
                 assert result == mock_turns
-                # Updated to match the new method signature with include_parent_events parameter
+                # Updated to match the new method signature with include_parent_branches parameter
                 mock_get_turns.assert_called_once_with("user-123", "session-456", 3, None, None, 100)
 
     def test_session_get_event_delegation(self):
@@ -1742,7 +1742,7 @@ class TestSession:
                     actor_id="user-123",
                     session_id="session-456",
                     branch_name="test-branch",
-                    include_parent_events=False,
+                    include_parent_branches=False,
                     include_payload=True,
                     max_results=100,
                 )
@@ -3075,8 +3075,8 @@ class TestAddTurnsWithDataClasses:
             assert "rec-1" in record_ids
             assert "rec-4" in record_ids
 
-    def test_get_last_k_turns_with_include_parent_events_true(self):
-        """Test get_last_k_turns with include_parent_events=True - covers line 539->529."""
+    def test_get_last_k_turns_with_include_parent_branches_true(self):
+        """Test get_last_k_turns with include_parent_branches=True - covers line 539->529."""
         with patch("boto3.Session") as mock_boto_client:
             mock_client_instance = MagicMock()
             mock_boto_client.return_value = mock_client_instance
@@ -3099,17 +3099,17 @@ class TestAddTurnsWithDataClasses:
                     session_id="session-456",
                     k=2,
                     branch_name="test-branch",
-                    include_parent_events=True,  # This should trigger include_parent_events=True
+                    include_parent_branches=True,  # This should trigger include_parent_branches=True
                 )
 
                 assert len(result) == 1
 
-                # Verify list_events was called with include_parent_events=True
+                # Verify list_events was called with include_parent_branches=True
                 mock_list_events.assert_called_once_with(
                     actor_id="user-123",
                     session_id="session-456",
                     branch_name="test-branch",
-                    include_parent_events=True,  # This is the key parameter
+                    include_parent_branches=True,  # This is the key parameter
                     max_results=100,
                 )
 


### PR DESCRIPTION
fix: rename list_events parameter include_parent_events to include_parent_branches to match the boto3 parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
