### PR TITLE
fix(ci): increase memory integration test timeout to 15 minutes

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -125,7 +125,7 @@ jobs:
           # TODO: expand to full tests_integ/memory once test stability is addressed
           - group: memory
             path: tests_integ/memory/test_controlplane.py tests_integ/memory/test_memory_client.py tests_integ/memory/integrations/test_session_manager.py
-            timeout: 10
+            timeout: 15
             extra-deps: ""
             ignore: ""
           - group: evaluation


### PR DESCRIPTION
## Summary
- Increases the memory integration test step timeout from 10 to 15 minutes
- Tests occasionally take ~10:04, causing CI failures despite all 42 tests passing
- Aligns with the evaluation test group which already uses a 15-minute timeout

## Test plan
- [ ] Memory integration tests complete without hitting the step timeout