### PR TITLE
fix: correct workflow output reference for external PR tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       approval-env: ${{ steps.collab-check.outputs.result }}
-      should-run: ${{ steps.safety-check.outputs.safe }}
+      should-run: ${{ steps.safety-check.outputs.result }}
     steps:
       - name: Checkout base branch for safety check
         uses: actions/checkout@v5


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#### Problem
External contributor PRs were not triggering integration tests. Both `check-access-and-checkout` and `safety-gate` jobs were being skipped.

#### Root Cause
The workflow referenced `steps.safety-check.outputs.safe` but `github-script` action stores return values in `steps.safety-check.outputs.result`.

This caused `should-run` output to be `undefined`, failing both job conditions:
- `check-access-and-checkout` needs `should-run == 'true'` 
- `safety-gate` needs `should-run == 'false'`

#### Fix
Changed from:
```yaml
should-run: ${{ steps.safety-check.outputs.safe }}

To:

should-run: ${{ steps.safety-check.outputs.result }}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
