### PR TITLE
docs: update memory READMEs with metadata types and message batching

### DIFF
--- a/src/bedrock_agentcore/memory/README.md
+++ b/src/bedrock_agentcore/memory/README.md
@@ -563,6 +563,8 @@ event = session.add_turns([
 - **ActorSummary**: Actor information summary
 - **SessionSummary**: Session information summary
 - **MemoryRecord**: Long-term memory records
+- **EventMetadataFilter**: Filter expression for querying events by metadata
+- **StringValue**: Metadata value type for string data
 
 ### Configuration Classes
 
@@ -570,5 +572,6 @@ event = session.add_turns([
 - **MessageRole**: Enumeration of message roles (USER, ASSISTANT, TOOL, OTHER)
 - **MemoryStatus**: Memory resource status enumeration
 - **StrategyType**: Memory strategy type enumeration
+- **MetadataValue**: Type alias for metadata value types (StringValue)
 
 For detailed API documentation, refer to the inline docstrings and type hints in the source code.


### PR DESCRIPTION
## Summary
- Add documentation for `EventMetadataFilter`, `StringValue`, and `MetadataValue` types to the memory README
- Add `batch_size` parameter documentation to the Strands integration README
- Add new **Message Batching** section with context manager and explicit `close()` usage examples
- Add best practice note about flushing buffered messages when using `batch_size > 1`

These README updates were missed when #244 was merged.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm documented types and parameters match the current codebase