### PR TITLE
fix: encode bytes before filtering empty text in message_to_payload

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/bedrock_converter.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/bedrock_converter.py
@@ -32,11 +32,13 @@ class AgentCoreMemoryConverter:
             list[Tuple[str, str]]: list of (text, role) tuples for Bedrock AgentCore Memory.
                 Returns empty list if message has no content after filtering.
         """
-        filtered_message = AgentCoreMemoryConverter._filter_empty_text(session_message.message)
+        # First convert to dict (which encodes bytes to base64),
+        # then filter empty text on the encoded version
+        session_dict = session_message.to_dict()
+        filtered_message = AgentCoreMemoryConverter._filter_empty_text(session_dict["message"])
         if not filtered_message.get("content"):
             logger.debug("Skipping message with no content after filtering empty text")
             return []
-        session_dict = session_message.to_dict()
         session_dict["message"] = filtered_message
         return [(json.dumps(session_dict), filtered_message["role"])]
 


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Object of type bytes is not JSON serializable` error in `message_to_payload` when messages contain binary data (e.g., images from tool results).

## Problem

The `_filter_empty_text` function was applied to `session_message.message` (which contains raw bytes) before `to_dict()` was called. The filtered message (with raw bytes) then overwrote the encoded version, causing `json.dumps()` to fail.

## Solution

Reorder operations to:
1. Call `to_dict()` first (encodes bytes to base64)
2. Apply `_filter_empty_text` to the encoded message

## Testing

Verified with test script that:
- v1.1.1: PASS (no `_filter_empty_text`)
- v1.1.2: FAIL (`message_to_payload` with image bytes)
- v1.1.2 + this fix: PASS

Fixes #198