### PR TITLE
feat(memory): add episodic memory strategy support

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -22,6 +22,7 @@ from botocore.exceptions import ClientError
 from .constants import (
     CUSTOM_CONSOLIDATION_WRAPPER_KEYS,
     CUSTOM_EXTRACTION_WRAPPER_KEYS,
+    CUSTOM_REFLECTION_WRAPPER_KEYS,
     DEFAULT_NAMESPACES,
     EXTRACTION_WRAPPER_KEYS,
     MemoryStatus,
@@ -1419,6 +1420,51 @@ class MemoryClient:
         self.add_user_preference_strategy(memory_id, name, description, namespaces)
         return self._wait_for_memory_active(memory_id, max_wait, poll_interval)
 
+    def add_episodic_strategy(
+        self,
+        memory_id: str,
+        name: str,
+        reflection_namespaces: List[str],
+        description: Optional[str] = None,
+        namespaces: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Add an episodic memory strategy.
+
+        Args:
+            memory_id: Memory resource ID
+            name: Strategy name
+            reflection_namespaces: Namespaces for reflections (can be less nested than episode namespaces)
+            description: Optional description
+            namespaces: Optional namespaces for episodes
+        """
+        strategy: Dict = {
+            StrategyType.EPISODIC.value: {
+                "name": name,
+                "reflectionConfiguration": {"namespaces": reflection_namespaces},
+            }
+        }
+
+        if description:
+            strategy[StrategyType.EPISODIC.value]["description"] = description
+        if namespaces:
+            strategy[StrategyType.EPISODIC.value]["namespaces"] = namespaces
+
+        return self._add_strategy(memory_id, strategy)
+
+    def add_episodic_strategy_and_wait(
+        self,
+        memory_id: str,
+        name: str,
+        reflection_namespaces: List[str],
+        description: Optional[str] = None,
+        namespaces: Optional[List[str]] = None,
+        max_wait: int = 300,
+        poll_interval: int = 10,
+    ) -> Dict[str, Any]:
+        """Add an episodic strategy and wait for memory to return to ACTIVE state."""
+        self.add_episodic_strategy(memory_id, name, reflection_namespaces, description, namespaces)
+        return self._wait_for_memory_active(memory_id, max_wait, poll_interval)
+
     def add_custom_semantic_strategy(
         self,
         memory_id: str,
@@ -1479,6 +1525,88 @@ class MemoryClient:
         """Add a custom semantic strategy and wait for memory to return to ACTIVE state."""
         self.add_custom_semantic_strategy(
             memory_id, name, extraction_config, consolidation_config, description, namespaces
+        )
+        return self._wait_for_memory_active(memory_id, max_wait, poll_interval)
+
+    def add_custom_episodic_strategy(
+        self,
+        memory_id: str,
+        name: str,
+        extraction_config: Dict[str, Any],
+        consolidation_config: Dict[str, Any],
+        reflection_config: Dict[str, Any],
+        description: Optional[str] = None,
+        namespaces: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Add a custom episodic strategy with prompts.
+
+        Args:
+            memory_id: Memory resource ID
+            name: Strategy name
+            extraction_config: {"prompt": "...", "modelId": "..."}
+            consolidation_config: {"prompt": "...", "modelId": "..."}
+            reflection_config: {"prompt": "...", "modelId": "...", "namespaces": [...]}
+            description: Optional description
+            namespaces: Optional namespaces list
+        """
+        for config, config_name in [
+            (extraction_config, "extraction_config"),
+            (consolidation_config, "consolidation_config"),
+            (reflection_config, "reflection_config"),
+        ]:
+            for key in ("prompt", "modelId"):
+                if key not in config:
+                    raise ValueError(f"{config_name} missing required key: {key}")
+
+        strategy = {
+            StrategyType.CUSTOM.value: {
+                "name": name,
+                "configuration": {
+                    "episodicOverride": {
+                        "extraction": {
+                            "appendToPrompt": extraction_config["prompt"],
+                            "modelId": extraction_config["modelId"],
+                        },
+                        "consolidation": {
+                            "appendToPrompt": consolidation_config["prompt"],
+                            "modelId": consolidation_config["modelId"],
+                        },
+                        "reflection": {
+                            "appendToPrompt": reflection_config["prompt"],
+                            "modelId": reflection_config["modelId"],
+                            **(
+                                {"namespaces": reflection_config["namespaces"]}
+                                if "namespaces" in reflection_config
+                                else {}
+                            ),
+                        },
+                    }
+                },
+            }
+        }
+
+        if description:
+            strategy[StrategyType.CUSTOM.value]["description"] = description
+        if namespaces:
+            strategy[StrategyType.CUSTOM.value]["namespaces"] = namespaces
+
+        return self._add_strategy(memory_id, strategy)
+
+    def add_custom_episodic_strategy_and_wait(
+        self,
+        memory_id: str,
+        name: str,
+        extraction_config: Dict[str, Any],
+        consolidation_config: Dict[str, Any],
+        reflection_config: Dict[str, Any],
+        description: Optional[str] = None,
+        namespaces: Optional[List[str]] = None,
+        max_wait: int = 300,
+        poll_interval: int = 10,
+    ) -> Dict[str, Any]:
+        """Add a custom episodic strategy and wait for memory to return to ACTIVE state."""
+        self.add_custom_episodic_strategy(
+            memory_id, name, extraction_config, consolidation_config, reflection_config, description, namespaces
         )
         return self._wait_for_memory_active(memory_id, max_wait, poll_interval)
 
@@ -1811,19 +1939,22 @@ class MemoryClient:
         if "extraction" in config:
             extraction = config["extraction"]
 
-            if any(key in extraction for key in ["triggerEveryNMessages", "historicalContextWindowSize"]):
-                strategy_type_enum = MemoryStrategyTypeEnum(strategy_type)
+            builtin_config_keys = ["triggerEveryNMessages", "historicalContextWindowSize"]
 
-                if strategy_type == "SEMANTIC":
+            if strategy_type == "CUSTOM" and override_type:
+                override_enum = OverrideType(override_type)
+                if override_enum in CUSTOM_EXTRACTION_WRAPPER_KEYS:
+                    wrapped_config["extraction"] = {
+                        "customExtractionConfiguration": {CUSTOM_EXTRACTION_WRAPPER_KEYS[override_enum]: extraction}
+                    }
+                else:
+                    wrapped_config["extraction"] = extraction
+            elif any(key in extraction for key in builtin_config_keys):
+                strategy_type_enum = MemoryStrategyTypeEnum(strategy_type)
+                if strategy_type in ("SEMANTIC", "USER_PREFERENCE"):
                     wrapped_config["extraction"] = {EXTRACTION_WRAPPER_KEYS[strategy_type_enum]: extraction}
-                elif strategy_type == "USER_PREFERENCE":
-                    wrapped_config["extraction"] = {EXTRACTION_WRAPPER_KEYS[strategy_type_enum]: extraction}
-                elif strategy_type == "CUSTOM" and override_type:
-                    override_enum = OverrideType(override_type)
-                    if override_type in ["SEMANTIC_OVERRIDE", "USER_PREFERENCE_OVERRIDE"]:
-                        wrapped_config["extraction"] = {
-                            "customExtractionConfiguration": {CUSTOM_EXTRACTION_WRAPPER_KEYS[override_enum]: extraction}
-                        }
+                else:
+                    wrapped_config["extraction"] = extraction
             else:
                 wrapped_config["extraction"] = extraction
 
@@ -1849,5 +1980,17 @@ class MemoryClient:
                         }
             else:
                 wrapped_config["consolidation"] = consolidation
+
+        if "reflection" in config:
+            reflection = config["reflection"]
+
+            if strategy_type == "CUSTOM" and override_type:
+                override_enum = OverrideType(override_type)
+                if override_enum in CUSTOM_REFLECTION_WRAPPER_KEYS:
+                    wrapped_config["reflection"] = {
+                        "customReflectionConfiguration": {CUSTOM_REFLECTION_WRAPPER_KEYS[override_enum]: reflection}
+                    }
+            else:
+                wrapped_config["reflection"] = reflection
 
         return wrapped_config

--- a/src/bedrock_agentcore/memory/constants.py
+++ b/src/bedrock_agentcore/memory/constants.py
@@ -13,6 +13,7 @@ class StrategyType(Enum):
     SEMANTIC = "semanticMemoryStrategy"
     SUMMARY = "summaryMemoryStrategy"
     USER_PREFERENCE = "userPreferenceMemoryStrategy"
+    EPISODIC = "episodicMemoryStrategy"
     CUSTOM = "customMemoryStrategy"
 
 
@@ -22,6 +23,7 @@ class MemoryStrategyTypeEnum(Enum):
     SEMANTIC = "SEMANTIC"
     SUMMARIZATION = "SUMMARIZATION"
     USER_PREFERENCE = "USER_PREFERENCE"
+    EPISODIC = "EPISODIC"
     CUSTOM = "CUSTOM"
 
 
@@ -31,6 +33,7 @@ class OverrideType(Enum):
     SEMANTIC_OVERRIDE = "SEMANTIC_OVERRIDE"
     SUMMARY_OVERRIDE = "SUMMARY_OVERRIDE"
     USER_PREFERENCE_OVERRIDE = "USER_PREFERENCE_OVERRIDE"
+    EPISODIC_OVERRIDE = "EPISODIC_OVERRIDE"
 
 
 class MemoryStatus(Enum):
@@ -70,9 +73,10 @@ class MessageRole(Enum):
 
 # Default namespaces for each strategy type
 DEFAULT_NAMESPACES: Dict[StrategyType, List[str]] = {
-    StrategyType.SEMANTIC: ["/actor/{actorId}/strategy/{strategyId}/{sessionId}"],
-    StrategyType.SUMMARY: ["/actor/{actorId}/strategy/{strategyId}/{sessionId}"],
-    StrategyType.USER_PREFERENCE: ["/actor/{actorId}/strategy/{strategyId}"],
+    StrategyType.SEMANTIC: ["/strategies/{memoryStrategyId}/actors/{actorId}"],
+    StrategyType.SUMMARY: ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"],
+    StrategyType.USER_PREFERENCE: ["/strategies/{memoryStrategyId}/actors/{actorId}"],
+    StrategyType.EPISODIC: ["/strategies/{memoryStrategyId}/actors/{actorId}/sessions/{sessionId}"],
 }
 
 
@@ -86,12 +90,18 @@ EXTRACTION_WRAPPER_KEYS: Dict[MemoryStrategyTypeEnum, str] = {
 CUSTOM_EXTRACTION_WRAPPER_KEYS: Dict[OverrideType, str] = {
     OverrideType.SEMANTIC_OVERRIDE: "semanticExtractionOverride",
     OverrideType.USER_PREFERENCE_OVERRIDE: "userPreferenceExtractionOverride",
+    OverrideType.EPISODIC_OVERRIDE: "episodicExtractionOverride",
 }
 
 CUSTOM_CONSOLIDATION_WRAPPER_KEYS: Dict[OverrideType, str] = {
     OverrideType.SEMANTIC_OVERRIDE: "semanticConsolidationOverride",
     OverrideType.SUMMARY_OVERRIDE: "summaryConsolidationOverride",
     OverrideType.USER_PREFERENCE_OVERRIDE: "userPreferenceConsolidationOverride",
+    OverrideType.EPISODIC_OVERRIDE: "episodicConsolidationOverride",
+}
+
+CUSTOM_REFLECTION_WRAPPER_KEYS: Dict[OverrideType, str] = {
+    OverrideType.EPISODIC_OVERRIDE: "episodicReflectionOverride",
 }
 
 


### PR DESCRIPTION
- Add EPISODIC to StrategyType, MemoryStrategyTypeEnum, OverrideType enums
- Add EPISODIC to DEFAULT_NAMESPACES
- Add episodic wrapper keys for extraction, consolidation, reflection
- Add add_episodic_strategy() and add_episodic_strategy_and_wait()
- Add add_custom_episodic_strategy() and add_custom_episodic_strategy_and_wait()
- Update _wrap_configuration() to handle EPISODIC_OVERRIDE
- Add unit tests for all new episodic functionality

*Issue #, if available:*

*Description of changes:*

Enable support for using Episodic Strategies with AgentCore Memory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
