### PR TITLE
ci: temporarily disable memory integration tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -117,11 +117,6 @@ jobs:
             timeout: 10
             extra-deps: ""
             ignore: ""
-          # - group: memory
-          #   path: tests_integ/memory
-          #   timeout: 20
-          #   extra-deps: ""
-          #   ignore: ""
           - group: evaluation
             path: tests_integ/evaluation
             timeout: 15


### PR DESCRIPTION
## Summary

- Comment out the `tests_integ/memory` group from the integration testing matrix while the underlying issue is being resolved (https://github.com/aws/bedrock-agentcore-sdk-python/issues/316)

## Test plan

- [x] Verify the workflow YAML is valid and the remaining test groups (runtime, evaluation) are unaffected