### PR TITLE
fix(strands-memory): restore positional arg order in SessionManager init

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -104,22 +104,23 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
     def __init__(
         self,
         agentcore_memory_config: AgentCoreMemoryConfig,
-        converter: Optional[type[MemoryConverter]] = None,
         region_name: Optional[str] = None,
         boto_session: Optional[boto3.Session] = None,
         boto_client_config: Optional[BotocoreConfig] = None,
+        *,
+        converter: Optional[type[MemoryConverter]] = None,
         **kwargs: Any,
     ):
         """Initialize AgentCoreMemorySessionManager with Bedrock AgentCore Memory.
 
         Args:
             agentcore_memory_config (AgentCoreMemoryConfig): Configuration for AgentCore Memory integration.
-            converter (Optional[type[MemoryConverter]], optional): Optional custom converter.
-                If None, native Bedrock/Strands converter is used.
             region_name (Optional[str], optional): AWS region for Bedrock AgentCore Memory. Defaults to None.
             boto_session (Optional[boto3.Session], optional): Optional boto3 session. Defaults to None.
             boto_client_config (Optional[BotocoreConfig], optional): Optional boto3 client configuration.
                Defaults to None.
+            converter (Optional[type[MemoryConverter]], optional): Optional custom converter.
+                If None, native Bedrock/Strands converter is used.
             **kwargs (Any): Additional keyword arguments.
         """
         self.converter = converter or AgentCoreMemoryConverter


### PR DESCRIPTION
## Summary

- PR #288 (`6cda0a3`) inserted `converter` as the 2nd positional parameter in `AgentCoreMemorySessionManager.__init__`, shifting `region_name` from position 2 to 3
- Any caller passing `region_name` positionally (e.g. `AgentCoreMemorySessionManager(config, REGION)`) silently assigns the region string to `converter`, leaving `region_name=None`
- This causes `botocore.exceptions.NoRegionError: You must specify a region.` at runtime when creating boto3 clients
- Affects the AgentCore CLI strands+memory template which passes region as a positional arg

## Fix

- Restore the original positional parameter order: `config, region_name, boto_session, boto_client_config`
- Make `converter` **keyword-only** (after `*`) so it can never be passed positionally, preventing future breaks
- All existing callers in the SDK already use `converter=` as a keyword argument, so no code changes needed elsewhere

## Test plan

- [x] All 125 existing unit tests pass
- [ ] Verify deployed strands+memory agent no longer gets `NoRegionError`