### PR TITLE
fix(gateway): use gateway ID instead of ARN for target polling

### DIFF
--- a/src/bedrock_agentcore/gateway/client.py
+++ b/src/bedrock_agentcore/gateway/client.py
@@ -156,11 +156,11 @@ class GatewayClient:
             TimeoutError: If the target doesn't become READY within max_wait.
         """
         response = self.cp_client.create_gateway_target(**convert_kwargs(kwargs))
-        gw_arn = response["gatewayArn"]
+        gw_id = response["gatewayArn"].rsplit("/", 1)[-1]
         target_id = response["targetId"]
         return wait_until(
             lambda: self.cp_client.get_gateway_target(
-                gatewayIdentifier=gw_arn,
+                gatewayIdentifier=gw_id,
                 targetId=target_id,
             ),
             "READY",
@@ -184,11 +184,11 @@ class GatewayClient:
             TimeoutError: If the target doesn't become READY within max_wait.
         """
         response = self.cp_client.update_gateway_target(**convert_kwargs(kwargs))
-        gw_arn = response["gatewayArn"]
+        gw_id = response["gatewayArn"].rsplit("/", 1)[-1]
         target_id = response["targetId"]
         return wait_until(
             lambda: self.cp_client.get_gateway_target(
-                gatewayIdentifier=gw_arn,
+                gatewayIdentifier=gw_id,
                 targetId=target_id,
             ),
             "READY",
@@ -232,11 +232,11 @@ class GatewayClient:
             TimeoutError: If the target isn't deleted within max_wait.
         """
         response = self.cp_client.delete_gateway_target(**convert_kwargs(kwargs))
-        gw_arn = response["gatewayArn"]
+        gw_id = response["gatewayArn"].rsplit("/", 1)[-1]
         target_id = response["targetId"]
         wait_until_deleted(
             lambda: self.cp_client.get_gateway_target(
-                gatewayIdentifier=gw_arn,
+                gatewayIdentifier=gw_id,
                 targetId=target_id,
             ),
             wait_config=wait_config,

--- a/tests_integ/gateway/test_gateway_client.py
+++ b/tests_integ/gateway/test_gateway_client.py
@@ -241,6 +241,9 @@ class TestGatewayTargetClient:
                     }
                 },
             },
+            credentialProviderConfigurations=[
+                {"credentialProviderType": "GATEWAY_IAM_ROLE"},
+            ],
             description="updated by integ test",
         )
         assert updated["status"] == "READY"


### PR DESCRIPTION
## Summary
- `get_gateway_target` returns `AccessDeniedException` when called with a gateway ARN as `gatewayIdentifier` — it only accepts gateway IDs
- `create_gateway_target_and_wait`, `update_gateway_target_and_wait`, and `delete_gateway_target_and_wait` were passing `gatewayArn` from the response directly to the polling call
- Fixed by extracting the gateway ID from the ARN: `response["gatewayArn"].rsplit("/", 1)[-1]`
- Added missing `credentialProviderConfigurations` to `test_update_gateway_target_and_wait` integ test (required by the API)

## Test plan
- [x] All 15 integ tests pass with `--order-scope=class`
- [x] Verified `get_gateway_target` works with gateway ID but fails with ARN