### PR TITLE
docs: remove preview verbiage following Bedrock AgentCore GA release

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Bedrock AgentCore CLI Starter Toolkit
+Bedrock AgentCore SDK Python
 Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 This product includes software developed by Amazon.com, Inc. (https://www.amazon.com/).

--- a/README.md
+++ b/README.md
@@ -79,9 +79,6 @@ app.run()  # Ready to run on Bedrock AgentCore
 
 **Production:** [AWS CDK](https://aws.amazon.com/cdk/) - coming soon.
 
-## ⚠️ Preview Status
-
-Bedrock AgentCore SDK is currently in public preview. APIs may change as we refine the SDK.
 
 ## 📝 License & Contributing
 


### PR DESCRIPTION
remove preview verbiage following Bedrock AgentCore GA release
