### PR TITLE
chore: enabling batch api pass through to boto3 client methods

### DIFF
--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -143,7 +143,7 @@ class MemorySessionManager:
             "list_events",
             "batch_create_memory_records",
             "batch_delete_memory_records",
-            "batch_update_memory_records"
+            "batch_update_memory_records",
         }
 
     def _validate_and_resolve_region(self, region_name: Optional[str], session: Optional[boto3.Session]) -> str:


### PR DESCRIPTION
*Description of changes:*
This change enables pass through support for the batch create, update, and delete apis to the corresponding boto3 client methods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing:* 
The three batch apis which were previously un-callable, are now callable with 
```
manager = MemorySessionManager(memory_id="pantsssdubs-z7y68R2Frj", region_name="us-east-1")
response = manager.batch_create_memory_records(
    memoryId="pantsssdubs-z7y68R2Frj",
    records=[]
)

Output:
SUCCESS: {'ResponseMetadata': {'RequestId': '9c6ea4f8-3367-4312-a939-7261359c430e', 'HTTPStatusCode': 201, 'HTTPHeaders': {'date': 'Wed, 22 Oct 2025 22:18:46 GMT', 'content-type': 'application/json', 'content-length': '43', 'connection': 'keep-alive', 'x-amzn-requestid': '9c6ea4f8-3367-4312-a939-7261359c430e'}, 'RetryAttempts': 0}, 'successfulRecords': [], 'failedRecords': []}
``` 