### PR TITLE
fix: Handle image-only messages in `retrieve_customer_context`

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -628,7 +628,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             event (MessageAddedEvent): The message added event containing the agent and message data.
         """
         messages = event.agent.messages
-        if not messages or messages[-1].get("role") != "user" or "toolResult" in messages[-1].get("content")[0]:
+        if not messages or messages[-1].get("role") != "user" or "text" not in messages[-1].get("content")[0]:
             return None
         if not self.config.retrieval_config:
             # Only retrieve LTM


### PR DESCRIPTION
*Description of changes:*

`retrieve_customer_context` crashed with `KeyError: 'text'` when a message contained no text content (e.g. an image-only message), because it unconditionally accessed `content[0]["text"]`.

The fix updates the early-return guard to check `"text" not in content[0]` instead of `"toolResult" in content[0]`, skipping LTM retrieval for any message whose first content block is not text.