### PR TITLE
fix: use correct boto3 service name for evaluation client

### DIFF
--- a/src/bedrock_agentcore/evaluation/integrations/strands_agents_evals/evaluator.py
+++ b/src/bedrock_agentcore/evaluation/integrations/strands_agents_evals/evaluator.py
@@ -98,7 +98,7 @@ class StrandsEvalsAgentCoreEvaluator(Evaluator[str, str]):
 
         # Create client with provided or default config
         client_config = config or self._get_default_config()
-        self.client = boto3.client("agentcore-evaluation-dataplane", region_name=region, config=client_config)
+        self.client = boto3.client("bedrock-agentcore", region_name=region, config=client_config)
 
     @staticmethod
     def _get_default_config() -> Config:


### PR DESCRIPTION
## Summary
- Fix `StrandsEvalsAgentCoreEvaluator` using invalid boto3 service name `agentcore-evaluation-dataplane`, which raises `botocore.exceptions.UnknownServiceError`
- Change to `bedrock-agentcore`, the correct service where the `Evaluate` API lives

Closes #266

## Test plan
- [ ] Verify `create_strands_evaluator("Builtin.Correctness")` no longer raises `UnknownServiceError`
- [ ] Confirm `boto3.client("bedrock-agentcore", ...)` creates a valid client