### PR TITLE
fix: return 400 for UnicodeDecodeError in invocation handler

### DIFF
--- a/src/bedrock_agentcore/runtime/app.py
+++ b/src/bedrock_agentcore/runtime/app.py
@@ -440,6 +440,10 @@ class BedrockAgentCoreApp(Starlette):
             duration = time.time() - start_time
             self.logger.warning("Invalid JSON in request (%.3fs): %s", duration, e)
             return JSONResponse({"error": "Invalid JSON", "details": str(e)}, status_code=400)
+        except UnicodeDecodeError as e:
+            duration = time.time() - start_time
+            self.logger.warning("Invalid encoding in request (%.3fs): %s", duration, e)
+            return JSONResponse({"error": "Invalid encoding", "details": str(e)}, status_code=400)
         except HTTPException as e:
             duration = time.time() - start_time
             # Use error level for 5xx to match the generic Exception handler's severity,

--- a/tests/bedrock_agentcore/runtime/test_app.py
+++ b/tests/bedrock_agentcore/runtime/test_app.py
@@ -472,6 +472,24 @@ class TestCustomStatusCodes:
         assert response.status_code == 500
         assert response.json() == {"error": "Intentional server error"}
 
+    def test_unicode_decode_error_returns_400(self):
+        """Test UnicodeDecodeError from invalid input returns 400, not 500."""
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint
+        def handler(payload):
+            return payload
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            "/invocations",
+            content=b"\x80\x81\x82",
+            headers={"content-type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid encoding" in response.json()["error"]
+
     def test_return_response_passthrough(self):
         """Test returning a Response object passes it through without wrapping."""
         from starlette.responses import JSONResponse


### PR DESCRIPTION
## Summary
- `UnicodeDecodeError` from invalid request bytes (e.g. non-UTF-8) was falling through to the generic `Exception` handler in `_handle_invocation`, returning a **500** instead of a **400**.
- Added an explicit `except UnicodeDecodeError` clause that returns `400 Bad Request` with an `"Invalid encoding"` error message.
- Added a test that sends raw invalid UTF-8 bytes to `/invocations` and asserts a 400 response.

Closes #311

## Test plan
- [x] New test `test_unicode_decode_error_returns_400` passes
- [x] All existing error-handling tests continue to pass