### PR TITLE
fix: escape special characters in Slack notification payload

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -18,6 +18,6 @@ jobs:
             issue_number: "${{ github.event.issue.number }}"
             issue_url: "${{ github.event.issue.html_url }}"
             issue_author: "${{ github.event.issue.user.login }}"
-            issue_body: "${{ github.event.issue.body }}"
+            issue_body: ${{ toJSON(github.event.issue.body) }}
             repository: "${{ github.repository }}"
             created_at: "${{ github.event.issue.created_at }}"


### PR DESCRIPTION
## Summary
- Use `toJSON()` function to properly escape special characters in issue body content
- Prevents YAML parsing errors when issue descriptions contain quotation marks or other special characters

Fixes #235

## Test plan
- [ ] Create a test issue with double quotes in the body to verify Slack notification succeeds
- [ ] Verify workflow syntax is valid