### PR TITLE
fix(converters): prepend reasoningContent blocks in _openai_to_bedrock()

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/converters/openai.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/converters/openai.py
@@ -77,6 +77,7 @@ def _openai_to_bedrock(openai_msg: dict) -> dict:
     """Convert an OpenAI message dict to Strands-native message shape."""
     role = openai_msg.get("role", "user")
     content_items: list[dict[str, Any]] = []
+    reasoning_items: list[dict[str, Any]] = []
 
     if role == "tool":
         tool_result: dict[str, Any] = {
@@ -119,11 +120,13 @@ def _openai_to_bedrock(openai_msg: dict) -> dict:
 
     for rc in openai_msg.get("_strands_reasoning_content", []):
         if isinstance(rc, dict) and "reasoningContent" in rc:
-            content_items.append(rc)
+            reasoning_items.append(rc)
 
     bedrock_role = "assistant" if role == "assistant" else "user"
 
-    return {"role": bedrock_role, "content": content_items}
+    # Reasoning blocks MUST come first per Bedrock API:
+    # "If an assistant message contains any thinking blocks, the first block must be thinking."
+    return {"role": bedrock_role, "content": reasoning_items + content_items}
 
 
 class OpenAIConverseConverter:


### PR DESCRIPTION
## Summary

Fixes #416 — `_openai_to_bedrock()` appends `reasoningContent` blocks after `text` and `toolUse`, but Bedrock requires thinking blocks to come first.

**3-line fix.** No new dependencies. No behavioral change for messages without reasoning.

## The Bug

```python
# Before: reasoning appended LAST
content_items = [text, toolUse, reasoningContent]  # → ValidationException

# After: reasoning prepended FIRST  
content_items = [reasoningContent, text, toolUse]  # → Correct
```

Bedrock error:
> `ValidationException: If an assistant message contains any thinking blocks, the first block must be thinking. Found text`

## Changes

```diff
 content_items: list[dict[str, Any]] = []
+reasoning_items: list[dict[str, Any]] = []
 ...
     for rc in openai_msg.get("_strands_reasoning_content", []):
         if isinstance(rc, dict) and "reasoningContent" in rc:
-            content_items.append(rc)
+            reasoning_items.append(rc)
 ...
-    return {"role": bedrock_role, "content": content_items}
+    # Reasoning blocks MUST come first per Bedrock API:
+    # "If an assistant message contains any thinking blocks, the first block must be thinking."
+    return {"role": bedrock_role, "content": reasoning_items + content_items}
```

## Verification

15 tests across 3 suites all pass:

| Suite | Tests | Result |
|-------|-------|--------|
| Strands SDK session managers | 5/5 | ✅ (no bug here) |
| AgentCoreMemoryConverter (default) | 5/5 | ✅ (no bug here) |
| **OpenAIConverseConverter** | **5/5** | **✅ after fix (was 1/5)** |

## Impact

- **Fixes**: Multi-turn conversations with extended thinking + `OpenAIConverseConverter`
- **No impact**: Messages without `reasoningContent` (empty list prepended = no change)
- **No impact**: Default `AgentCoreMemoryConverter` users (already works correctly)

I understand this repo's policy on external PRs — feel free to close if preferred and cherry-pick internally. The fix is also documented in the [#416 comment thread](https://github.com/aws/bedrock-agentcore-sdk-python/issues/416#issuecomment-4262667952).