### PR TITLE
fix(ci): add pytest-rerunfailures to integration test dependencies

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -e .
-          pip install --no-cache-dir pytest pytest-xdist pytest-order requests strands-agents uvicorn httpx starlette websockets ${{ matrix.extra-deps }}
+          pip install --no-cache-dir pytest pytest-xdist pytest-order pytest-rerunfailures requests strands-agents uvicorn httpx starlette websockets ${{ matrix.extra-deps }}
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
## Summary
- Adds `pytest-rerunfailures` to the integration test CI pip install step
- Without it, `@pytest.mark.flaky(reruns=2, reruns_delay=5)` decorators in integration tests are silently ignored, so flaky tests never retry and pytest emits unknown mark warnings

## Test plan
- [x] Verify `pytest-rerunfailures` is already in dev dependencies in `pyproject.toml`
- [ ] CI integration tests should now properly retry flaky tests instead of failing on first attempt