### PR TITLE
feat: add Slack notification workflow for new issues

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -1,0 +1,23 @@
+name: Slack Issue Notification
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue details to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            issue_title: "${{ github.event.issue.title }}"
+            issue_number: "${{ github.event.issue.number }}"
+            issue_url: "${{ github.event.issue.html_url }}"
+            issue_author: "${{ github.event.issue.user.login }}"
+            issue_body: "${{ github.event.issue.body }}"
+            repository: "${{ github.repository }}"
+            created_at: "${{ github.event.issue.created_at }}"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that automatically sends notifications to Slack when new issues are created
- Includes comprehensive issue details: title, number, URL, author, body, repository, and timestamp
- Uses Slack's webhook-triggered workflow integration via the official slack-github-action

## Test plan
- [x] Configure a Slack webhook URL in Workflow Builder
- [x] Add `SLACK_WEBHOOK_URL` secret to repository settings
- [ ] Create a test issue to verify the workflow triggers
- [ ] Confirm that all issue details are correctly sent to Slack
- [ ] Verify the Slack message formatting appears as expected