### PR TITLE
docs: document time_of_last_update in /ping response

### DIFF
--- a/docs/examples/a2a_protocol_examples.md
+++ b/docs/examples/a2a_protocol_examples.md
@@ -142,7 +142,12 @@ Builds a Starlette ASGI application without starting a server. Useful for testin
 Returns a `Starlette` application with routes:
 - `POST /` — A2A JSON-RPC endpoint (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`)
 - `GET /.well-known/agent-card.json` — Agent card discovery
-- `GET /ping` — Bedrock health check
+- `GET /ping` — Bedrock health check. Returns JSON:
+  ```json
+  {"status": "Healthy" | "HealthyBusy", "time_of_last_update": 1715000000}
+  ```
+  - `status` — current health status from the `ping_handler` (or `"Healthy"` by default)
+  - `time_of_last_update` — Unix timestamp (seconds) indicating when the status was last updated
 
 ### `build_runtime_url(agent_arn, region=None)`
 
@@ -192,3 +197,5 @@ serve_a2a(executor, ping_handler=my_ping)
 ```
 
 If the ping handler raises an exception, the server falls back to `PingStatus.HEALTHY`.
+
+The `/ping` response always includes a `time_of_last_update` field (Unix timestamp in seconds) reflecting when the status last changed. Clients can use this to detect stale health state.


### PR DESCRIPTION
## Summary

- Documents the previously undocumented `time_of_last_update` field in the `/ping` endpoint response
- Adds the full response schema (`status` + `time_of_last_update`) to the API reference section
- Adds a note in the Custom Ping Handler section explaining the timestamp semantics

## Context

The `/ping` endpoint has always returned `{"status": "...", "time_of_last_update": <unix_timestamp>}` across all runtime protocols (main app, A2A, AG-UI), but the `time_of_last_update` field was never documented. This caused confusion for developers integrating with the health check endpoint (#471).

The code is correct — this is purely a documentation fix.

## Test plan

- [ ] Verify markdown renders correctly
- [ ] No code changes, so no runtime testing needed

Fixes #471