### PR TITLE
chore: test matrix for primitive clients and expose GH secrets to test env

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -138,6 +138,21 @@ jobs:
             timeout: 5
             extra-deps: ""
             ignore: ""
+          - group: policy
+            path: tests_integ/policy
+            timeout: 15
+            extra-deps: ""
+            ignore: ""
+          - group: gateway
+            path: tests_integ/gateway
+            timeout: 15
+            extra-deps: ""
+            ignore: ""
+          - group: identity
+            path: tests_integ/identity/test_identity_client.py
+            timeout: 15
+            extra-deps: ""
+            ignore: ""
     steps:
       - name: Configure Credentials
         uses: aws-actions/configure-aws-credentials@v6
@@ -172,6 +187,15 @@ jobs:
           MEMORY_PREPOPULATED_ID: ${{ secrets.MEMORY_PREPOPULATED_ID }}
           RESOURCE_POLICY_TEST_ARN: ${{ secrets.RESOURCE_POLICY_TEST_ARN }}
           RESOURCE_POLICY_TEST_PRINCIPAL: ${{ secrets.RESOURCE_POLICY_TEST_PRINCIPAL }}
+          GATEWAY_ROLE_ARN: ${{ secrets.GATEWAY_ROLE_ARN }}
+          GATEWAY_LAMBDA_ARN: ${{ secrets.GATEWAY_LAMBDA_ARN }}
+          EVAL_ROLE_ARN: ${{ secrets.EVAL_ROLE_ARN }}
+          EVAL_LOG_GROUP: ${{ secrets.EVAL_LOG_GROUP }}
+          RUNTIME_ROLE_ARN: ${{ secrets.RUNTIME_ROLE_ARN }}
+          RUNTIME_S3_CODE_URI: ${{ secrets.RUNTIME_S3_CODE_URI }}
+          COGNITO_POOL_ID: ${{ secrets.COGNITO_POOL_ID }}
+          COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+          COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
         id: tests
         timeout-minutes: ${{ matrix.timeout }}
         run: |


### PR DESCRIPTION
Recent updates/additions of primitive clients added integ tests to cover all new functionality. This PR updates CI/CD workflow to run all recently added integ tests on PRs and merged code.

*Description of changes:*
* Added test matrix for policy, gateway, and identity clients
* Updated env vars to include secrets needed to running new integ tests

*Note:* the primitive client updates included changes to runtime and evaluations clients as well. Existing test matrices for these clients cover the new tests, thus no additions were needed to run these. Env vars were added however

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
