### PR TITLE
fix: apply ruff formatting to openai converter files

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/converters/openai.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/converters/openai.py
@@ -138,9 +138,7 @@ class OpenAIConverseConverter:
             return []
 
         has_non_empty = any(
-            (isinstance(item.get("text"), str) and item["text"].strip())
-            or "toolUse" in item
-            or "toolResult" in item
+            (isinstance(item.get("text"), str) and item["text"].strip()) or "toolUse" in item or "toolResult" in item
             for item in content
         )
         if not has_non_empty:

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager_openai_converter.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager_openai_converter.py
@@ -1,4 +1,5 @@
 """Session manager tests with OpenAI converter."""
+
 from unittest.mock import Mock, patch
 
 from strands.types.session import Session, SessionMessage, SessionType


### PR DESCRIPTION
## Summary
- Applies `ruff format` to 2 files introduced in #288 that were not formatted
- Fixes lint failures blocking all open dependabot PRs (#306, #307, #308, #309, #310, #221, #140, #139)

## Files changed
- `src/bedrock_agentcore/memory/integrations/strands/converters/openai.py`
- `tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager_openai_converter.py`

## Test plan
- [x] `ruff format --check .` passes after this change