### PR TITLE
feat: integrate metadata support for short-term-memory (STM)

### DIFF
--- a/src/bedrock_agentcore/memory/models/__init__.py
+++ b/src/bedrock_agentcore/memory/models/__init__.py
@@ -3,7 +3,15 @@
 from typing import Any, Dict
 
 from .DictWrapper import DictWrapper
-
+from .filters import (
+    StringValue,
+    MetadataValue,
+    MetadataKey,
+    LeftExpression,
+    OperatorType,
+    RightExpression,
+    EventMetadataFilter,
+)
 
 class ActorSummary(DictWrapper):
     """A class representing an actor summary."""
@@ -75,3 +83,20 @@ class SessionSummary(DictWrapper):
             session_summary: Dictionary containing session summary data.
         """
         super().__init__(session_summary)
+
+__all__ = [
+    "DictWrapper",
+    "ActorSummary",
+    "Branch",
+    "Event",
+    "EventMessage",
+    "MemoryRecord",
+    "SessionSummary",
+    "StringValue",
+    "MetadataValue",
+    "MetadataKey",
+    "LeftExpression",
+    "OperatorType",
+    "RightExpression",
+    "EventMetadataFilter",
+]

--- a/src/bedrock_agentcore/memory/models/filters.py
+++ b/src/bedrock_agentcore/memory/models/filters.py
@@ -1,0 +1,118 @@
+from enum import Enum
+from typing import Optional, TypedDict, Union, NotRequired
+
+class StringValue(TypedDict):
+    """Value associated with the `eventMetadata` key."""
+    stringValue: str
+    
+    @staticmethod
+    def build(value: str) -> 'StringValue':
+        return {
+            "stringValue": value
+        }
+
+MetadataValue = Union[StringValue]
+"""
+Union type representing metadata values.
+
+Variants:
+- StringValue: {"stringValue": str} - String metadata value
+"""
+
+MetadataKey = Union[str]
+"""
+Union type representing metadata key.
+"""
+
+class LeftExpression(TypedDict):
+    """
+    Left operand of the event metadata filter expression.
+    """
+    metadataKey: MetadataKey
+    
+    @staticmethod
+    def build(key: str) -> 'LeftExpression':
+        """Builds the `metadataKey` for `LeftExpression`"""
+        return {
+            "metadataKey": key
+        }
+
+class OperatorType(Enum):
+    """
+    Operator applied to the event metadata filter expression.
+    
+    Currently supports:
+    - `EQUALS_TO`
+    - `EXISTS`
+    - `NOT_EXISTS`
+    """
+    EQUALS_TO = "EQUALS_TO"
+    EXISTS = "EXISTS"
+    NOT_EXISTS = "NOT_EXISTS"
+
+class RightExpression(TypedDict):
+    """
+    Right operand of the event metadata filter expression.
+    
+    Variants:
+    - StringValue: {"metadataValue": {"stringValue": str}}
+    """
+    metadataValue: MetadataValue
+
+    @staticmethod
+    def build(value: str) -> 'RightExpression':
+        """Builds the `RightExpression` for `stringValue` type"""
+        return {"metadataValue": StringValue.build(value)}
+
+class EventMetadataFilter(TypedDict):
+    """
+    Filter expression for retrieving events based on metadata associated with an event.
+    
+    Args:
+        left: `LeftExpression` of the event metadata filter expression.
+        operator: `OperatorType` applied to the event metadata filter expression.
+        right: Optional `RightExpression` of the event metadata filter expression.
+    """
+    left: LeftExpression
+    operator: OperatorType
+    right: NotRequired[RightExpression]
+    
+    def build_expression(left_operand: LeftExpression, operator: OperatorType, right_operand: Optional[RightExpression] = None) -> 'EventMetadataFilter':
+        """
+        This method builds the required event metadata filter expression into the `EventMetadataFilterExpression` type when querying listEvents.
+        
+        Args:  
+            left_operand: Left operand of the event metadata filter expression
+            operator: Operator applied to the event metadata filter expression
+            right_operand: Optional right_operand of the event metadata filter expression.
+        
+        Example:
+        ```
+            left_operand = LeftExpression.build_key(key='location')
+            operator = OperatorType.EQUALS_TO
+            right_operand = RightExpression.build_string_value(value='NYC')
+        ```
+
+        #### Response Object:
+        ```
+            {
+                'left': {
+                    'metadataKey': 'location'
+                },
+                'operator': 'EQUALS_TO',
+                'right': {
+                    'metadataValue': {
+                        'stringValue': 'NYC'
+                    }
+                }
+            }
+        ```
+        """
+        filter = {
+            'left': left_operand,
+            'operator': operator.value
+        }
+        
+        if right_operand:
+            filter['right'] = right_operand
+        return filter


### PR DESCRIPTION
### Summary
BedrockAgent Memory now integrates SDK support for `metadata` in Short-Term Memory (STM).

Event metadata lets you attach additional contextual information to your short-term memory events as key-value pairs.
When creating events, you can include metadata that isn't part of the core event content but provides valuable context for retrieval.

For example, a travel booking agent can attach location metadata to events, making it easy to find all conversations that mentioned specific destinations.

You can then use the `ListEvents` operation with metadata filters to efficiently retrieve events based on these attached properties, enabling your agent to quickly locate relevant conversation history without scanning through entire sessions. 


### Usage
Example:

```
from bedrock_agentcore.memory.models import StringValue, LeftExpression, OperatorType, RightExpression, EventMetadataFilter

session_manager = MemorySessionManager(
      memory_id='test-memory-id', 
      region_name='us-east-1'
)

session = session_manager.create_memory_session(
    actor_id='user-123',
    session_id='test-session'
)

...
...

# Defining custom key-value pairs for metadata when creating an event with CreateEvent API
metadata = {}
metadataKey = "location"
metadataValue = "NYC"

metadata[metadataKey] = StringValue.build(value=metadataValue)
session.add_turns(messages=messages, metadata=metadata)


# Retrieving events with event metadata filter expression with ListEvents API
left_operand = LeftExpression.build(key=metadataKey)
operator = OperatorType.EQUALS_TO
right_operand = RightExpression.build(value=metadataValue)

filter_expression_1 = EventMetadataFilter.build_expression(left_operand, operator, right_operand)

params = {
    'actor_id': 'user-123',
    'session_id': 'test-session',
    'eventMetadata': [filter_expression_1]
}

filtered_events = session_manager.list_events(**params)
```
