### PR TITLE
Update DP APIs to support namespace re-design

### DIFF
--- a/src/bedrock_agentcore/_utils/namespace.py
+++ b/src/bedrock_agentcore/_utils/namespace.py
@@ -1,0 +1,28 @@
+"""Namespace utilities for data plane API calls."""
+
+from typing import Dict, Optional
+
+
+def build_namespace_params(namespace: Optional[str] = None, namespace_path: Optional[str] = None) -> Dict[str, str]:
+    """Build the namespace kwargs for a data plane API call.
+
+    Exactly one of ``namespace`` (exact match) or ``namespace_path``
+    (hierarchical path prefix) must be provided. Wildcards (``*``) are not
+    supported in either field.
+
+    Raises:
+        ValueError: if both arguments are provided, neither is provided, or
+            the provided value contains a wildcard.
+    """
+    if namespace is not None and namespace_path is not None:
+        raise ValueError("'namespace' and 'namespace_path' are mutually exclusive.")
+    if namespace is None and namespace_path is None:
+        raise ValueError("At least one of 'namespace' or 'namespace_path' must be provided.")
+
+    value = namespace if namespace is not None else namespace_path
+    if "*" in value:
+        raise ValueError("Wildcards (*) are not supported in namespaces.")
+
+    if namespace is not None:
+        return {"namespace": namespace}
+    return {"namespacePath": namespace_path}

--- a/src/bedrock_agentcore/_utils/namespace.py
+++ b/src/bedrock_agentcore/_utils/namespace.py
@@ -73,3 +73,37 @@ def resolve_namespace_templates(
         return namespaces
 
     return namespace_templates
+
+
+def resolve_namespace_prefix_deprecation(
+    namespace_prefix: Optional[str] = None,
+    namespace: Optional[str] = None,
+) -> Optional[str]:
+    """Collapse the deprecated ``namespace_prefix`` kwarg into ``namespace``.
+
+    Used by high-level session-manager retrieval helpers that historically took a
+    ``namespace_prefix`` parameter. During the service redesign's grace period,
+    ``namespace`` preserves the pre-redesign string-prefix behavior, so migrating
+    ``namespace_prefix`` callers to ``namespace`` keeps results identical until
+    allowlisting is removed.
+
+    Returns the effective ``namespace`` value (or ``None`` if neither was provided
+    and the caller supplied ``namespace_path`` instead). When ``namespace_prefix``
+    is used, emits a ``DeprecationWarning``.
+
+    Raises:
+        ValueError: if both ``namespace_prefix`` and ``namespace`` are provided.
+    """
+    if namespace_prefix is not None and namespace is not None:
+        raise ValueError("'namespace' and 'namespace_prefix' (deprecated) are mutually exclusive.")
+    if namespace_prefix is not None:
+        warnings.warn(
+            "The 'namespace_prefix' parameter is deprecated and will be removed in a future "
+            "release. Use 'namespace' for exact-match retrieval (current pre-redesign behavior "
+            "during the service grace period) or 'namespace_path' for hierarchical path-prefix "
+            "retrieval.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return namespace_prefix
+    return namespace

--- a/src/bedrock_agentcore/memory/README.md
+++ b/src/bedrock_agentcore/memory/README.md
@@ -186,14 +186,14 @@ session.add_turns([
 # Search long-term memories (after memory extraction has occurred)
 memories = session.search_long_term_memories(
     query="what food does the user like",
-    namespace_prefix="/food/user-123/",
+    namespace_path="/food/user-123/",
     top_k=5
 )
 
 # Or search across multiple users
 memories = manager.search_long_term_memories(
     query="Food preferences",
-    namespace_prefix="/food/",  # Search all food-related memories
+    namespace_path="/food/",  # Search all food-related memories
     top_k=10
 )
 ```
@@ -301,7 +301,7 @@ session2 = manager.create_memory_session(
 ```python
 # List all memory records in a namespace
 records = session.list_long_term_memory_records(
-    namespace_prefix="/user/preferences/user-123/",
+    namespace_path="/user/preferences/user-123/",
     max_results=20
 )
 
@@ -327,7 +327,7 @@ Learn more here!: [Working example](metadata-workflow.ipynb)
 # Step 1: Retrieve relevant memories
 memories = session.search_long_term_memories(
     query="previous discussion",
-    namespace_prefix="support/facts/session-456/",
+    namespace_path="support/facts/session-456/",
     top_k=5
 )
 

--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -20,6 +20,7 @@ import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+from bedrock_agentcore._utils.namespace import build_namespace_params
 from bedrock_agentcore._utils.snake_case import accept_snake_case_kwargs
 from bedrock_agentcore._utils.user_agent import build_user_agent_suffix
 
@@ -126,8 +127,11 @@ class MemoryClient:
             # Access any boto3 method directly
             client = MemoryClient()
 
-            # These calls are forwarded to the appropriate boto3 client
-            response = client.list_memory_records(memoryId="mem-123", namespace="test/")
+            # These calls are forwarded to the appropriate boto3 client.
+            # Use `namespace` for exact match, or `namespace_path` for
+            # hierarchical path-prefix retrieval.
+            response = client.list_memory_records(memoryId="mem-123", namespace="/actor/Jane/")
+            response = client.list_memory_records(memoryId="mem-123", namespace_path="/org/MyOrg/")
             metadata = client.get_memory_metadata(memoryId="mem-123")
         """
         if name in self._ALLOWED_GMDP_METHODS and hasattr(self.gmdp_client, name):
@@ -307,46 +311,48 @@ class MemoryClient:
         raise TimeoutError("Memory %s did not become ACTIVE within %d seconds" % (memory_id, max_wait))
 
     def retrieve_memories(
-        self, memory_id: str, namespace: str, query: str, actor_id: Optional[str] = None, top_k: int = 3
+        self,
+        memory_id: str,
+        namespace: Optional[str] = None,
+        query: str = None,
+        actor_id: Optional[str] = None,
+        top_k: int = 3,
+        namespace_path: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
-        """Retrieve relevant memories from a namespace.
+        """Retrieve relevant memories using exact match or hierarchical path prefix.
 
-        Note: Wildcards (*) are NOT supported in namespaces. You must provide the
-        exact namespace path with all variables resolved.
+        Exactly one of ``namespace`` or ``namespace_path`` must be provided.
 
         Args:
             memory_id: Memory resource ID
-            namespace: Exact namespace path (no wildcards)
-            query: Search query
+            namespace: Exact namespace to match (e.g., "/actor/Jane/")
+            query: Search query (required)
             actor_id: Optional actor ID (deprecated, use namespace)
             top_k: Number of results to return
+            namespace_path: Hierarchical path prefix (e.g., "/org/team/")
 
         Returns:
-            List of memory records
-
-        Example:
-            # Correct - exact namespace
-            memories = client.retrieve_memories(
-                memory_id="mem-123",
-                namespace="support/facts/session-456/",
-                query="customer preferences"
-            )
-
-            # Incorrect - wildcards not supported
-            # memories = client.retrieve_memories(..., namespace="support/facts/*/", ...)
+            List of memory records. Returns an empty list if the namespace
+            arguments are invalid (both provided, neither provided, or contain
+            wildcards) or if the service call fails.
         """
-        if "*" in namespace:
-            logger.error("Wildcards are not supported in namespaces. Please provide exact namespace.")
-            return []
+        if query is None:
+            raise TypeError("retrieve_memories() missing required argument: 'query'")
 
         try:
-            # Let service handle all namespace validation
-            response = self.gmdp_client.retrieve_memory_records(
-                memoryId=memory_id, namespace=namespace, searchCriteria={"searchQuery": query, "topK": top_k}
-            )
+            ns_params = build_namespace_params(namespace, namespace_path)
+        except ValueError as e:
+            logger.error(str(e))
+            return []
 
+        ns_value = namespace or namespace_path
+
+        try:
+            response = self.gmdp_client.retrieve_memory_records(
+                memoryId=memory_id, searchCriteria={"searchQuery": query, "topK": top_k}, **ns_params
+            )
             memories = response.get("memoryRecordSummaries", [])
-            logger.info("Retrieved %d memories from namespace: %s", len(memories), namespace)
+            logger.info("Retrieved %d memories from namespace: %s", len(memories), ns_value)
             return memories
 
         except ClientError as e:
@@ -357,7 +363,7 @@ class MemoryClient:
                 logger.warning(
                     "Memory or namespace not found. Ensure memory %s exists and namespace '%s' is configured",
                     memory_id,
-                    namespace,
+                    ns_value,
                 )
             elif error_code == "ValidationException":
                 logger.warning("Invalid search parameters: %s", error_msg)
@@ -662,6 +668,7 @@ class MemoryClient:
         retrieval_query: Optional[str] = None,
         top_k: int = 3,
         event_timestamp: Optional[datetime] = None,
+        retrieval_namespace_path: Optional[str] = None,
     ) -> Tuple[List[Dict[str, Any]], str, Dict[str, Any]]:
         r"""Complete conversation turn with LLM callback integration.
 
@@ -676,10 +683,11 @@ class MemoryClient:
             llm_callback: Function that takes (user_input, memories) and returns agent_response
                          The callback receives the user input and retrieved memories,
                          and should return the agent's response string
-            retrieval_namespace: Namespace to search for memories (optional)
+            retrieval_namespace: Namespace for exact match retrieval (optional)
             retrieval_query: Custom search query (defaults to user_input)
             top_k: Number of memories to retrieve
             event_timestamp: Optional timestamp for the event
+            retrieval_namespace_path: Namespace path for hierarchical prefix retrieval (optional)
 
         Returns:
             Tuple of (retrieved_memories, agent_response, created_event)
@@ -709,10 +717,14 @@ class MemoryClient:
         """
         # Step 1: Retrieve relevant memories
         retrieved_memories = []
-        if retrieval_namespace:
+        if retrieval_namespace or retrieval_namespace_path:
             search_query = retrieval_query or user_input
             retrieved_memories = self.retrieve_memories(
-                memory_id=memory_id, namespace=retrieval_namespace, query=search_query, top_k=top_k
+                memory_id=memory_id,
+                namespace=retrieval_namespace,
+                namespace_path=retrieval_namespace_path,
+                query=search_query,
+                top_k=top_k,
             )
             logger.info("Retrieved %d memories for LLM context", len(retrieved_memories))
 

--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -854,7 +854,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
 
             memories = self.memory_client.retrieve_memories(
                 memory_id=self.config.memory_id,
-                namespace=resolved_namespace,
+                namespace_path=resolved_namespace,
                 query=user_query,
                 top_k=retrieval_config.top_k,
             )

--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -913,7 +913,7 @@ class MemorySessionManager:
         params = {
             "memoryId": self._memory_id,
             "searchCriteria": search_criteria,
-            "namespace": namespace,
+            "namespacePath": namespace,
             "maxResults": max_results,
         }
 
@@ -940,7 +940,7 @@ class MemorySessionManager:
 
             params = {
                 "memoryId": self._memory_id,
-                "namespace": namespace_prefix,
+                "namespacePath": namespace_prefix,
             }
 
             if strategy_id:

--- a/src/bedrock_agentcore/memory/session.py
+++ b/src/bedrock_agentcore/memory/session.py
@@ -10,6 +10,7 @@ import boto3
 from botocore.config import Config as BotocoreConfig
 from botocore.exceptions import ClientError
 
+from bedrock_agentcore._utils.namespace import build_namespace_params, resolve_namespace_prefix_deprecation
 from bedrock_agentcore._utils.snake_case import accept_snake_case_kwargs
 
 from .constants import BlobMessage, ConversationalMessage, MessageRole, RetrievalConfig
@@ -398,8 +399,9 @@ class MemorySessionManager:
                     strategyId=config.strategy_id or "",
                 )
                 search_query = f"{config.retrieval_query} {user_input}" if config.retrieval_query else user_input
+                # TODO: revisit after full deprecation of namespace fields
                 memory_records = self.search_long_term_memories(
-                    query=search_query, namespace_prefix=resolved_namespace, top_k=config.top_k
+                    query=search_query, namespace=resolved_namespace, top_k=config.top_k
                 )
                 # Filter memory records with a relevance score which is lower than config.relevance_score
                 if config.relevance_score:
@@ -895,26 +897,45 @@ class MemorySessionManager:
     def search_long_term_memories(
         self,
         query: str,
-        namespace_prefix: str,
+        namespace_prefix: Optional[str] = None,
         top_k: int = 3,
         strategy_id: str = None,
         max_results: int = 20,
+        namespace: Optional[str] = None,
+        namespace_path: Optional[str] = None,
     ) -> List[MemoryRecord]:
         """Performs a semantic search against the long-term memory for this actor.
 
         Maps to: bedrock-agentcore.retrieve_memory_records.
+
+        Exactly one of ``namespace`` (exact match), ``namespace_path`` (hierarchical
+        path prefix), or ``namespace_prefix`` (DEPRECATED alias for ``namespace``)
+        must be provided.
+
+        Args:
+            query: Search query
+            namespace_prefix: DEPRECATED. Use ``namespace`` or ``namespace_path`` instead.
+            top_k: Number of top-scoring records to return
+            strategy_id: Optional strategy filter
+            max_results: Maximum records to return
+            namespace: Exact-match namespace (preserves pre-redesign behavior during the
+                service grace period)
+            namespace_path: Hierarchical path-prefix namespace
         """
-        logger.info("  -> Querying long-term memory in namespace '%s' with query: '%s'...", namespace_prefix, query)
+        resolved_namespace = resolve_namespace_prefix_deprecation(namespace_prefix, namespace)
+        ns_params = build_namespace_params(resolved_namespace, namespace_path)
+        ns_value = resolved_namespace or namespace_path
+
+        logger.info("  -> Querying long-term memory in namespace '%s' with query: '%s'...", ns_value, query)
         search_criteria = {"searchQuery": query, "topK": top_k}
         if strategy_id:
             search_criteria["memoryStrategyId"] = strategy_id
 
-        namespace = namespace_prefix
         params = {
             "memoryId": self._memory_id,
             "searchCriteria": search_criteria,
-            "namespacePath": namespace,
             "maxResults": max_results,
+            **ns_params,
         }
 
         try:
@@ -927,20 +948,41 @@ class MemorySessionManager:
             raise
 
     def list_long_term_memory_records(
-        self, namespace_prefix: str, strategy_id: Optional[str] = None, max_results: int = 10
+        self,
+        namespace_prefix: Optional[str] = None,
+        strategy_id: Optional[str] = None,
+        max_results: int = 10,
+        namespace: Optional[str] = None,
+        namespace_path: Optional[str] = None,
     ) -> List[MemoryRecord]:
         """Lists all long-term memory records for this actor without a semantic query.
 
         Maps to: bedrock-agentcore.list_memory_records.
+
+        Exactly one of ``namespace`` (exact match), ``namespace_path`` (hierarchical
+        path prefix), or ``namespace_prefix`` (DEPRECATED alias for ``namespace``)
+        must be provided.
+
+        Args:
+            namespace_prefix: DEPRECATED. Use ``namespace`` or ``namespace_path`` instead.
+            strategy_id: Optional strategy filter
+            max_results: Maximum records to return
+            namespace: Exact-match namespace (preserves pre-redesign behavior during the
+                service grace period)
+            namespace_path: Hierarchical path-prefix namespace
         """
-        logger.info("  -> Listing all long-term records in namespace '%s'...", namespace_prefix)
+        resolved_namespace = resolve_namespace_prefix_deprecation(namespace_prefix, namespace)
+        ns_params = build_namespace_params(resolved_namespace, namespace_path)
+        ns_value = resolved_namespace or namespace_path
+
+        logger.info("  -> Listing all long-term records in namespace '%s'...", ns_value)
 
         try:
             paginator = self._data_plane_client.get_paginator("list_memory_records")
 
             params = {
                 "memoryId": self._memory_id,
-                "namespacePath": namespace_prefix,
+                **ns_params,
             }
 
             if strategy_id:
@@ -1049,7 +1091,8 @@ class MemorySessionManager:
         logger.info("🗑️ Deleting all long-term memories in namespace '%s'...", namespace)
 
         # Retrieve all memory records in the specified namespace
-        memory_records = self.list_long_term_memory_records(namespace_prefix=namespace)
+        # TODO: revisit after full deprecation of namespace fields
+        memory_records = self.list_long_term_memory_records(namespace=namespace)
         logger.info("  -> Found %d memory records to delete", len(memory_records))
 
         if not memory_records:
@@ -1203,19 +1246,40 @@ class MemorySession(DictWrapper):
     def search_long_term_memories(
         self,
         query: str,
-        namespace_prefix: str,
+        namespace_prefix: Optional[str] = None,
         top_k: int = 3,
         strategy_id: Optional[str] = None,
         max_results: int = 20,
+        namespace: Optional[str] = None,
+        namespace_path: Optional[str] = None,
     ) -> List[MemoryRecord]:
         """Delegates to manager.search_long_term_memories."""
-        return self._manager.search_long_term_memories(query, namespace_prefix, top_k, strategy_id, max_results)
+        return self._manager.search_long_term_memories(
+            query,
+            namespace_prefix,
+            top_k,
+            strategy_id,
+            max_results,
+            namespace=namespace,
+            namespace_path=namespace_path,
+        )
 
     def list_long_term_memory_records(
-        self, namespace_prefix: str, strategy_id: Optional[str] = None, max_results: int = 10
+        self,
+        namespace_prefix: Optional[str] = None,
+        strategy_id: Optional[str] = None,
+        max_results: int = 10,
+        namespace: Optional[str] = None,
+        namespace_path: Optional[str] = None,
     ) -> List[MemoryRecord]:
         """Delegates to manager.list_long_term_memory_records."""
-        return self._manager.list_long_term_memory_records(namespace_prefix, strategy_id, max_results)
+        return self._manager.list_long_term_memory_records(
+            namespace_prefix,
+            strategy_id,
+            max_results,
+            namespace=namespace,
+            namespace_path=namespace_path,
+        )
 
     def list_actors(self) -> List[ActorSummary]:
         """Delegates to manager.list_actors."""

--- a/tests/bedrock_agentcore/memory/test_client.py
+++ b/tests/bedrock_agentcore/memory/test_client.py
@@ -1,11 +1,13 @@
 """Unit tests for Memory Client - no external connections."""
 
+import logging
 import time
 import uuid
 import warnings
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
 from botocore.exceptions import ClientError
 
 from bedrock_agentcore.memory import MemoryClient
@@ -1625,6 +1627,68 @@ def test_retrieve_memories_wildcard_namespace():
 
         # Should not make API call due to wildcard rejection
         assert not mock_gmdp.retrieve_memory_records.called
+
+
+def test_retrieve_memories_with_namespace_path():
+    """Test retrieve_memories uses namespacePath for hierarchical retrieval."""
+    with patch("boto3.Session"):
+        client = MemoryClient()
+
+        mock_gmdp = MagicMock()
+        mock_gmdp.retrieve_memory_records.return_value = {"memoryRecordSummaries": [{"memoryRecordId": "rec-1"}]}
+        client.gmdp_client = mock_gmdp
+
+        result = client.retrieve_memories(memory_id="mem-123", namespace_path="/org/team/", query="test", top_k=3)
+
+        assert len(result) == 1
+        call_kwargs = mock_gmdp.retrieve_memory_records.call_args[1]
+        assert "namespacePath" in call_kwargs
+        assert call_kwargs["namespacePath"] == "/org/team/"
+        assert "namespace" not in call_kwargs
+
+
+def test_retrieve_memories_mutual_exclusivity(caplog):
+    """Test retrieve_memories soft-fails when both namespace and namespace_path are passed."""
+    with patch("boto3.Session"):
+        client = MemoryClient()
+
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        with caplog.at_level(logging.ERROR):
+            result = client.retrieve_memories(memory_id="mem-123", namespace="/a/", namespace_path="/b/", query="test")
+
+        # Should log the error and return [] without calling the service
+        assert result == []
+        assert not mock_gmdp.retrieve_memory_records.called
+        assert any(
+            "mutually exclusive" in record.message and record.levelno == logging.ERROR for record in caplog.records
+        )
+
+
+def test_retrieve_memories_missing_namespace_and_path(caplog):
+    """Test retrieve_memories soft-fails when neither namespace nor namespace_path is passed."""
+    with patch("boto3.Session"):
+        client = MemoryClient()
+
+        mock_gmdp = MagicMock()
+        client.gmdp_client = mock_gmdp
+
+        with caplog.at_level(logging.ERROR):
+            result = client.retrieve_memories(memory_id="mem-123", query="test")
+
+        assert result == []
+        assert not mock_gmdp.retrieve_memory_records.called
+        assert any("At least one" in record.message and record.levelno == logging.ERROR for record in caplog.records)
+
+
+def test_retrieve_memories_missing_query_raises():
+    """Test retrieve_memories raises TypeError when query is omitted."""
+    with patch("boto3.Session"):
+        client = MemoryClient()
+
+        with pytest.raises(TypeError, match="query"):
+            client.retrieve_memories(memory_id="mem-123", namespace="/actor/Jane/")
 
 
 def test_add_semantic_strategy_and_wait():

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -1197,7 +1197,7 @@ class TestSessionManager:
             assert call_args["memoryId"] == "testMemory-1234567890"
             assert call_args["searchCriteria"]["searchQuery"] == "test query"
             assert call_args["searchCriteria"]["topK"] == 5
-            assert call_args["namespace"] == "test/namespace/"
+            assert call_args["namespacePath"] == "test/namespace/"
 
     def test_search_long_term_memories_with_strategy(self):
         """Test search_long_term_memories with strategy_id."""

--- a/tests/bedrock_agentcore/memory/test_session.py
+++ b/tests/bedrock_agentcore/memory/test_session.py
@@ -1197,7 +1197,44 @@ class TestSessionManager:
             assert call_args["memoryId"] == "testMemory-1234567890"
             assert call_args["searchCriteria"]["searchQuery"] == "test query"
             assert call_args["searchCriteria"]["topK"] == 5
-            assert call_args["namespacePath"] == "test/namespace/"
+            # namespace_prefix (deprecated) now routes to `namespace` on the wire
+            # (preserves pre-redesign behavior during the service grace period).
+            assert call_args["namespace"] == "test/namespace/"
+
+    def test_search_long_term_memories_with_namespace_path(self):
+        """namespace_path kwarg routes to namespacePath on the wire."""
+        with patch("boto3.Session") as mock_session_class:
+            mock_session = MagicMock()
+            mock_session.region_name = "us-west-2"
+            mock_client_instance = MagicMock()
+            mock_session.client.return_value = mock_client_instance
+            mock_session_class.return_value = mock_session
+
+            manager = MemorySessionManager(memory_id="testMemory-1234567890", region_name="us-west-2")
+            mock_client_instance.retrieve_memory_records.return_value = {"memoryRecordSummaries": []}
+
+            manager.search_long_term_memories(query="q", namespace_path="/org/team/")
+
+            call_args = mock_client_instance.retrieve_memory_records.call_args[1]
+            assert call_args["namespacePath"] == "/org/team/"
+            assert "namespace" not in call_args
+
+    def test_search_long_term_memories_mutual_exclusivity(self):
+        """Providing namespace_prefix alongside namespace (or namespace_path) raises."""
+        with patch("boto3.Session"):
+            manager = MemorySessionManager(memory_id="testMemory-1234567890", region_name="us-west-2")
+
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                manager.search_long_term_memories(query="q", namespace_prefix="/a/", namespace="/b/")
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                manager.search_long_term_memories(query="q", namespace="/a/", namespace_path="/b/")
+
+    def test_search_long_term_memories_requires_one(self):
+        """Calling without any namespace kwarg raises."""
+        with patch("boto3.Session"):
+            manager = MemorySessionManager(memory_id="testMemory-1234567890", region_name="us-west-2")
+            with pytest.raises(ValueError, match="At least one"):
+                manager.search_long_term_memories(query="q")
 
     def test_search_long_term_memories_with_strategy(self):
         """Test search_long_term_memories with strategy_id."""
@@ -1857,10 +1894,16 @@ class TestSession:
             # Mock manager method
             mock_records = [MemoryRecord({"memoryRecordId": "rec-123"})]
             with patch.object(manager, "search_long_term_memories", return_value=mock_records) as mock_search:
-                result = session.search_long_term_memories(query="test query", namespace_prefix="test/namespace/")
+                import warnings
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    result = session.search_long_term_memories(query="test query", namespace_prefix="test/namespace/")
 
                 assert result == mock_records
-                mock_search.assert_called_once_with("test query", "test/namespace/", 3, None, 20)
+                mock_search.assert_called_once_with(
+                    "test query", "test/namespace/", 3, None, 20, namespace=None, namespace_path=None
+                )
 
     def test_session_list_long_term_memory_records_delegation(self):
         """Test MemorySession.list_long_term_memory_records delegates to manager."""
@@ -1873,10 +1916,14 @@ class TestSession:
             # Mock manager method
             mock_records = [MemoryRecord({"memoryRecordId": "rec-123"})]
             with patch.object(manager, "list_long_term_memory_records", return_value=mock_records) as mock_list:
-                result = session.list_long_term_memory_records(namespace_prefix="test/namespace/")
+                import warnings
+
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    result = session.list_long_term_memory_records(namespace_prefix="test/namespace/")
 
                 assert result == mock_records
-                mock_list.assert_called_once_with("test/namespace/", None, 10)
+                mock_list.assert_called_once_with("test/namespace/", None, 10, namespace=None, namespace_path=None)
 
     def test_session_list_actors_delegation(self):
         """Test MemorySession.list_actors delegates to manager."""
@@ -2037,9 +2084,10 @@ class TestEdgeCases:
                         retrieval_config=retrieval_config,
                     )
 
-                    # Verify custom query was used
+                    # Verify custom query was used. The internal caller now passes `namespace=`
+                    # (previously `namespace_prefix=`, which is deprecated).
                     mock_search.assert_called_once_with(
-                        query="custom query Hello", namespace_prefix="test/namespace/", top_k=5
+                        query="custom query Hello", namespace="test/namespace/", top_k=5
                     )
 
     def test_list_events_max_results_respected(self):
@@ -2722,8 +2770,9 @@ class TestAdditionalCoverage:
                         retrieval_config=retrieval_config,
                     )
 
-                    # Verify user_input was used as query
-                    mock_search.assert_called_once_with(query="Hello", namespace_prefix="test/namespace/", top_k=3)
+                    # Verify user_input was used as query. The internal caller now passes `namespace=`
+                    # (previously `namespace_prefix=`, which is deprecated).
+                    mock_search.assert_called_once_with(query="Hello", namespace="test/namespace/", top_k=3)
 
     def test_add_turns_with_custom_timestamp(self):
         """Test add_turns with custom timestamp."""

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 from botocore.exceptions import ClientError
 
+from bedrock_agentcore._utils.namespace import build_namespace_params
 from bedrock_agentcore._utils.polling import wait_until, wait_until_deleted
 
 
@@ -112,3 +113,29 @@ class TestWaitUntilDeleted:
         poll_fn = Mock(return_value={"status": "DELETING"})
         with pytest.raises(TimeoutError):
             wait_until_deleted(poll_fn)
+
+
+class TestBuildNamespaceParams:
+    """Tests for build_namespace_params utility."""
+
+    def test_namespace_only(self):
+        assert build_namespace_params(namespace="/actor/Jane/") == {"namespace": "/actor/Jane/"}
+
+    def test_namespace_path_only(self):
+        assert build_namespace_params(namespace_path="/org/team/") == {"namespacePath": "/org/team/"}
+
+    def test_both_raises(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            build_namespace_params(namespace="/a/", namespace_path="/b/")
+
+    def test_neither_raises(self):
+        with pytest.raises(ValueError, match="At least one"):
+            build_namespace_params()
+
+    def test_wildcard_in_namespace_raises(self):
+        with pytest.raises(ValueError, match="[Ww]ildcard"):
+            build_namespace_params(namespace="/actor/*/")
+
+    def test_wildcard_in_namespace_path_raises(self):
+        with pytest.raises(ValueError, match="[Ww]ildcard"):
+            build_namespace_params(namespace_path="/org/*/team/")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch
 import pytest
 from botocore.exceptions import ClientError
 
-from bedrock_agentcore._utils.namespace import build_namespace_params, resolve_namespace_templates
+from bedrock_agentcore._utils.namespace import (
+    build_namespace_params,
+    resolve_namespace_prefix_deprecation,
+    resolve_namespace_templates,
+)
 from bedrock_agentcore._utils.polling import wait_until, wait_until_deleted
 
 
@@ -168,3 +172,24 @@ class TestResolveNamespaceTemplates:
     def test_custom_param_name_in_warning(self):
         with pytest.warns(DeprecationWarning, match="reflection_namespaces"):
             resolve_namespace_templates(namespaces=["/a/"], param_name="reflection_namespaces")
+
+
+class TestResolveNamespacePrefixDeprecation:
+    """Tests for resolve_namespace_prefix_deprecation helper."""
+
+    def test_namespace_only_returns_namespace(self):
+        assert resolve_namespace_prefix_deprecation(namespace="/a/") == "/a/"
+
+    def test_namespace_prefix_returns_value_and_warns(self):
+        with pytest.warns(DeprecationWarning, match="namespace_prefix"):
+            result = resolve_namespace_prefix_deprecation(namespace_prefix="/a/")
+        assert result == "/a/"
+
+    def test_both_raises(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            resolve_namespace_prefix_deprecation(namespace_prefix="/a/", namespace="/b/")
+
+    def test_neither_returns_none(self):
+        # Caller is responsible for combining this with namespace_path; helper just
+        # reports "no legacy/exact value was provided."
+        assert resolve_namespace_prefix_deprecation() is None

--- a/tests_integ/memory/test_memory_client.py
+++ b/tests_integ/memory/test_memory_client.py
@@ -371,11 +371,11 @@ class TestMemoryClient:
         assert len(results) > 0, "Expected summary memories in /summaries/ namespace"
 
     @pytest.mark.order(14)
-    # retrieve_memories with a prefix namespace matches broader results
+    # retrieve_memories with a path prefix matches all descendants under /facts/
     def test_retrieve_memories_prefix_namespace(self):
         results = self.client.retrieve_memories(
             memory_id=self.prepopulated_memory_id,
-            namespace="/facts/",
+            namespace_path="/facts/",
             query="developer preferences",
         )
         assert len(results) > 0, "Expected prefix namespace to match"


### PR DESCRIPTION
### Summary:
Adds support for the new namespacePath field introduced on the memory data-plane APIs (ListMemoryRecords and RetrieveMemoryRecords). This lets callers opt into hierarchical path-prefix retrieval, separate from the existing namespace field (which is evolving toward exact-match semantics service-side).


 ### Description of changes:
New utility (`src/bedrock_agentcore/_utils/namespace.py`):
- build_namespace_params(namespace, namespace_path) — validates caller input (mutual exclusivity, presence, no wildcards) and produces the correct wire kwargs for boto.

MemoryClient (`memory/client.py`):
- retrieve_memories() — accepts both namespace and namespace_path. On invalid input (both provided, neither provided, wildcard present), logs an error and returns [] — preserves the existing soft-fail contract of this method.
- process_turn_with_llm() — adds retrieval_namespace_path parameter, forwards to retrieve_memories.

MemorySessionManager (`memory/session.py`):
- search_long_term_memories() and list_long_term_memory_records() now route the existing namespace_prefix argument to namespacePath. The parameter name and user-facing semantics remain unchanged; only the underlying field is updated.

Strands integration (`memory/integrations/strands/session_manager.py`):
- _load_ltm() now calls retrieve_memories(namespace_path=...) to preserve the historical hierarchical-scoping behavior under the new API semantics.


### Behavior changes for users

- Existing callers using retrieve_memories(namespace=...) continue to work. Namespace will eventually become the exact-match field
- Existing callers using search_long_term_memories(namespace_prefix=...) continue to work as before
- New callers can opt into hierarchical retrieval explicitly via retrieve_memories(namespace_path=...).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
