### PR TITLE
fix: increase memory regression test timeout to 15 minutes

### DIFF
--- a/.github/workflows/integration-testing-regression.yml
+++ b/.github/workflows/integration-testing-regression.yml
@@ -147,7 +147,7 @@ jobs:
               tests_integ/memory/test_controlplane.py
               tests_integ/memory/test_memory_client.py
               tests_integ/memory/integrations/test_session_manager.py
-            timeout: 10
+            timeout: 15
             extra-deps: ""
           - group: evaluation
             path: tests_integ/evaluation


### PR DESCRIPTION
Our regression test: `Integration Tests (Backward Compat) / Compat (memory)` frequently fails due to timeout being reached before all tests can finish executing. This causes workflows to fail, even though all tests in the suite pass. Increasing this timeout should give the suite enough time to run to completion, preventing flaky failures on PRs/merges

*Description of changes:*
* Increased memory regression test matrix from 10m -> 15m timeout

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
