### PR TITLE
fix: use separate ports for runtime integ tests to avoid parallel conflicts

### DIFF
--- a/tests_integ/runtime/base_test.py
+++ b/tests_integ/runtime/base_test.py
@@ -10,7 +10,7 @@ from typing import IO, Generator
 
 logger = logging.getLogger("sdk-runtime-base-test")
 
-AGENT_SERVER_ENDPOINT = "http://127.0.0.1:8080"
+DEFAULT_PORT = 8080
 
 
 class BaseSDKRuntimeTest(ABC):
@@ -36,8 +36,8 @@ class BaseSDKRuntimeTest(ABC):
 
 
 @contextmanager
-def start_agent_server(agent_module, timeout=5) -> Generator[Popen, None, None]:
-    logger.info("Starting agent server...")
+def start_agent_server(agent_module, port=DEFAULT_PORT, timeout=5) -> Generator[Popen, None, None]:
+    logger.info("Starting agent server on port %d...", port)
     start_time = time.time()
 
     try:
@@ -58,7 +58,7 @@ def start_agent_server(agent_module, timeout=5) -> Generator[Popen, None, None]:
                 line = line.strip()
                 if line:
                     logger.info(line)
-                    if "Uvicorn running on http://127.0.0.1:8080" in line:
+                    if f"Uvicorn running on http://127.0.0.1:{port}" in line:
                         _start_logging_thread(agent_server.stdout)
                         yield agent_server
                         return

--- a/tests_integ/runtime/test_simple_agent.py
+++ b/tests_integ/runtime/test_simple_agent.py
@@ -1,7 +1,7 @@
 import logging
 import textwrap
 
-from tests_integ.runtime.base_test import AGENT_SERVER_ENDPOINT, BaseSDKRuntimeTest, start_agent_server
+from tests_integ.runtime.base_test import DEFAULT_PORT, BaseSDKRuntimeTest, start_agent_server
 from tests_integ.runtime.http_client import HttpClient
 
 logger = logging.getLogger("sdk-runtime-simple-agent-test")
@@ -28,7 +28,7 @@ class TestSDKSimpleAgent(BaseSDKRuntimeTest):
 
     def run_test(self):
         with start_agent_server(self.agent_module):
-            client = HttpClient(AGENT_SERVER_ENDPOINT)
+            client = HttpClient(f"http://127.0.0.1:{DEFAULT_PORT}")
 
             ping_response = client.ping()
             logger.info(ping_response)

--- a/tests_integ/runtime/test_websocket_agent.py
+++ b/tests_integ/runtime/test_websocket_agent.py
@@ -5,9 +5,11 @@ import textwrap
 
 import websockets
 
-from tests_integ.runtime.base_test import AGENT_SERVER_ENDPOINT, BaseSDKRuntimeTest, start_agent_server
+from tests_integ.runtime.base_test import BaseSDKRuntimeTest, start_agent_server
 
 logger = logging.getLogger("sdk-runtime-websocket-test")
+
+WEBSOCKET_PORT = 8081
 
 
 class TestSDKWebSocketAgent(BaseSDKRuntimeTest):
@@ -53,14 +55,13 @@ class TestSDKWebSocketAgent(BaseSDKRuntimeTest):
                     finally:
                         await websocket.close()
 
-                app.run()
+                app.run(port=8081)
             """).strip()
             file.write(content)
 
     def run_test(self):
-        with start_agent_server(self.agent_module):
-            # Replace http:// with ws:// for WebSocket connection
-            ws_endpoint = AGENT_SERVER_ENDPOINT.replace("http://", "ws://") + "/ws"
+        with start_agent_server(self.agent_module, port=WEBSOCKET_PORT):
+            ws_endpoint = f"ws://127.0.0.1:{WEBSOCKET_PORT}/ws"
 
             # Run async WebSocket tests
             asyncio.run(self._test_websocket_echo(ws_endpoint))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Problem 
The integration tests have been configured to run in parallel. However, the runtime tests do not support this because they start up local servers on the same port. 

## Solution
- use different ports for different tests so they can run concurrently. 

## Testing
- CI

## Notes
memory tests should be fixed by https://github.com/aws/bedrock-agentcore-sdk-python/pull/331. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
