### PR TITLE
ci: add payments group to integration test matrix

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -153,6 +153,11 @@ jobs:
             timeout: 15
             extra-deps: ""
             ignore: ""
+          - group: payments
+            path: tests_integ/payments
+            timeout: 15
+            extra-deps: "strands-agents"
+            ignore: ""
     steps:
       - name: Configure Credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Summary
- Add payments integration tests to the CI matrix
- Uses `strands-agents` as extra dependency for plugin tests
- 15 minute timeout matching other integration test groups

## Test plan
- [ ] CI runs payments integ tests on merge