### PR TITLE
fix(payments): skip connector integ tests requiring CDP credentials

### DIFF
--- a/tests_integ/payments/test_payment_client.py
+++ b/tests_integ/payments/test_payment_client.py
@@ -150,6 +150,7 @@ class TestPaymentClientControlPlane:
 
         assert update_result.get("paymentManagerId") == payment_manager_id
 
+    @pytest.mark.skip(reason="Requires real CDP credential provider - needs CDP credentials configured")
     def test_create_and_get_payment_connector(self):
         """Test creating and retrieving a payment connector."""
         # First create a payment manager
@@ -219,6 +220,7 @@ class TestPaymentClientControlPlane:
             assert "name" in connector
             assert "status" in connector
 
+    @pytest.mark.skip(reason="Requires real CDP credential provider - needs CDP credentials configured")
     def test_update_payment_connector(self):
         """Test updating a payment connector."""
         # First create a payment manager


### PR DESCRIPTION
## Summary
Skip `test_create_and_get_payment_connector` and `test_update_payment_connector` — they require a real CDP credential provider ARN which needs CDP API keys configured.

## Context
These tests pass a dummy ARN that fails botocore's min-length validation (69 chars required). Until CDP test credentials are available in CI, these tests should skip.