### PR TITLE
fix: remove NotRequried as it is supported only in python 3.11

### DIFF
--- a/src/bedrock_agentcore/memory/models/filters.py
+++ b/src/bedrock_agentcore/memory/models/filters.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, TypedDict, Union, NotRequired
+from typing import Optional, TypedDict, Union
 
 class StringValue(TypedDict):
     """Value associated with the `eventMetadata` key."""
@@ -75,7 +75,7 @@ class EventMetadataFilter(TypedDict):
     """
     left: LeftExpression
     operator: OperatorType
-    right: NotRequired[RightExpression]
+    right: Optional[RightExpression]
     
     def build_expression(left_operand: LeftExpression, operator: OperatorType, right_operand: Optional[RightExpression] = None) -> 'EventMetadataFilter':
         """


### PR DESCRIPTION
The `NotRequired` construct from `typing` is supported only in Python `3.11`. 

To avoid breaking dependencies which use a lower version (Python `<3.11`) - replacing the `NotRequired` with `Optional` for the `EventMetadataFilter.right` field.

