### PR TITLE
ci: skip bearer token integ tests pending AgentCredentialProviderService fix

### DIFF
--- a/tests_integ/payments/test_payment_manager.py
+++ b/tests_integ/payments/test_payment_manager.py
@@ -1100,7 +1100,7 @@ class TestPaymentManagerBearerTokenAuth:
                     raise
                 time.sleep(initial_delay * (2**attempt))
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
+    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_bearer_token_real_api_call(self):
         """Test a real API call using bearer token from Cognito.
 
@@ -1121,7 +1121,7 @@ class TestPaymentManagerBearerTokenAuth:
         assert isinstance(result, dict)
         assert "paymentInstruments" in result
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
+    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_token_provider_real_api_call(self):
         """Test a real API call using token_provider with Cognito.
 
@@ -1146,7 +1146,7 @@ class TestPaymentManagerBearerTokenAuth:
         assert "paymentInstruments" in result
         assert call_count["n"] >= 1
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
+    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_bearer_create_session_real_api_call(self):
         """Test creating a payment session using bearer token auth.
 

--- a/tests_integ/payments/test_payment_manager.py
+++ b/tests_integ/payments/test_payment_manager.py
@@ -1100,6 +1100,7 @@ class TestPaymentManagerBearerTokenAuth:
                     raise
                 time.sleep(initial_delay * (2**attempt))
 
+    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
     def test_bearer_token_real_api_call(self):
         """Test a real API call using bearer token from Cognito.
 
@@ -1120,6 +1121,7 @@ class TestPaymentManagerBearerTokenAuth:
         assert isinstance(result, dict)
         assert "paymentInstruments" in result
 
+    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
     def test_token_provider_real_api_call(self):
         """Test a real API call using token_provider with Cognito.
 
@@ -1144,6 +1146,7 @@ class TestPaymentManagerBearerTokenAuth:
         assert "paymentInstruments" in result
         assert call_count["n"] >= 1
 
+    @pytest.mark.skip(reason="AgentCredentialProviderService returning 500 in us-east-1 — waiting for payments oncall to investigate")
     def test_bearer_create_session_real_api_call(self):
         """Test creating a payment session using bearer token auth.
 


### PR DESCRIPTION
## Summary

- Skip 3 `TestPaymentManagerBearerTokenAuth` integ tests that are persistently failing due to `AgentCredentialProviderService` returning 500 in us-east-1
- Waiting for payments oncall to investigate and resolve the backend issue

## Context

- Account: `389323710475`
- Region: `us-east-1`
- Resource: `arn:aws:bedrock-agentcore:us-east-1:389323710475:payment-manager/bearertest846c7b3d-iwksrwtlsr`
- Failing operations: `ListPaymentInstruments`, `CreatePaymentSession`
- Error: `InternalServerException: AgentCredentialProviderServiceException error` (after 4 retries)
- 30 other payment tests pass fine (SigV4 auth paths are healthy)
- Failed consistently across multiple runs: https://github.com/aws/bedrock-agentcore-sdk-python/actions/runs/26662426337

## Tests skipped

- `test_bearer_token_real_api_call`
- `test_token_provider_real_api_call`
- `test_bearer_create_session_real_api_call`

## Test plan

- [x] Only the 3 affected tests are skipped
- [x] All other payment tests remain enabled
- [ ] Re-enable once AgentCredentialProviderService is healthy