### PR TITLE
fix: update Discord invite link to strands community

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   <p>
   <a href="https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html">Documentation</a>
     ◆ <a href="https://github.com/awslabs/amazon-bedrock-agentcore-samples">Samples</a>
-    ◆ <a href="https://discord.gg/bedrockagentcore-preview">Discord</a>
+    ◆ <a href="https://discord.gg/strands">Discord</a>
     ◆ <a href="https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-agentcore-control.html">Boto3 Python SDK</a>
     ◆ <a href="https://github.com/aws/bedrock-agentcore-sdk-python">Runtime Python SDK</a>
 


### PR DESCRIPTION
## Summary
- Replaces abandoned `discord.gg/bedrockagentcore-preview` vanity URL with `discord.gg/strands`
- The old URL was claimed by an external party (reported via V2208165288 / AWS Vulnerability Reporting Program)
- Anyone clicking the old link from this README was redirected to a server not controlled by AWS

## Test plan
- [ ] Verify the new Discord link resolves to the correct Strands community server