### PR TITLE
fix: pin griffe version and fix ExplanationStyle attribute error

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install griffe
-        run: pip install griffe
+        run: pip install griffe==1.7.3
 
       # Fetch the base branch so the ref is available for griffe's worktree.
       - name: Fetch base branch
@@ -122,7 +122,7 @@ jobs:
               "",
           ]
           for b in breakages:
-              lines.append(b.explain(style=griffe.ExplanationStyle.markdown))
+              lines.append(b.explain())
 
           lines += [
               "",


### PR DESCRIPTION
**Fix Breaking Change Check Workflow**
The breaking change detection workflow was failing with an AttributeError on griffe.ExplanationStyle.markdown — the enum member name differs across griffe versions.

Fixed by pinning griffe to a specific version so the workflow behaves consistently regardless of what the runner installs, and removed the style argument from explain() entirely so it’s not coupled to any enum name going forward.​​​​​​​​​​​​​​​​
