### PR TITLE
fix: skip integration tests for Dependabot and remove missing label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,6 @@ updates:
       - "aws/bedrock-agentcore-maintainers"
     labels:
       - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "ci"
       include: "scope"

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -17,6 +17,11 @@ jobs:
   authorization-check:
     permissions: read-all
     runs-on: ubuntu-latest
+    # Skip entirely for Dependabot PRs — they are not collaborators so they
+    # would always route to manual-approval, blocking auto-merge indefinitely.
+    # Dependabot PRs are validated by ci.yml (lint, test, build) which are
+    # the required status checks in the main-status-checks Ruleset.
+    if: github.actor != 'dependabot[bot]'
     outputs:
       approval-env: ${{ steps.collab-check.outputs.result }}
       should-run: ${{ steps.safety-check.outputs.result }}


### PR DESCRIPTION
**Fix Dependabot Auto-merge Blocking Issues**
Two issues were preventing Dependabot PRs from auto-merging cleanly.

- First, the integration test workflow was routing all Dependabot PRs to the manual-approval environment because Dependabot is not a repository collaborator. This caused pip dependency PRs to sit waiting indefinitely for a human to approve the environment, blocking auto-merge from completing. Dependabot PRs are fully validated by the CI pipeline — lint, tests across all Python versions, build, and install verification — which is the correct and sufficient gate for dependency bumps.
- Second, the Dependabot configuration was referencing a github-actions label that does not exist in the repository, causing an error comment to appear on every github-actions Dependabot PR. Removed the non-existent label — the dependencies label which already exists is sufficient.​​​​​​​​​​​​​​​​
