### PR TITLE
revert: rename retrieved_memory tag back to user_context

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -641,7 +641,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             if all_context:
                 context_text = "\n".join(all_context)
                 event.agent.messages[-1]["content"].insert(
-                    0, {"text": f"<retrieved_memory>{context_text}</retrieved_memory>"}
+                    0, {"text": f"<user_context>{context_text}</user_context>"}
                 )
                 logger.info("Retrieved %s customer context items", len(all_context))
 

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
@@ -1937,7 +1937,7 @@ class TestThinkingModeCompatibility:
                     # Memory prepended, original query remains last
                     content = mock_agent.messages[0]["content"]
                     assert len(content) == 2
-                    assert "<retrieved_memory>" in content[0]["text"]
+                    assert "<user_context>" in content[0]["text"]
                     assert content[1]["text"] == "What are my preferences?"
 
     def test_retrieve_customer_context_no_assistant_message_multi_turn(
@@ -1982,5 +1982,5 @@ class TestThinkingModeCompatibility:
                     # Memory injected into last user message
                     content = mock_agent.messages[-1]["content"]
                     assert len(content) == 2
-                    assert "<retrieved_memory>" in content[0]["text"]
+                    assert "<user_context>" in content[0]["text"]
                     assert content[1]["text"] == "What do I like to eat?"

--- a/tests_integ/memory/integrations/test_session_manager.py
+++ b/tests_integ/memory/integrations/test_session_manager.py
@@ -151,7 +151,7 @@ class TestAgentCoreMemorySessionManager:
         response2 = agent("What do I like to eat?")
         assert response2 is not None
         assert "sushi" in str(agent.messages)
-        assert "<retrieved_memory>" in str(agent.messages)
+        assert "<user_context>" in str(agent.messages)
 
     def test_multiple_namespace_retrieval_config(self, test_memory_ltm):
         """Test session manager with multiple namespace retrieval configurations."""
@@ -182,7 +182,7 @@ class TestAgentCoreMemorySessionManager:
         response2 = agent("What do I like to eat?")
         assert response2 is not None
         assert "sushi" in str(agent.messages)
-        assert "<retrieved_memory>" in str(agent.messages)
+        assert "<user_context>" in str(agent.messages)
 
     def test_session_manager_error_handling(self):
         """Test session manager error handling with invalid configuration."""


### PR DESCRIPTION
## Summary

Reverts the `<user_context>` → `<retrieved_memory>` tag rename introduced in #271. This tag rename is a breaking change for users who reference `<user_context>` in system prompts or parsing logic.

The core prefill fix from #271 (inserting memory before the last user message) is **not affected** — only the tag name is reverted.

A configurable `context_tag` parameter is proposed in #277 so users can opt in to a custom tag name without breaking existing setups.

## Test plan

- [x] All `<retrieved_memory>` references replaced with `<user_context>` in source + tests
- [x] Unit tests pass
- [ ] Integration tests pass