### PR TITLE
test(payments): re-enable bearer token integ tests (AgentCredentialProviderService fixed)

### DIFF
--- a/tests_integ/payments/test_payment_manager.py
+++ b/tests_integ/payments/test_payment_manager.py
@@ -1100,7 +1100,6 @@ class TestPaymentManagerBearerTokenAuth:
                     raise
                 time.sleep(initial_delay * (2**attempt))
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_bearer_token_real_api_call(self):
         """Test a real API call using bearer token from Cognito.
 
@@ -1121,7 +1120,6 @@ class TestPaymentManagerBearerTokenAuth:
         assert isinstance(result, dict)
         assert "paymentInstruments" in result
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_token_provider_real_api_call(self):
         """Test a real API call using token_provider with Cognito.
 
@@ -1146,7 +1144,6 @@ class TestPaymentManagerBearerTokenAuth:
         assert "paymentInstruments" in result
         assert call_count["n"] >= 1
 
-    @pytest.mark.skip(reason="AgentCredentialProviderService 500 in us-east-1, payments oncall investigating")
     def test_bearer_create_session_real_api_call(self):
         """Test creating a payment session using bearer token auth.
 


### PR DESCRIPTION
## Summary

Reverts #499, which added `@pytest.mark.skip` to three bearer-token (CUSTOM_JWT) integration tests while the AgentCredentialProviderService was returning 500s:

- `TestPaymentManagerBearerTokenAuth::test_bearer_token_real_api_call`
- `TestPaymentManagerBearerTokenAuth::test_token_provider_real_api_call`
- `TestPaymentManagerBearerTokenAuth::test_bearer_create_session_real_api_call`

The underlying service issue is now resolved, so the skips are no longer needed.

## Why it's safe to re-enable

The original failure was a **service-side** defect, not a test or SDK bug: `CreatePaymentSession` / `ListPaymentInstruments` with a valid Cognito bearer token against a READY CUSTOM_JWT Payment Manager returned `InternalServerException: AgentCredentialProviderServiceException` (the post-validation JWT→workload-identity exchange was 5xx-ing). It was reproducible across two independent accounts in us-west-2 and began ~May 29.

Verification that it's fixed:
- **Live repro now succeeds** — a fresh CUSTOM_JWT manager + Cognito client_credentials token returns a valid `paymentSessionId`, with the service correctly deriving `userId` from the JWT claim.
- **CI is green** — the last several `Secure Integration test` runs on `main` pass, including the payments job, with no code changes.

## Change

Pure revert of #499 — removes the three `@pytest.mark.skip` decorators. No other changes.