### PR TITLE
feat: Emit OTEL attributes for AgentCore Evaluation support

### DIFF
--- a/src/bedrock_agentcore/runtime/app.py
+++ b/src/bedrock_agentcore/runtime/app.py
@@ -120,6 +120,8 @@ class BedrockAgentCoreApp(Starlette):
         self.handlers: Dict[str, Callable] = {}
         self._ping_handler: Optional[Callable] = None
         self._websocket_handler: Optional[Callable] = None
+        self._prompt_key: Optional[str] = None
+        self._response_key: Optional[str] = None
         self._active_tasks: Dict[int, Dict[str, Any]] = {}
         self._task_counter_lock: threading.Lock = threading.Lock()
         self._forced_ping_status: Optional[PingStatus] = None
@@ -144,18 +146,44 @@ class BedrockAgentCoreApp(Starlette):
             self.logger.addHandler(handler)
             self.logger.setLevel(logging.DEBUG if self.debug else logging.INFO)
 
-    def entrypoint(self, func: Callable) -> Callable:
+    def entrypoint(
+        self, func: Callable = None, *, prompt_key: Optional[str] = None, response_key: Optional[str] = None
+    ) -> Callable:
         """Decorator to register a function as the main entrypoint.
 
         Args:
             func: The function to register as entrypoint
+            prompt_key: Optional key to extract user prompt from the payload dict.
+                If not specified, tries common keys in order (prompt, input, query,
+                message, question, user_input) then falls back to JSON serialization.
+            response_key: Optional key to extract agent response from the result dict.
+                If not specified, the full result is used.
 
         Returns:
             The decorated function with added serve method
+
+        Examples:
+            @app.entrypoint
+            def handler(payload):
+                ...
+
+            @app.entrypoint(prompt_key="user_input")
+            def handler(payload):
+                ...
         """
-        self.handlers["main"] = func
-        func.run = lambda port=8080, host=None: self.run(port, host)
-        return func
+
+        def decorator(f: Callable) -> Callable:
+            self.handlers["main"] = f
+            self._prompt_key = prompt_key
+            self._response_key = response_key
+            f.run = lambda port=8080, host=None: self.run(port, host)
+            return f
+
+        if func is not None:
+            # Called as @app.entrypoint without arguments
+            return decorator(func)
+        # Called as @app.entrypoint(...) with arguments
+        return decorator
 
     def ping(self, func: Callable) -> Callable:
         """Decorator to register a custom ping status handler.
@@ -395,6 +423,10 @@ class BedrockAgentCoreApp(Starlette):
 
         The attributes are set on the current active span (typically the root
         POST /invocations span created by ADOT auto-instrumentation).
+
+        When prompt_key or response_key is configured via @app.entrypoint(),
+        those specific keys are used to extract from dict payloads/results.
+        Otherwise, a heuristic tries common keys in priority order.
         """
         try:
             from opentelemetry import trace as otel_trace
@@ -406,10 +438,15 @@ class BedrockAgentCoreApp(Starlette):
             # Extract user prompt from payload
             user_prompt = None
             if isinstance(payload, dict):
-                for key in ("prompt", "input", "query", "message", "question", "user_input"):
-                    if key in payload and isinstance(payload[key], str):
-                        user_prompt = payload[key]
-                        break
+                if self._prompt_key is not None:
+                    value = payload.get(self._prompt_key)
+                    if isinstance(value, str):
+                        user_prompt = value
+                else:
+                    for key in ("prompt", "input", "query", "message", "question", "user_input"):
+                        if key in payload and isinstance(payload[key], str):
+                            user_prompt = payload[key]
+                            break
                 if user_prompt is None:
                     user_prompt = json.dumps(payload, ensure_ascii=False, default=str)
             elif isinstance(payload, str):
@@ -422,17 +459,25 @@ class BedrockAgentCoreApp(Starlette):
             if isinstance(result, str):
                 agent_response = result
             elif isinstance(result, Response):
-                return  # Skip for streaming/custom responses — cannot capture full output
+                pass  # Skip for streaming/custom responses — cannot capture full output
+            elif isinstance(result, dict) and self._response_key is not None:
+                value = result.get(self._response_key)
+                if isinstance(value, str):
+                    agent_response = value
+                elif value is not None:
+                    try:
+                        agent_response = json.dumps(value, ensure_ascii=False, default=str)
+                    except Exception:
+                        agent_response = str(value)
             elif result is not None:
                 try:
                     agent_response = json.dumps(result, ensure_ascii=False, default=str)
                 except Exception:
                     agent_response = str(result)
 
-            existing_attrs = span.attributes if hasattr(span, "attributes") and span.attributes else {}
-            if user_prompt and "agentcore.invocation.user_prompt" not in existing_attrs:
+            if user_prompt:
                 span.set_attribute("agentcore.invocation.user_prompt", user_prompt[:16384])
-            if agent_response and "agentcore.invocation.agent_response" not in existing_attrs:
+            if agent_response:
                 span.set_attribute("agentcore.invocation.agent_response", agent_response[:16384])
         except ImportError:
             pass  # OpenTelemetry not installed — silently skip

--- a/tests/bedrock_agentcore/runtime/test_app.py
+++ b/tests/bedrock_agentcore/runtime/test_app.py
@@ -2821,12 +2821,10 @@ class TestEmitInvocationOtelAttributes:
         with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
             app._emit_invocation_otel_attributes("prompt", {"answer": "42"})
 
-        mock_span.set_attribute.assert_any_call(
-            "agentcore.invocation.agent_response", json.dumps({"answer": "42"})
-        )
+        mock_span.set_attribute.assert_any_call("agentcore.invocation.agent_response", json.dumps({"answer": "42"}))
 
-    def test_response_object_skips_emission(self):
-        """Starlette Response result causes early return (no agent_response set)."""
+    def test_response_object_skips_agent_response_but_emits_user_prompt(self):
+        """Starlette Response result skips agent_response but still emits user_prompt."""
         from starlette.responses import Response as StarletteResponse
 
         app = self._make_app()
@@ -2834,10 +2832,11 @@ class TestEmitInvocationOtelAttributes:
         mock_span.is_recording.return_value = True
 
         with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
-            app._emit_invocation_otel_attributes("prompt", StarletteResponse(content="streaming"))
+            app._emit_invocation_otel_attributes("my prompt", StarletteResponse(content="streaming"))
 
         attr_names = [c[0][0] for c in mock_span.set_attribute.call_args_list]
         assert "agentcore.invocation.agent_response" not in attr_names
+        mock_span.set_attribute.assert_any_call("agentcore.invocation.user_prompt", "my prompt")
 
     def test_none_result_skips_agent_response(self):
         """None result does not set agent_response attribute."""
@@ -2910,47 +2909,89 @@ class TestEmitInvocationOtelAttributes:
         assert call_args[0] == {"prompt": "test"}
         assert call_args[1] == {"result": "ok"}
 
-    def test_does_not_override_existing_user_prompt(self):
-        """If user_prompt attribute is already set on the span, it should not be overridden."""
+    def test_prompt_key_extracts_specified_key(self):
+        """When prompt_key is configured, that specific key is used."""
         app = self._make_app()
+        app._prompt_key = "user_input"
         mock_span = MagicMock()
         mock_span.is_recording.return_value = True
-        mock_span.attributes = {"agentcore.invocation.user_prompt": "custom prompt"}
 
         with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
-            app._emit_invocation_otel_attributes({"prompt": "auto-extracted"}, "response text")
+            app._emit_invocation_otel_attributes(
+                {"input": "file.txt", "user_input": "What is the weather?"},
+                "Sunny",
+            )
 
-        # user_prompt should NOT be set (already exists), but agent_response should be set
-        attr_names = [c[0][0] for c in mock_span.set_attribute.call_args_list]
-        assert "agentcore.invocation.user_prompt" not in attr_names
-        mock_span.set_attribute.assert_any_call("agentcore.invocation.agent_response", "response text")
+        mock_span.set_attribute.assert_any_call("agentcore.invocation.user_prompt", "What is the weather?")
 
-    def test_does_not_override_existing_agent_response(self):
-        """If agent_response attribute is already set on the span, it should not be overridden."""
+    def test_prompt_key_falls_back_to_json_when_key_missing(self):
+        """When prompt_key is configured but missing from payload, falls back to JSON."""
         app = self._make_app()
+        app._prompt_key = "user_input"
         mock_span = MagicMock()
         mock_span.is_recording.return_value = True
-        mock_span.attributes = {"agentcore.invocation.agent_response": "custom response"}
 
         with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
-            app._emit_invocation_otel_attributes({"prompt": "hello"}, "auto-extracted response")
+            app._emit_invocation_otel_attributes({"input": "file.txt"}, "resp")
 
-        # agent_response should NOT be set (already exists), but user_prompt should be set
-        attr_names = [c[0][0] for c in mock_span.set_attribute.call_args_list]
-        assert "agentcore.invocation.agent_response" not in attr_names
-        mock_span.set_attribute.assert_any_call("agentcore.invocation.user_prompt", "hello")
+        calls = {c[0][0]: c[0][1] for c in mock_span.set_attribute.call_args_list}
+        assert calls["agentcore.invocation.user_prompt"] == json.dumps({"input": "file.txt"})
 
-    def test_does_not_override_when_both_already_set(self):
-        """If both attributes are already set on the span, neither should be overridden."""
+    def test_response_key_extracts_specified_key(self):
+        """When response_key is configured, that specific key is used from dict result."""
         app = self._make_app()
+        app._response_key = "answer"
         mock_span = MagicMock()
         mock_span.is_recording.return_value = True
-        mock_span.attributes = {
-            "agentcore.invocation.user_prompt": "custom prompt",
-            "agentcore.invocation.agent_response": "custom response",
-        }
 
         with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
-            app._emit_invocation_otel_attributes({"prompt": "auto"}, "auto resp")
+            app._emit_invocation_otel_attributes("prompt", {"answer": "42", "debug": "info"})
 
-        mock_span.set_attribute.assert_not_called()
+        mock_span.set_attribute.assert_any_call("agentcore.invocation.agent_response", "42")
+
+    def test_response_key_ignored_for_string_result(self):
+        """When response_key is configured but result is a string, string is used directly."""
+        app = self._make_app()
+        app._response_key = "answer"
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+
+        with patch("opentelemetry.trace.get_current_span", return_value=mock_span):
+            app._emit_invocation_otel_attributes("prompt", "plain response")
+
+        mock_span.set_attribute.assert_any_call("agentcore.invocation.agent_response", "plain response")
+
+    def test_entrypoint_with_prompt_key(self):
+        """@app.entrypoint(prompt_key=...) stores the key on the app."""
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint(prompt_key="user_input")
+        def handler(payload):
+            return "ok"
+
+        assert app._prompt_key == "user_input"
+        assert app._response_key is None
+        assert app.handlers["main"] is handler
+
+    def test_entrypoint_with_prompt_and_response_key(self):
+        """@app.entrypoint(prompt_key=..., response_key=...) stores both keys."""
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint(prompt_key="user_input", response_key="answer")
+        def handler(payload):
+            return {"answer": "42"}
+
+        assert app._prompt_key == "user_input"
+        assert app._response_key == "answer"
+
+    def test_entrypoint_without_args_still_works(self):
+        """@app.entrypoint without arguments still works as before."""
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint
+        def handler(payload):
+            return "ok"
+
+        assert app._prompt_key is None
+        assert app._response_key is None
+        assert app.handlers["main"] is handler


### PR DESCRIPTION
## Summary

- Add `_emit_invocation_otel_attributes()` to `BedrockAgentCoreApp` that automatically emits `agentcore.invocation.user_prompt` and `agentcore.invocation.agent_response` as OTEL span attributes on the root `POST /invocations` span
- These attributes provide a canonical, framework-agnostic source of the user's prompt and the agent's response for AgentCore Evaluation, enabling evaluation of **workflow agents** that use custom state schemas (e.g. `TypedDict` with `user_input`/`final_response` fields) where the default `MessagesState`-based extraction in the evaluation mapper fails silently with null scores
- Add `prompt_key` and `response_key` params to `@app.entrypoint()` so users can control which payload/result keys are used for OTEL attributes
- Add 15 unit tests covering all code paths (payload extraction, response serialization, truncation, error handling, integration)

## Test plan

- [ ] 15 new unit tests pass (`TestEmitInvocationOtelAttributes`)
- [ ] No regressions in existing test suite
- [ ] Deploy workflow agent with updated SDK to AgentCore Runtime, verify attributes appear in CloudWatch spans
- [ ] Run evaluation against workflow agent traces, confirm non-null scores