### PR TITLE
fix: allow bound methods in entrypoint() registration

### DIFF
--- a/src/bedrock_agentcore/runtime/app.py
+++ b/src/bedrock_agentcore/runtime/app.py
@@ -220,7 +220,10 @@ class BedrockAgentCoreApp(Starlette):
             The decorated function with added serve method
         """
         self.handlers["main"] = func
-        func.run = lambda port=8080, host=None: self.run(port, host)
+        try:
+            func.run = lambda port=8080, host=None: self.run(port, host)
+        except AttributeError:
+            pass
         return func
 
     def ping(self, func: Callable) -> Callable:

--- a/tests/bedrock_agentcore/runtime/test_app.py
+++ b/tests/bedrock_agentcore/runtime/test_app.py
@@ -61,6 +61,21 @@ class TestBedrockAgentCoreApp:
         assert hasattr(test_handler, "run")
         assert callable(test_handler.run)
 
+    def test_entrypoint_bound_method(self):
+        """Test entrypoint accepts a bound method without raising AttributeError."""
+
+        class MyAgent:
+            def __init__(self):
+                self.app = BedrockAgentCoreApp()
+                self.app.entrypoint(self.handle)
+
+            def handle(self, payload):
+                return {"result": "success"}
+
+        agent = MyAgent()
+        assert "main" in agent.app.handlers
+        assert agent.app.handlers["main"] == agent.handle
+
     def test_invocation_without_context(self):
         """Test handler without context parameter works correctly."""
         bedrock_agentcore = BedrockAgentCoreApp()


### PR DESCRIPTION
## Summary

- Guard the `.run` attribute assignment in `entrypoint()` with `try/except AttributeError` so that bound methods (and other callables without a writable `__dict__`) can be registered without raising
- Adds a regression test for the class-based agent pattern

Fixes #473

## Test plan

- [x] `test_entrypoint_bound_method` passes — registers a bound method without error
- [x] `test_entrypoint_decorator` still passes — plain functions still get `.run` sugar