### PR TITLE
chore: replace all github.token/GITHUB_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,11 +33,18 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
 
       # patch and minor bumps: enable auto-merge.
       # GitHub holds the merge until all required status checks pass.
@@ -48,7 +55,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge --auto --squash "$PR_URL"
           echo "✓ Auto-merge enabled: ${{ steps.metadata.outputs.dependency-names }} \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -115,9 +115,16 @@ jobs:
             exit 1
           fi
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ steps.bump.outputs.version }}
           GITHUB_REF: ${{ github.ref }}
           GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
## Summary
Replace all `github.token` and `secrets.GITHUB_TOKEN` usage with short-lived tokens from the `agentcore-devx-automation` GitHub App.

Updated workflows: release-prepare, dependabot-auto-merge.

## Test plan
- [ ] Add APP_ID variable and APP_PRIVATE_KEY secret to this repo
- [ ] Merge and confirm workflows run successfully