### PR TITLE
Ci/dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,68 @@
+# .github/workflows/dependabot-auto-merge.yml
+#
+# Automatically enables auto-merge on Dependabot PRs for minor and patch
+# version bumps. GitHub holds the actual merge until all required status
+# checks in the 'main-status-checks' Ruleset pass.
+#
+# Major version bumps are explicitly skipped and require human review
+# from the aws/bedrock-agentcore-maintainers team.
+#
+# PREREQUISITES (already completed):
+#   ✅ Ruleset 'main-status-checks' — CI must pass, no bypass for anyone
+#   ✅ Ruleset 'main' — approval requirement, Dependabot bypass added
+#   ✅ Settings → General → Allow auto-merge enabled
+
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write      # required to execute the squash merge
+  pull-requests: write # required to enable auto-merge
+
+jobs:
+  dependabot-auto-merge:
+    name: Auto-merge minor/patch PRs
+    runs-on: ubuntu-latest
+
+    # Only act on PRs opened by the Dependabot bot.
+    # The correct login is 'dependabot[bot]' — the bare string 'dependabot'
+    # never matches and would silently skip all runs.
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # patch and minor bumps: enable auto-merge.
+      # GitHub holds the merge until all required status checks pass.
+      # If CI fails the PR stays open — no merge happens.
+      - name: Enable auto-merge for minor/patch bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge --auto --squash "$PR_URL"
+          echo "✓ Auto-merge enabled: ${{ steps.metadata.outputs.dependency-names }} \
+          (${{ steps.metadata.outputs.previous-version }} → \
+          ${{ steps.metadata.outputs.new-version }}, \
+          ${{ steps.metadata.outputs.update-type }})"
+
+      # major bumps: log clearly and do nothing.
+      # The PR stays open and is assigned to aws/bedrock-agentcore-maintainers
+      # via dependabot.yml for human review.
+      - name: Skip major bumps — human review required
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          echo "⏭ Skipped: ${{ steps.metadata.outputs.dependency-names }} \
+          is a major bump (${{ steps.metadata.outputs.previous-version }} → \
+          ${{ steps.metadata.outputs.new-version }}). \
+          Requires review from aws/bedrock-agentcore-maintainers."


### PR DESCRIPTION

## Dependabot Auto-merge for Minor/Patch PRs

Adds `.github/workflows/dependabot-auto-merge.yml` to automatically enable
auto-merge on Dependabot PRs for minor and patch version bumps after all CI
checks pass. Major version bumps are explicitly skipped and require manual
review.

### Behavior

|Bump type                          |What happens                                 |
|-----------------------------------|---------------------------------------------|
|`semver-patch` (e.g. 1.4.5 → 1.4.6)|Auto-merge enabled — merges after CI passes  |
|`semver-minor` (e.g. 1.4.5 → 1.5.0)|Auto-merge enabled — merges after CI passes  |
|`semver-major` (e.g. 1.4.5 → 2.0.0)|Skipped — PR stays open for maintainer review|

### How it works

1. Triggers on `pull_request` — Dependabot gets a full write-access
   `GITHUB_TOKEN` on this trigger because of the bypass configured in the
   `main` Ruleset
1. Fetches structured metadata via `dependabot/fetch-metadata@v2` to determine
   the bump type
1. Calls `gh pr merge --auto --squash` for patch and minor bumps
1. GitHub holds the actual merge until all required checks in the
   `main-status-checks` Ruleset pass (lint, tests across Python 3.10–3.13,
   build, install verification)
1. If CI fails the PR stays open — no merge happens

### Repo settings already in place

|Setting                                                            |Status   |
|-------------------------------------------------------------------|---------|
|Ruleset `main-status-checks` — CI must pass, no bypass for anyone  |✅ Active |
|Ruleset `main` — approval requirement with `dependabot[bot]` bypass|✅ Active |
|Settings → General → Allow auto-merge                              |✅ Enabled|

### Security

- `github.actor == 'dependabot[bot]'` gate at the job level — the workflow
  only acts on PRs opened by the GitHub-internal Dependabot bot, not any
  human or external contributor
- `GITHUB_TOKEN` is ephemeral and scoped to `contents: write` and
  `pull-requests: write` only — no other permissions
- CI remains a hard gate with no bypass — Dependabot PRs must pass all
  checks in `main-status-checks` before GitHub executes the merge
- Major version bumps are never auto-merged — they follow the normal
  review process and are assigned to `aws/bedrock-agentcore-maintainers`
  via `dependabot.yml`
