### PR TITLE
fix: add newly required param protocolType to test input

### DIFF
--- a/tests_integ/gateway/test_gateway_client.py
+++ b/tests_integ/gateway/test_gateway_client.py
@@ -97,6 +97,7 @@ class TestGatewayClient:
             name=f"{self.test_prefix}-gw",
             roleArn=self.role_arn,
             authorizerType="NONE",
+            protocolType="MCP",
             description="updated by integ test",
         )
         assert updated["status"] == "READY"


### PR DESCRIPTION
Add missing required parameter to input on test method


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
