### PR TITLE
ci: migrate PyPI publishing to OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,6 +80,12 @@ jobs:
       name: pypi
       url: https://pypi.org/project/bedrock-agentcore/
 
+    # id-token: write is required for OIDC Trusted Publishing.
+    # This replaces the PYPI_API_TOKEN secret
+    permissions:
+      id-token: write
+      contents: write
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -91,30 +97,27 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Verify PyPI token exists
-        env:
-          PYPI_TOKEN_SET: ${{ secrets.PYPI_API_TOKEN != '' }}
-        run: |
-          if [ "$PYPI_TOKEN_SET" != "true" ]; then
-            echo "❌ ERROR: PYPI_API_TOKEN not configured!"
-            exit 1
-          fi
-          echo "✓ PyPI token is configured"
-
-      - name: Check if version exists on PyPI
+      # Uses the PyPI JSON API — stable and versioned.
+      # pip index versions output format is not guaranteed stable across
+      # pip versions and should not be used in CI.
+      - name: Check if version already exists on PyPI
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          if pip index versions bedrock-agentcore | grep -q "^Available versions.*$VERSION"; then
+          PYPI_VERSIONS=$(curl -sf https://pypi.org/pypi/bedrock-agentcore/json \
+            | python3 -c "import sys, json; releases = json.load(sys.stdin)['releases']; print('\n'.join(releases.keys()))")
+
+          if echo "$PYPI_VERSIONS" | grep -qx "$VERSION"; then
             echo "❌ ERROR: Version $VERSION already exists on PyPI!"
             exit 1
           fi
           echo "✓ Version $VERSION is not on PyPI, safe to publish"
 
+      # automatically detects and uses Trusted Publishing via OIDC when
+      # no token is provided and id-token: write permission is set.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: false
           verbose: true
 
@@ -124,7 +127,9 @@ jobs:
         run: |
           echo "Waiting for package to be available on PyPI..."
           for i in {1..10}; do
-            if pip index versions bedrock-agentcore | grep -q "$VERSION"; then
+            PYPI_VERSIONS=$(curl -sf https://pypi.org/pypi/bedrock-agentcore/json \
+              | python3 -c "import sys, json; releases = json.load(sys.stdin)['releases']; print('\n'.join(releases.keys()))" 2>/dev/null)
+            if echo "$PYPI_VERSIONS" | grep -qx "$VERSION"; then
               echo "✓ Package version $VERSION is now available on PyPI"
               break
             fi


### PR DESCRIPTION
#### Migrate PyPI Publishing to Trusted Publishing

Update our PyPI release workflow by migrating from a long-lived API token to OpenID Connect (OIDC) Trusted Publishing — the current recommended approach by PyPI for publishing from GitHub Actions.

#### What changed

Long-lived API tokens are a maintenance burden. With this change, GitHub will now generate a short-lived cryptographic token at publish time that PyPI verifies directly. The token is scoped to a single workflow run and expires immediately after. 

#### What else was improved
The version existence check before publishing was updated to use the official PyPI JSON API, which is stable and versioned, replacing a previous approach that was fragile across different environments.

#### After this PR merges

Once the next release confirms publishing works correctly, the old PYPI_API_TOKEN secret should be deleted from the repo settings and the corresponding token removed from PyPI account settings.

No functional change to the release process: The trigger, the approval gate, the build steps, and the GitHub Release creation are all identical to before. Only the authentication mechanism for the PyPI publish step has changed.​​​​​​​​​​​​​​​​
