### PR TITLE
fix: remove NotRequried as it is supported only in python 3.11

### DIFF
--- a/src/bedrock_agentcore/memory/models/__init__.py
+++ b/src/bedrock_agentcore/memory/models/__init__.py
@@ -4,14 +4,15 @@ from typing import Any, Dict
 
 from .DictWrapper import DictWrapper
 from .filters import (
-    StringValue,
-    MetadataValue,
-    MetadataKey,
+    EventMetadataFilter,
     LeftExpression,
+    MetadataKey,
+    MetadataValue,
     OperatorType,
     RightExpression,
-    EventMetadataFilter,
+    StringValue,
 )
+
 
 class ActorSummary(DictWrapper):
     """A class representing an actor summary."""
@@ -83,6 +84,7 @@ class SessionSummary(DictWrapper):
             session_summary: Dictionary containing session summary data.
         """
         super().__init__(session_summary)
+
 
 __all__ = [
     "DictWrapper",

--- a/src/bedrock_agentcore/memory/models/filters.py
+++ b/src/bedrock_agentcore/memory/models/filters.py
@@ -1,15 +1,19 @@
+"""Event metadata filter models for querying events based on metadata."""
+
 from enum import Enum
 from typing import Optional, TypedDict, Union
 
+
 class StringValue(TypedDict):
     """Value associated with the `eventMetadata` key."""
+
     stringValue: str
-    
+
     @staticmethod
-    def build(value: str) -> 'StringValue':
-        return {
-            "stringValue": value
-        }
+    def build(value: str) -> "StringValue":
+        """Build a StringValue from a string."""
+        return {"stringValue": value}
+
 
 MetadataValue = Union[StringValue]
 """
@@ -24,68 +28,75 @@ MetadataKey = Union[str]
 Union type representing metadata key.
 """
 
+
 class LeftExpression(TypedDict):
-    """
-    Left operand of the event metadata filter expression.
-    """
+    """Left operand of the event metadata filter expression."""
+
     metadataKey: MetadataKey
-    
+
     @staticmethod
-    def build(key: str) -> 'LeftExpression':
-        """Builds the `metadataKey` for `LeftExpression`"""
-        return {
-            "metadataKey": key
-        }
+    def build(key: str) -> "LeftExpression":
+        """Builds the `metadataKey` for `LeftExpression`."""
+        return {"metadataKey": key}
+
 
 class OperatorType(Enum):
-    """
-    Operator applied to the event metadata filter expression.
-    
+    """Operator applied to the event metadata filter expression.
+
     Currently supports:
     - `EQUALS_TO`
     - `EXISTS`
     - `NOT_EXISTS`
     """
+
     EQUALS_TO = "EQUALS_TO"
     EXISTS = "EXISTS"
     NOT_EXISTS = "NOT_EXISTS"
 
+
 class RightExpression(TypedDict):
-    """
-    Right operand of the event metadata filter expression.
-    
+    """Right operand of the event metadata filter expression.
+
     Variants:
     - StringValue: {"metadataValue": {"stringValue": str}}
     """
+
     metadataValue: MetadataValue
 
     @staticmethod
-    def build(value: str) -> 'RightExpression':
-        """Builds the `RightExpression` for `stringValue` type"""
+    def build(value: str) -> "RightExpression":
+        """Builds the `RightExpression` for `stringValue` type."""
         return {"metadataValue": StringValue.build(value)}
 
+
 class EventMetadataFilter(TypedDict):
-    """
-    Filter expression for retrieving events based on metadata associated with an event.
-    
+    """Filter expression for retrieving events based on metadata associated with an event.
+
     Args:
         left: `LeftExpression` of the event metadata filter expression.
         operator: `OperatorType` applied to the event metadata filter expression.
         right: Optional `RightExpression` of the event metadata filter expression.
     """
+
     left: LeftExpression
     operator: OperatorType
     right: Optional[RightExpression]
-    
-    def build_expression(left_operand: LeftExpression, operator: OperatorType, right_operand: Optional[RightExpression] = None) -> 'EventMetadataFilter':
-        """
-        This method builds the required event metadata filter expression into the `EventMetadataFilterExpression` type when querying listEvents.
-        
-        Args:  
+
+    def build_expression(
+        left_operand: LeftExpression,
+        operator: OperatorType,
+        right_operand: Optional[RightExpression] = None,
+    ) -> "EventMetadataFilter":
+        """Build the required event metadata filter expression.
+
+        This method builds the required event metadata filter expression into the
+        `EventMetadataFilterExpression` type when querying listEvents.
+
+        Args:
             left_operand: Left operand of the event metadata filter expression
             operator: Operator applied to the event metadata filter expression
             right_operand: Optional right_operand of the event metadata filter expression.
-        
+
         Example:
         ```
             left_operand = LeftExpression.build_key(key='location')
@@ -108,11 +119,8 @@ class EventMetadataFilter(TypedDict):
             }
         ```
         """
-        filter = {
-            'left': left_operand,
-            'operator': operator.value
-        }
-        
+        filter = {"left": left_operand, "operator": operator.value}
+
         if right_operand:
-            filter['right'] = right_operand
+            filter["right"] = right_operand
         return filter

--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -16,10 +16,10 @@ from .models import (
     DictWrapper,
     Event,
     EventMessage,
+    EventMetadataFilter,
     MemoryRecord,
-    SessionSummary,
     MetadataValue,
-    EventMetadataFilter
+    SessionSummary,
 )
 
 logger = logging.getLogger(__name__)
@@ -428,7 +428,7 @@ class MemorySessionManager:
 
         if branch:
             params["branch"] = branch
-        
+
         if metadata:
             params["metadata"] = metadata
 
@@ -490,6 +490,7 @@ class MemorySessionManager:
             session_id: Session identifier
             branch_name: Optional branch name to filter events (None for all branches)
             include_parent_branches: Whether to include parent branch events (only applies with branch_name)
+            eventMetadata: Optional list of event metadata filters to apply
             max_results: Maximum number of events to return
             include_payload: Whether to include event payloads in response
 
@@ -505,12 +506,12 @@ class MemorySessionManager:
 
             # Get events from a specific branch
             branch_events = client.list_events(actor_id, session_id, branch_name="test-branch")
-            
+
             #### Get events with event metadata filter
             ```
             filtered_events_with_metadata = client.list_events(
                 actor_id=actor_id,
-                session_id=session_id, 
+                session_id=session_id,
                 eventMetadata=[
                     {
                         'left': {
@@ -522,7 +523,7 @@ class MemorySessionManager:
                                 'stringValue': 'NYC'
                             }
                         }
-                    }       
+                    }
                 ]
             )
             ```
@@ -544,7 +545,7 @@ class MemorySessionManager:
                                 'stringValue': 'NYC'
                             }
                         }
-                    }       
+                    }
                 ]
             )
             ```
@@ -577,9 +578,7 @@ class MemorySessionManager:
 
                 # Add eventMetadata filter if specified
                 if eventMetadata:
-                    params["filter"] = {
-                        "eventMetadata": eventMetadata
-                    }
+                    params["filter"] = {"eventMetadata": eventMetadata}
 
                 response = self._data_plane_client.list_events(**params)
 

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -1570,7 +1570,9 @@ class TestSession:
                 result = session.add_turns(messages=[BlobMessage(blob_data)])
 
                 assert result == mock_event
-                mock_add_turns.assert_called_once_with("user-123", "session-456", [BlobMessage(blob_data)], None, None, None)
+                mock_add_turns.assert_called_once_with(
+                    "user-123", "session-456", [BlobMessage(blob_data)], None, None, None
+                )
 
     def test_session_process_turn_with_llm_delegation(self):
         """Test MemorySession.process_turn_with_llm delegates to manager."""
@@ -2203,6 +2205,7 @@ class TestEdgeCases:
                     custom_timestamp,
                 )
 
+
 class TestEventMetadataFlow:
     """Test cases for metadata support for STM in MemorySessionManager."""
 
@@ -2221,7 +2224,7 @@ class TestEventMetadataFlow:
             mock_event = {"eventId": "fork-event-123", "memoryId": "testMemory-1234567890"}
             with patch.object(manager, "add_turns", return_value=Event(mock_event)) as mock_add_turns:
                 metadata = {"location": {"stringValue": "NYC"}}
-                
+
                 result = manager.fork_conversation(
                     actor_id="user-123",
                     session_id="session-456",
@@ -2258,22 +2261,14 @@ class TestEventMetadataFlow:
             # Test with eventMetadata filter
             event_metadata_filter = [
                 {
-                    'left': {
-                        'metadataKey': 'location'
-                    },
-                    'operator': 'EQUALS_TO',
-                    'right': {
-                        'metadataValue': {
-                            'stringValue': 'NYC'
-                        }
-                    }
+                    "left": {"metadataKey": "location"},
+                    "operator": "EQUALS_TO",
+                    "right": {"metadataValue": {"stringValue": "NYC"}},
                 }
             ]
 
             result = manager.list_events(
-                actor_id="user-123", 
-                session_id="session-456", 
-                eventMetadata=event_metadata_filter
+                actor_id="user-123", session_id="session-456", eventMetadata=event_metadata_filter
             )
 
             assert len(result) == 1
@@ -2302,24 +2297,18 @@ class TestEventMetadataFlow:
             # Test with both branch and eventMetadata filters
             event_metadata_filter = [
                 {
-                    'left': {
-                        'metadataKey': 'location'
-                    },
-                    'operator': 'EQUALS_TO',
-                    'right': {
-                        'metadataValue': {
-                            'stringValue': 'NYC'
-                        }
-                    }
+                    "left": {"metadataKey": "location"},
+                    "operator": "EQUALS_TO",
+                    "right": {"metadataValue": {"stringValue": "NYC"}},
                 }
             ]
 
             result = manager.list_events(
-                actor_id="user-123", 
-                session_id="session-456", 
+                actor_id="user-123",
+                session_id="session-456",
                 branch_name="test-branch",
                 include_parent_branches=True,
-                eventMetadata=event_metadata_filter
+                eventMetadata=event_metadata_filter,
             )
 
             assert len(result) == 1
@@ -2343,23 +2332,14 @@ class TestEventMetadataFlow:
             mock_events = [Event({"eventId": "event-1"})]
             event_metadata_filter = [
                 {
-                    'left': {
-                        'metadataKey': 'location'
-                    },
-                    'operator': 'EQUALS_TO',
-                    'right': {
-                        'metadataValue': {
-                            'stringValue': 'NYC'
-                        }
-                    }
+                    "left": {"metadataKey": "location"},
+                    "operator": "EQUALS_TO",
+                    "right": {"metadataValue": {"stringValue": "NYC"}},
                 }
             ]
 
             with patch.object(manager, "list_events", return_value=mock_events) as mock_list_events:
-                result = session.list_events(
-                    branch_name="test-branch",
-                    eventMetadata=event_metadata_filter
-                )
+                result = session.list_events(branch_name="test-branch", eventMetadata=event_metadata_filter)
 
                 assert result == mock_events
                 mock_list_events.assert_called_once_with(
@@ -2383,7 +2363,7 @@ class TestEventMetadataFlow:
             # Mock manager method
             mock_event = Event({"eventId": "fork-event-123"})
             metadata = {"location": {"stringValue": "NYC"}}
-            
+
             with patch.object(manager, "fork_conversation", return_value=mock_event) as mock_fork:
                 result = session.fork_conversation(
                     messages=[ConversationalMessage("Fork message", MessageRole.USER)],
@@ -2416,7 +2396,7 @@ class TestEventMetadataFlow:
             mock_response = "LLM response"
             mock_event = {"eventId": "event-123"}
             metadata = {"location": {"stringValue": "NYC"}}
-            
+
             with patch.object(
                 manager, "process_turn_with_llm", return_value=(mock_memories, mock_response, mock_event)
             ) as mock_process:
@@ -2425,24 +2405,13 @@ class TestEventMetadataFlow:
                     return "Response"
 
                 memories, response, event = session.process_turn_with_llm(
-                    user_input="Hello", 
-                    llm_callback=mock_llm, 
-                    retrieval_config=None,
-                    metadata=metadata
+                    user_input="Hello", llm_callback=mock_llm, retrieval_config=None, metadata=metadata
                 )
 
                 assert memories == mock_memories
                 assert response == mock_response
                 assert event == mock_event
-                mock_process.assert_called_once_with(
-                    "user-123", 
-                    "session-456", 
-                    "Hello", 
-                    mock_llm, 
-                    None, 
-                    metadata,
-                    None
-                )
+                mock_process.assert_called_once_with("user-123", "session-456", "Hello", mock_llm, None, metadata, None)
 
     def test_process_turn_with_llm_with_metadata_parameter(self):
         """Test process_turn_with_llm with metadata parameter."""
@@ -2468,7 +2437,7 @@ class TestEventMetadataFlow:
                     # Test process_turn_with_llm with metadata
                     retrieval_config = {"test/namespace": RetrievalConfig(top_k=5)}
                     metadata = {"location": {"stringValue": "NYC"}}
-                    
+
                     memories, response, event = manager.process_turn_with_llm(
                         actor_id="user-123",
                         session_id="session-456",
@@ -2507,12 +2476,9 @@ class TestEventMetadataFlow:
                 ConversationalMessage("Hi there", MessageRole.ASSISTANT),
             ]
             metadata = {"location": {"stringValue": "NYC"}}
-            
+
             result = manager.add_turns(
-                actor_id="user-123", 
-                session_id="session-456", 
-                messages=messages,
-                metadata=metadata
+                actor_id="user-123", session_id="session-456", messages=messages, metadata=metadata
             )
 
             assert isinstance(result, Event)
@@ -2534,21 +2500,15 @@ class TestEventMetadataFlow:
             # Mock manager method
             mock_event = Event({"eventId": "event-123"})
             metadata = {"location": {"stringValue": "NYC"}}
-            
+
             with patch.object(manager, "add_turns", return_value=mock_event) as mock_add_turns:
                 result = session.add_turns(
-                    messages=[ConversationalMessage("Hello", MessageRole.USER)],
-                    metadata=metadata
+                    messages=[ConversationalMessage("Hello", MessageRole.USER)], metadata=metadata
                 )
 
                 assert result == mock_event
                 mock_add_turns.assert_called_once_with(
-                    "user-123", 
-                    "session-456", 
-                    [ConversationalMessage("Hello", MessageRole.USER)], 
-                    None, 
-                    metadata,
-                    None
+                    "user-123", "session-456", [ConversationalMessage("Hello", MessageRole.USER)], None, metadata, None
                 )
 
 
@@ -2924,7 +2884,9 @@ class TestAdditionalCoverage:
                 session.add_turns(messages=messages, branch=branch, event_timestamp=custom_timestamp)
 
                 # Verify the exact parameter order: actor_id, session_id, messages, branch, event_timestamp
-                mock_add_turns.assert_called_once_with("user-123", "session-456", messages, branch, None, custom_timestamp)
+                mock_add_turns.assert_called_once_with(
+                    "user-123", "session-456", messages, branch, None, custom_timestamp
+                )
 
     def test_process_turn_with_llm_no_relevance_score_config(self):
         """Test process_turn_with_llm when RetrievalConfig has no relevance_score."""


### PR DESCRIPTION
The `NotRequired` construct from `typing` is supported only in Python `3.11`. 

To avoid breaking dependencies which use a lower version (Python `<3.11`) - replacing the `NotRequired` with `Optional` for the `EventMetadataFilter.right` field.

