### PR TITLE
fix: list_events with branch & eventMetadata filter

### DIFF
--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -653,15 +653,19 @@ class MemorySessionManager:
                 if next_token:
                     params["nextToken"] = next_token
 
+                # Initialize the filterMap
+                filterMap = {}
+
                 # Add branch filter if specified (but not for "main")
                 if branch_name and branch_name != "main":
-                    params["filter"] = {
-                        "branch": {"name": branch_name, "includeParentBranches": include_parent_branches}
-                    }
+                    filterMap["branch"] = {"name": branch_name, "includeParentBranches": include_parent_branches}
 
                 # Add eventMetadata filter if specified
                 if eventMetadata:
-                    params["filter"] = {"eventMetadata": eventMetadata}
+                    filterMap["eventMetadata"] = eventMetadata
+
+                if filterMap:
+                    params["filter"] = filterMap
 
                 response = self._data_plane_client.list_events(**params)
 

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -2505,8 +2505,8 @@ class TestEventMetadataFlow:
             call_args = mock_client_instance.list_events.call_args[1]
             assert "filter" in call_args
             assert call_args["filter"]["eventMetadata"] == event_metadata_filter
-            # Branch filter should not be present when eventMetadata is specified
-            assert "branch" not in call_args["filter"]
+            # Branch filter should be present when eventMetadata is specified
+            assert "branch" in call_args["filter"]
 
     def test_memory_session_list_events_with_event_metadata(self):
         """Test MemorySession.list_events with eventMetadata parameter."""


### PR DESCRIPTION
*Issue #, if available:*
Existing `MemorySessionManager.list_events()` implementation of listing events with both `branch` and `eventMetadata` filter had a bug. If both the filters were provided, the `eventMetadata` filter was over-writing the `branch` filter.

This led towards the listing of events with `eventMetadata` filtering across all the events present in the session as compared to the expected behavior of listing only the events that adhere to the `eventMetadata` filter conditions present in the `branch` specified.

*Description of changes:*
This PR fixes the above issue by creating a `filterMap` that takes in both branch and eventMetadata filter when provided during `list_events()` invocation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
