### PR TITLE
feat(browser): Add viewport configuration support to BrowserClient

### DIFF
--- a/tests_integ/tools/test_browser.py
+++ b/tests_integ/tools/test_browser.py
@@ -10,3 +10,8 @@ with browser_session("us-west-2") as client:
 
     client.take_control()
     client.release_control()
+
+with browser_session("us-west-2", viewport={"width": 1280, "height": 720}) as client:
+    assert client.session_id is not None
+    url, headers = client.generate_ws_headers()
+    assert url.startswith("wss")


### PR DESCRIPTION
*Description of changes:*

Add viewport optional parameter to the BrowserClient.start() method to properly configure browser viewport dimensions through the underlying StartBrowserSession API.

```
uv-lock..................................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check toml...............................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check for added large files..............................................Passed
debug statements (python)................................................Passed
bandit...................................................................Passed
pytest with coverage.....................................................Passed
```