### PR TITLE
fix: use memoryStrategyId instead of strategyId in search_long_term_memories

### DIFF
--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -905,7 +905,7 @@ class MemorySessionManager:
         logger.info("  -> Querying long-term memory in namespace '%s' with query: '%s'...", namespace_prefix, query)
         search_criteria = {"searchQuery": query, "topK": top_k}
         if strategy_id:
-            search_criteria["strategyId"] = strategy_id
+            search_criteria["memoryStrategyId"] = strategy_id
 
         namespace = namespace_prefix
         params = {

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -1213,7 +1213,7 @@ class TestSessionManager:
 
             # Verify strategy_id was passed
             call_args = mock_client_instance.retrieve_memory_records.call_args[1]
-            assert call_args["searchCriteria"]["strategyId"] == "strategy-123"
+            assert call_args["searchCriteria"]["memoryStrategyId"] == "strategy-123"
 
     def test_search_long_term_memories_client_error(self):
         """Test search_long_term_memories with ClientError."""
@@ -2182,7 +2182,7 @@ class TestEdgeCases:
 
             # Verify strategy_id was not passed
             call_args = mock_client_instance.retrieve_memory_records.call_args[1]
-            assert "strategyId" not in call_args["searchCriteria"]
+            assert "memoryStrategyId" not in call_args["searchCriteria"]
 
     def test_list_long_term_memory_records_without_strategy_id(self):
         """Test list_long_term_memory_records without strategy_id to cover missing branch."""


### PR DESCRIPTION
## Summary

- Fixes `MemorySessionManager.search_long_term_memories` sending `strategyId` instead of `memoryStrategyId` in the search criteria passed to the boto3 `retrieve_memory_records` API, which requires `memoryStrategyId`.
- Updates corresponding test assertions to match the corrected parameter name.

Closes #303

## Test plan

- [x] Existing unit tests updated and passing (294 tests in memory suite)
- [x] `test_search_long_term_memories_with_strategy` verifies `memoryStrategyId` is sent
- [x] `test_search_long_term_memories_without_strategy_id` verifies key is absent when not provided