### PR TITLE
fix: lazy import strands-agents-evals to avoid ImportError when not installed

### DIFF
--- a/src/bedrock_agentcore/evaluation/__init__.py
+++ b/src/bedrock_agentcore/evaluation/__init__.py
@@ -1,10 +1,6 @@
 """AgentCore Evaluation: EvaluationClient and Strands integration."""
 
 from bedrock_agentcore.evaluation.client import EvaluationClient
-from bedrock_agentcore.evaluation.integrations.strands_agents_evals.evaluator import (
-    StrandsEvalsAgentCoreEvaluator,
-    create_strands_evaluator,
-)
 from bedrock_agentcore.evaluation.span_to_adot_serializer import (
     convert_strands_to_adot,
 )
@@ -19,3 +15,31 @@ __all__ = [
     "create_strands_evaluator",
     "fetch_spans_from_cloudwatch",
 ]
+
+_STRANDS_EVALS_EXTRAS = {
+    "StrandsEvalsAgentCoreEvaluator",
+    "create_strands_evaluator",
+}
+
+
+def __getattr__(name: str):
+    """Lazy import for optional strands-agents-evals dependencies."""
+    if name in _STRANDS_EVALS_EXTRAS:
+        try:
+            from bedrock_agentcore.evaluation.integrations.strands_agents_evals.evaluator import (
+                StrandsEvalsAgentCoreEvaluator,
+                create_strands_evaluator,
+            )
+        except ImportError as e:
+            raise ImportError(
+                f"'{name}' requires the 'strands-agents-evals' extra. "
+                "Install it with: pip install 'bedrock-agentcore[strands-agents-evals]'"
+            ) from e
+
+        _lazy = {
+            "StrandsEvalsAgentCoreEvaluator": StrandsEvalsAgentCoreEvaluator,
+            "create_strands_evaluator": create_strands_evaluator,
+        }
+        return _lazy[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- Use `__getattr__` lazy loading in `evaluation/__init__.py` so `StrandsEvalsAgentCoreEvaluator` and `create_strands_evaluator` are only imported when accessed
- Users who install `bedrock-agentcore` without the `strands-agents-evals` extra can now use `EvaluationClient` without hitting an `ImportError`
- When strands-dependent symbols are accessed without the extra installed, a clear error message tells users how to install it

Closes #340

## Test plan
- [x] `from bedrock_agentcore.evaluation import EvaluationClient` works without strands installed
- [x] `from bedrock_agentcore.evaluation import create_strands_evaluator` works when strands is installed
- [x] `from bedrock_agentcore.evaluation import create_strands_evaluator` gives clear `ImportError` when strands is not installed
- [x] All 119 existing evaluation tests pass