### PR TITLE
fix(payments): use RUNTIME_ROLE_ARN for CP integ tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -156,7 +156,7 @@ jobs:
           - group: payments
             path: tests_integ/payments
             timeout: 15
-            extra-deps: "strands-agents"
+            extra-deps: "strands-agents strands-agents-tools"
             ignore: ""
     steps:
       - name: Configure Credentials

--- a/tests_integ/payments/test_payment_client.py
+++ b/tests_integ/payments/test_payment_client.py
@@ -64,21 +64,14 @@ class TestPaymentClientControlPlane:
     def setup_class(cls):
         """Set up test environment."""
         cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
-        cls.role_arn = os.environ.get(
-            "TEST_PAYMENT_ROLE_ARN",
-            "arn:aws:iam::123456789012:role/bedrock-payment-role",
-        )
+        cls.role_arn = os.environ.get("RUNTIME_ROLE_ARN")
+        if not cls.role_arn:
+            pytest.skip("RUNTIME_ROLE_ARN must be set")
         cls.client = PaymentClient(region_name=cls.region)
-        # Use timestamp with microseconds for uniqueness
         cls.test_prefix = f"t{int(time.time() * 1000000)}"
         cls.created_managers = []
         cls.created_connectors = []
-        cls.role_arn = os.environ.get(
-            "TEST_PAYMENT_ROLE_ARN",
-            "arn:aws:iam::123456789012:role/bedrock-payment-role",
-        )
 
-    @classmethod
     @classmethod
     def teardown_class(cls):
         """Clean up test resources."""
@@ -285,10 +278,8 @@ class TestCreatePaymentManagerWithConnectorIntegration:
         cls.api_key_secret = os.environ.get("PAYMENT_TEST_API_KEY_SECRET")
         cls.wallet_secret = os.environ.get("PAYMENT_TEST_WALLET_SECRET")
         cls.skip_tests = not (cls.api_key_secret and cls.wallet_secret)
-        cls.role_arn = os.environ.get(
-            "TEST_PAYMENT_ROLE_ARN",
-            "arn:aws:iam::123456789012:role/bedrock-payment-role",
-        )
+        cls.role_arn = os.environ.get("RUNTIME_ROLE_ARN")
+        cls.skip_tests = cls.skip_tests or not cls.role_arn
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
## Summary
- Replace hardcoded dummy role ARN (`123456789012`) with `RUNTIME_ROLE_ARN` env var
- Add `pytest.skip()` when env var not set (matches runtime/gateway/memory test pattern)
- Fix duplicate `@classmethod` decorator and duplicate `role_arn` assignment

## Test plan
- [x] Tests skip cleanly when `RUNTIME_ROLE_ARN` not set (10 skipped, 0 failed)
- [x] Syntax valid, collection works
- [ ] Tests pass when `RUNTIME_ROLE_ARN` is set to a valid payment-capable role