### PR TITLE
fix(runtime): distinguish request parse errors from handler JSON errors

### DIFF
--- a/src/bedrock_agentcore/runtime/app.py
+++ b/src/bedrock_agentcore/runtime/app.py
@@ -537,6 +537,16 @@ class BedrockAgentCoreApp(Starlette):
 
         try:
             payload = await request.json()
+        except json.JSONDecodeError as e:
+            duration = time.time() - start_time
+            self.logger.warning("Invalid JSON in request (%.3fs): %s", duration, e)
+            return JSONResponse({"error": "Invalid JSON", "details": str(e)}, status_code=400)
+        except UnicodeDecodeError as e:
+            duration = time.time() - start_time
+            self.logger.warning("Invalid encoding in request (%.3fs): %s", duration, e)
+            return JSONResponse({"error": "Invalid encoding", "details": str(e)}, status_code=400)
+
+        try:
             self.logger.debug("Processing invocation request")
 
             if self.debug:
@@ -581,15 +591,6 @@ class BedrockAgentCoreApp(Starlette):
             # Use safe serialization for consistency with streaming paths
             safe_json_string = self._safe_serialize_to_json_string(result)
             return Response(safe_json_string, media_type="application/json")
-
-        except json.JSONDecodeError as e:
-            duration = time.time() - start_time
-            self.logger.warning("Invalid JSON in request (%.3fs): %s", duration, e)
-            return JSONResponse({"error": "Invalid JSON", "details": str(e)}, status_code=400)
-        except UnicodeDecodeError as e:
-            duration = time.time() - start_time
-            self.logger.warning("Invalid encoding in request (%.3fs): %s", duration, e)
-            return JSONResponse({"error": "Invalid encoding", "details": str(e)}, status_code=400)
         except HTTPException as e:
             duration = time.time() - start_time
             # Use error level for 5xx to match the generic Exception handler's severity,

--- a/tests/bedrock_agentcore/runtime/test_app.py
+++ b/tests/bedrock_agentcore/runtime/test_app.py
@@ -494,6 +494,48 @@ class TestCustomStatusCodes:
         assert response.status_code == 400
         assert "Invalid encoding" in response.json()["error"]
 
+    def test_handler_json_decode_error_returns_500_not_400(self):
+        """Test that JSONDecodeError raised inside the handler returns 500, not 400.
+
+        Regression test: previously, a broad except caught JSONDecodeError from
+        both request parsing and handler logic, returning a misleading 400
+        "Invalid JSON in request" for application-level parse failures.
+        """
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint
+        def handler(payload):
+            import json
+
+            # Simulate parsing model output that isn't valid JSON
+            json.loads("not valid json from model")
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post("/invocations", json={"input": "test"})
+
+        assert response.status_code == 500, f"Handler JSONDecodeError should return 500, got {response.status_code}"
+        assert "Invalid JSON" not in response.json().get("error", ""), (
+            "Handler JSONDecodeError should not say 'Invalid JSON' (that implies bad request)"
+        )
+
+    def test_invalid_request_json_returns_400(self):
+        """Test that malformed JSON in the request body returns 400 with 'Invalid JSON'."""
+        app = BedrockAgentCoreApp()
+
+        @app.entrypoint
+        def handler(payload):
+            return payload
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            "/invocations",
+            content=b"not valid json",
+            headers={"content-type": "application/json"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid JSON" in response.json()["error"]
+
     def test_return_response_passthrough(self):
         """Test returning a Response object passes it through without wrapping."""
         from starlette.responses import JSONResponse


### PR DESCRIPTION
## Summary

- Fixes misleading "Invalid JSON in request" error when the handler (not the request) raises `json.JSONDecodeError` (e.g., parsing model output)
- Narrows the `JSONDecodeError`/`UnicodeDecodeError` catches to only cover `request.json()` parsing
- Handler-raised exceptions now correctly return HTTP 500 with the actual error message

Resolves [V2192037347](https://t.corp.amazon.com/V2192037347) — customer reported AgentCore runtime surfaces misleading error classification for downstream application JSON parsing errors.

## Test plan

- [x] Verified bug reproduction: handler `JSONDecodeError` previously returned 400 "Invalid JSON"
- [x] Verified fix: handler `JSONDecodeError` now returns 500 with actual error
- [x] Verified regression: actual invalid request JSON still returns 400 "Invalid JSON"
- [x] All 311 runtime unit tests pass