### PR TITLE
fix: out-of-scope variable in catch block

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -75,8 +75,8 @@ jobs:
         with:
           result-encoding: string
           script: |
+            let username;
             try {
-              let username;
               if (context.payload.pull_request) {
                 username = context.payload.pull_request.user.login;
               } else {
@@ -99,7 +99,7 @@ jobs:
                 return "auto-approve"
               }
             } catch (error) {
-              console.log(`${username} does not have write access. Requiring Manual Approval to run PR Checks.`)
+              console.log(`Permission check failed for ${username}. Requiring Manual Approval to run PR Checks. Error: ${error.message}`);
               return "manual-approval"
             }
 


### PR DESCRIPTION
*Description of changes:*
The collaborator check workflow will error out before completing execution when stepping into the catch block. This is caused by `username` being scoped inside the try-block, meaning it is not visible to the code inside the catch-block. 

Simple fix to move username instantiation outside of the try.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
