### PR TITLE
fix: insert retrieved LTM before last user message to avoid prefill error

### DIFF
--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
@@ -1156,9 +1156,10 @@ class TestAgentCoreMemorySessionManager:
                     event = MessageAddedEvent(agent=mock_agent, message={"role": "user", "content": [{"text": "test"}]})
                     manager.retrieve_customer_context(event)
 
-                    # Verify context was injected
-                    assert len(mock_agent.messages) == 2
-                    injected_context = mock_agent.messages[1]["content"][0]["text"]
+                    # Verify context was injected into the user message as a content block
+                    # (single-message conversation uses inline injection)
+                    assert len(mock_agent.messages) == 1
+                    injected_context = mock_agent.messages[0]["content"][0]["text"]
 
                     # With threshold 0.5, only scores >= 0.5 should be included (0.6 and 0.9)
                     assert "High relevance 1" in injected_context

--- a/tests_integ/memory/integrations/test_session_manager.py
+++ b/tests_integ/memory/integrations/test_session_manager.py
@@ -151,7 +151,7 @@ class TestAgentCoreMemorySessionManager:
         response2 = agent("What do I like to eat?")
         assert response2 is not None
         assert "sushi" in str(agent.messages)
-        assert "<user_context>" in str(agent.messages)
+        assert "<retrieved_memory>" in str(agent.messages)
 
     def test_multiple_namespace_retrieval_config(self, test_memory_ltm):
         """Test session manager with multiple namespace retrieval configurations."""
@@ -182,7 +182,7 @@ class TestAgentCoreMemorySessionManager:
         response2 = agent("What do I like to eat?")
         assert response2 is not None
         assert "sushi" in str(agent.messages)
-        assert "<user_context>" in str(agent.messages)
+        assert "<retrieved_memory>" in str(agent.messages)
 
     def test_session_manager_error_handling(self):
         """Test session manager error handling with invalid configuration."""


### PR DESCRIPTION
## Summary
- Fixes assistant-prefill error on Claude 4.6+ models (Opus 4.6, Sonnet 4.6) when using `AgentCoreMemorySessionManager` with LTM retrieval

- Previously, retrieved memory was appended as an `assistant` message **after** the last user message, making it the final message sent to the model. Claude 4.6 rejects this with: `"This model does not support assistant message prefill. The conversation must end with a user message."`

- Now inserts the `assistant` memory message **before** the last user message, keeping the user's query last

- For the first message in a conversation (where prepending an assistant message would violate Bedrock's "must start with user" rule), injects memory as a content block within the user message instead

- Renames `<user_context>` tag to `<retrieved_memory>` for semantic accuracy

Closes #191

Related issue https://github.com/strands-agents/sdk-python/issues/1694

## Testing
- [x] Ran all unit tests 
- [x] Reproduced the prefill error against Opus 4.6 with the old code path (`ValidationException: does not support assistant message prefill`)
- [x] Verified both fix paths (insert-before and inline-in-first-msg) work against Opus 4.6
- [x] Full end-to-end test with `AgentCoreMemorySessionManager` + Opus 4.6 — no prefill error
- [x] Integration tests updated (`<user_context>` → `<retrieved_memory>`)