### PR TITLE
fix: add pytest-rerunfailures to integ test config

### DIFF
--- a/.github/workflows/integration-testing-regression.yml
+++ b/.github/workflows/integration-testing-regression.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Install test dependencies
         run: |
           pip install --no-cache-dir \
-            pytest pytest-xdist pytest-order \
+            pytest pytest-xdist pytest-order pytest-rerunfailures \
             requests strands-agents uvicorn httpx starlette websockets \
             ${{ matrix.extra-deps }}
 


### PR DESCRIPTION
*Description of changes:*
While looking into the failing memory integ test, I noticed the following message in the failures logs: `integrations/test_session_manager.py:139: PytestUnknownMarkWarning: Unknown pytest.mark.flaky`. 

This mark comes from `pytest-rerunfailures`, which was not being installed as a test dependency in the test space. Thus, the mark was not having any effect. This change should allow the flaky test to rerun as intended (and hopefully succeed on retries!)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
