### PR TITLE
fix: Update list_events max results to max value 100

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -761,7 +761,7 @@ class MemoryClient:
                     "memoryId": memory_id,
                     "actorId": actor_id,
                     "sessionId": session_id,
-                    "maxResults": min(100, max_results - len(all_events)),
+                    "maxResults": 100,
                     "includePayloads": include_payload,
                 }
 

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -493,7 +493,7 @@ def test_list_events_with_pagination():
         # Check second call parameters
         second_call = mock_gmdp.list_events.call_args_list[1]
         assert second_call[1]["nextToken"] == "token-123"
-        assert second_call[1]["maxResults"] == 50
+        assert second_call[1]["maxResults"] == 100
 
 
 def test_list_events_with_branch_filter():
@@ -662,7 +662,7 @@ def test_list_events_max_results_limit():
 
         # Verify API was called with correct max_results
         args, kwargs = mock_gmdp.list_events.call_args
-        assert kwargs["maxResults"] == 25
+        assert kwargs["maxResults"] == 100
 
 
 def test_list_memories():


### PR DESCRIPTION

*Description of changes:* Updating max_results for list_events API to 100. This is to fix api multiple calls while filtering for sparse metadata events. The ListEvents API's maxResults param limits the number of events scanned, and not how many results matched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
