### PR TITLE
feat(runtime): add interactive runtime shell support

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install griffe
-        run: pip install griffe==1.7.3
+        run: pip install "griffe<2"
 
       # Fetch the base branch so the ref is available for griffe's worktree.
       - name: Fetch base branch
@@ -122,7 +122,7 @@ jobs:
               "",
           ]
           for b in breakages:
-              lines.append(b.explain())
+              lines.append(b.explain(style=griffe.ExplanationStyle.MARKDOWN))
 
           lines += [
               "",

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -43,7 +43,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install griffe
-        run: pip install "griffe<2"
+        run: pip install griffe==1.7.3
 
       # Fetch the base branch so the ref is available for griffe's worktree.
       - name: Fetch base branch
@@ -122,7 +122,7 @@ jobs:
               "",
           ]
           for b in breakages:
-              lines.append(b.explain(style=griffe.ExplanationStyle.MARKDOWN))
+              lines.append(b.explain())
 
           lines += [
               "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "starlette>=0.46.2",
     "typing-extensions>=4.13.2,<5.0.0",
     "uvicorn>=0.34.2",
-    "websockets>=12.0",
+    "websockets>=13.0",
 ]
 
 [project.scripts]

--- a/src/bedrock_agentcore/runtime/__init__.py
+++ b/src/bedrock_agentcore/runtime/__init__.py
@@ -10,15 +10,33 @@ from .agent_core_runtime_client import AgentCoreRuntimeClient
 from .app import BedrockAgentCoreApp
 from .context import BedrockAgentCoreContext, RequestContext
 from .models import PingStatus
+from .shell import (
+    AuthMode,
+    OAuthAuth,
+    PresignedAuth,
+    ReconnectConfig,
+    ShellChannel,
+    ShellFrame,
+    ShellFramer,
+    ShellSession,
+)
 
 __all__ = [
     "AgentCoreRuntimeClient",
     "AGUIApp",
+    "AuthMode",
     "BedrockAgentCoreApp",
     "BedrockCallContextBuilder",
-    "RequestContext",
     "BedrockAgentCoreContext",
+    "OAuthAuth",
+    "PresignedAuth",
+    "ReconnectConfig",
+    "RequestContext",
     "PingStatus",
+    "ShellChannel",
+    "ShellFrame",
+    "ShellFramer",
+    "ShellSession",
     "build_a2a_app",
     "build_ag_ui_app",
     "build_runtime_url",

--- a/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
+++ b/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
@@ -446,25 +446,25 @@ class AgentCoreRuntimeClient:
         endpoint_name: Optional[str] = None,
         shell_id: Optional[str] = None,
     ) -> str:
-        """Build wss:// URL for /ws/commands (shell op).
+        """Build wss:// URL for /ws/shells (shell op).
 
         Args:
             runtime_arn: Full runtime ARN.
             endpoint_name: Optional qualifier query param.
-            shell_id: Optional commandSessionId query param (wire name unchanged).
+            shell_id: Optional shellId query param.
 
         Returns:
             WebSocket URL (wss://…).
         """
         host = get_data_plane_endpoint(self.region).replace("https://", "")
         encoded_arn = quote(runtime_arn, safe="")
-        path = f"/runtimes/{encoded_arn}/ws/commands"
+        path = f"/runtimes/{encoded_arn}/ws/shells"
 
         params: Dict[str, str] = {}
         if endpoint_name:
             params["qualifier"] = endpoint_name
         if shell_id:
-            params["commandSessionId"] = shell_id
+            params["shellId"] = shell_id
 
         qs = urlencode(params)
         return f"wss://{host}{path}?{qs}" if qs else f"wss://{host}{path}"
@@ -713,8 +713,8 @@ class AgentCoreRuntimeClient:
                     if frame.channel == ShellChannel.STDOUT:
                         print(frame.text, end="")
                     elif frame.channel == ShellChannel.STATUS:
-                        # Termination frames have empty metadata (no commandSessionId).
-                        if not frame.json().get("metadata", {}).get("commandSessionId"):
+                        # Termination frames have empty metadata (no shellId).
+                        if not frame.json().get("metadata", {}).get("shellId"):
                             break
 
         Example — presigned URL:

--- a/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
+++ b/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
@@ -9,8 +9,13 @@ import datetime
 import logging
 import secrets
 import uuid
-from typing import Any, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, urlencode, urlparse
+
+from .shell._validation import parse_runtime_arn, validate_shell_id
+
+if TYPE_CHECKING:
+    from .shell import AuthMode, ReconnectConfig, ShellSession
 
 import boto3
 from botocore.auth import SigV4Auth, SigV4QueryAuth
@@ -23,7 +28,6 @@ from .._utils.endpoints import get_data_plane_endpoint, validate_region
 from .._utils.polling import wait_until, wait_until_deleted
 from .._utils.snake_case import accept_snake_case_kwargs, convert_kwargs
 from .._utils.user_agent import build_user_agent_suffix
-from .utils import is_valid_partition
 
 DEFAULT_PRESIGNED_URL_TIMEOUT = 300
 MAX_PRESIGNED_URL_TIMEOUT = 300
@@ -80,21 +84,20 @@ class AgentCoreRuntimeClient:
             integration_source: Optional integration source for user-agent
                 telemetry.
         """
-        session = session if session else boto3.Session()
-        self.region = validate_region(region or session.region_name or "us-west-2")
-        self.session = session
+        self.region = validate_region(region or (session.region_name if session else None) or "us-west-2")
+        self.session = session if session else boto3.Session(region_name=self.region)
         self.integration_source = integration_source
         self.logger = logging.getLogger(__name__)
 
         user_agent_extra = build_user_agent_suffix(integration_source)
         client_config = Config(user_agent_extra=user_agent_extra)
 
-        self.cp_client = session.client(
+        self.cp_client = self.session.client(
             "bedrock-agentcore-control",
             region_name=self.region,
             config=client_config,
         )
-        self.dp_client = session.client(
+        self.dp_client = self.session.client(
             "bedrock-agentcore",
             region_name=self.region,
             config=client_config,
@@ -124,47 +127,6 @@ class AgentCoreRuntimeClient:
             f"Available methods can be found in the boto3 documentation for "
             f"'bedrock-agentcore' and 'bedrock-agentcore-control' services."
         )
-
-    def _parse_runtime_arn(self, runtime_arn: str) -> Dict[str, str]:
-        """Parse runtime ARN and extract components.
-
-        Args:
-            runtime_arn (str): Full runtime ARN
-
-        Returns:
-            Dict[str, str]: Dictionary with region, account_id, runtime_id
-
-        Raises:
-            ValueError: If ARN format is invalid
-        """
-        # Expected format: arn:aws:bedrock-agentcore:{region}:{account}:runtime/{runtime_id}
-        parts = runtime_arn.split(":")
-
-        if len(parts) != 6:
-            raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
-
-        if parts[0] != "arn" or not is_valid_partition(parts[1]) or parts[2] != "bedrock-agentcore":
-            raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
-
-        # Parse the resource part (runtime/{runtime_id})
-        resource = parts[5]
-        if not resource.startswith("runtime/"):
-            raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
-
-        runtime_id = resource.split("/", 1)[1]
-
-        # Validate that components are not empty
-        region = parts[3]
-        account_id = parts[4]
-
-        if not region or not account_id or not runtime_id:
-            raise ValueError("ARN components cannot be empty")
-
-        return {
-            "region": region,
-            "account_id": account_id,
-            "runtime_id": runtime_id,
-        }
 
     def _build_websocket_url(
         self,
@@ -209,6 +171,72 @@ class AgentCoreRuntimeClient:
 
         return ws_url
 
+    def _sigv4_sign(
+        self,
+        https_url: str,
+        signed_headers: Optional[Dict[str, str]] = None,
+        unsigned_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, str]:
+        """SigV4-sign a WebSocket upgrade URL and return the full header dict.
+
+        Args:
+            https_url: The https:// form of the wss:// URL to sign.
+            signed_headers: Headers to include inside the AWSRequest so they
+                are covered by the SigV4 signature.
+            unsigned_headers: Headers appended to the result after signing
+                (not covered by the signature).
+
+        Returns:
+            Dict with Host, X-Amz-Date, Authorization, optionally
+            X-Amz-Security-Token, plus any signed/unsigned headers passed in.
+        """
+        credentials = self.session.get_credentials()
+        if not credentials:
+            raise RuntimeError("No AWS credentials found")
+        frozen = credentials.get_frozen_credentials()
+        host = urlparse(https_url).netloc
+        req_headers: Dict[str, str] = {
+            "host": host,
+            "x-amz-date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        }
+        if signed_headers:
+            req_headers.update({k.lower(): v for k, v in signed_headers.items()})
+        request = AWSRequest(method="GET", url=https_url, headers=req_headers)
+        SigV4Auth(frozen, "bedrock-agentcore", self.region).add_auth(request)
+        headers: Dict[str, str] = {
+            "Host": host,
+            "X-Amz-Date": request.headers["x-amz-date"],
+            "Authorization": request.headers["Authorization"],
+        }
+        if frozen.token:
+            headers["X-Amz-Security-Token"] = frozen.token
+        if signed_headers:
+            headers.update(signed_headers)
+        if unsigned_headers:
+            headers.update(unsigned_headers)
+        return headers
+
+    def _presign(self, https_url: str, expires: int) -> str:
+        """Sign a WebSocket URL with SigV4 query-string auth and return it as wss://.
+
+        Args:
+            https_url: The https:// URL to sign (query params already embedded).
+            expires: Seconds until the presigned URL expires.
+
+        Returns:
+            Presigned wss:// URL.
+
+        Raises:
+            RuntimeError: If no AWS credentials are found.
+        """
+        credentials = self.session.get_credentials()
+        if not credentials:
+            raise RuntimeError("No AWS credentials found")
+        frozen = credentials.get_frozen_credentials()
+        request = AWSRequest(method="GET", url=https_url, headers={"host": urlparse(https_url).hostname})
+        SigV4QueryAuth(frozen, "bedrock-agentcore", self.region, expires=expires).add_auth(request)
+        return request.url.replace("https://", "wss://")
+
     def generate_ws_connection(
         self,
         runtime_arn: str,
@@ -243,7 +271,7 @@ class AgentCoreRuntimeClient:
         self.logger.info("Generating WebSocket connection credentials...")
 
         # Validate ARN
-        self._parse_runtime_arn(runtime_arn)
+        parse_runtime_arn(runtime_arn)
 
         # Auto-generate session ID if not provided
         if not session_id:
@@ -252,50 +280,17 @@ class AgentCoreRuntimeClient:
 
         # Build WebSocket URL
         ws_url = self._build_websocket_url(runtime_arn, endpoint_name)
-
-        # Get AWS credentials
-        credentials = self.session.get_credentials()
-        if not credentials:
-            raise RuntimeError("No AWS credentials found")
-
-        frozen_credentials = credentials.get_frozen_credentials()
-
-        # Convert wss:// to https:// for signing
-        https_url = ws_url.replace("wss://", "https://")
-        parsed = urlparse(https_url)
-        host = parsed.netloc
-
-        # Create the request to sign
-        request = AWSRequest(
-            method="GET",
-            url=https_url,
-            headers={
-                "host": host,
-                "x-amz-date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ"),
+        headers = self._sigv4_sign(
+            ws_url.replace("wss://", "https://"),
+            unsigned_headers={
+                "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
+                "Upgrade": "websocket",
+                "Connection": "Upgrade",
+                "Sec-WebSocket-Version": "13",
+                "Sec-WebSocket-Key": base64.b64encode(secrets.token_bytes(16)).decode(),
+                "User-Agent": "AgentCoreRuntimeClient/1.0",
             },
         )
-
-        # Sign the request with SigV4
-        auth = SigV4Auth(frozen_credentials, "bedrock-agentcore", self.region)
-        auth.add_auth(request)
-
-        # Build headers for WebSocket connection
-        headers = {
-            "Host": host,
-            "X-Amz-Date": request.headers["x-amz-date"],
-            "Authorization": request.headers["Authorization"],
-            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id,
-            "Upgrade": "websocket",
-            "Connection": "Upgrade",
-            "Sec-WebSocket-Version": "13",
-            "Sec-WebSocket-Key": base64.b64encode(secrets.token_bytes(16)).decode(),
-            "User-Agent": "AgentCoreRuntimeClient/1.0",
-        }
-
-        # Add session token if present
-        if frozen_credentials.token:
-            headers["X-Amz-Security-Token"] = frozen_credentials.token
-
         self.logger.info("✓ WebSocket connection credentials generated (Session: %s)", session_id)
         return ws_url, headers
 
@@ -347,7 +342,7 @@ class AgentCoreRuntimeClient:
             raise ValueError(f"Expiry timeout cannot exceed {MAX_PRESIGNED_URL_TIMEOUT} seconds, got {expires}")
 
         # Validate ARN
-        self._parse_runtime_arn(runtime_arn)
+        parse_runtime_arn(runtime_arn)
 
         # Auto-generate session ID if not provided
         if not session_id:
@@ -361,38 +356,7 @@ class AgentCoreRuntimeClient:
 
         # Build WebSocket URL with query parameters
         ws_url = self._build_websocket_url(runtime_arn, endpoint_name, custom_headers)
-
-        # Convert wss:// to https:// for signing
-        https_url = ws_url.replace("wss://", "https://")
-
-        # Parse URL
-        url = urlparse(https_url)
-
-        # Get AWS credentials
-        credentials = self.session.get_credentials()
-        if not credentials:
-            raise RuntimeError("No AWS credentials found")
-
-        frozen_credentials = credentials.get_frozen_credentials()
-
-        # Create the request to sign
-        request = AWSRequest(method="GET", url=https_url, headers={"host": url.hostname})
-
-        # Sign the request with SigV4QueryAuth
-        signer = SigV4QueryAuth(
-            credentials=frozen_credentials,
-            service_name="bedrock-agentcore",
-            region_name=self.region,
-            expires=expires,
-        )
-        signer.add_auth(request)
-
-        if not request.url:
-            raise RuntimeError("Failed to generate presigned URL")
-
-        # Convert back to wss:// for WebSocket connection
-        presigned_url = request.url.replace("https://", "wss://")
-
+        presigned_url = self._presign(ws_url.replace("wss://", "https://"), expires)
         self.logger.info("✓ Presigned URL generated (expires in %s seconds, Session: %s)", expires, session_id)
         return presigned_url
 
@@ -439,7 +403,7 @@ class AgentCoreRuntimeClient:
             raise ValueError("Bearer token cannot be empty")
 
         # Validate ARN
-        self._parse_runtime_arn(runtime_arn)
+        parse_runtime_arn(runtime_arn)
 
         # Auto-generate session ID if not provided
         if not session_id:
@@ -472,6 +436,333 @@ class AgentCoreRuntimeClient:
         self.logger.debug("Bearer token length: %d characters", len(bearer_token))
 
         return ws_url, headers
+
+    # InvokeAgentRuntimeCommandShell auth helpers
+    # -------------------------------------------------------------------------
+
+    def _build_shell_url(
+        self,
+        runtime_arn: str,
+        endpoint_name: Optional[str] = None,
+        shell_id: Optional[str] = None,
+    ) -> str:
+        """Build wss:// URL for /ws/commands (shell op).
+
+        Args:
+            runtime_arn: Full runtime ARN.
+            endpoint_name: Optional qualifier query param.
+            shell_id: Optional commandSessionId query param (wire name unchanged).
+
+        Returns:
+            WebSocket URL (wss://…).
+        """
+        host = get_data_plane_endpoint(self.region).replace("https://", "")
+        encoded_arn = quote(runtime_arn, safe="")
+        path = f"/runtimes/{encoded_arn}/ws/commands"
+
+        params: Dict[str, str] = {}
+        if endpoint_name:
+            params["qualifier"] = endpoint_name
+        if shell_id:
+            params["commandSessionId"] = shell_id
+
+        qs = urlencode(params)
+        return f"wss://{host}{path}?{qs}" if qs else f"wss://{host}{path}"
+
+    def connect_shell(
+        self,
+        runtime_arn: str,
+        session_id: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        shell_id: Optional[str] = None,
+    ) -> Tuple[str, Dict[str, str]]:
+        """Return (wss_url, headers) for a SigV4-authenticated shell session.
+
+        SigV4 is the correct auth path for server-side Python.  Browsers cannot
+        set arbitrary headers on a WebSocket upgrade (RFC 6455); use
+        ``connect_shell_oauth`` for browser-facing use cases instead.
+
+        Args:
+            runtime_arn: Full agent runtime ARN.
+            session_id: Routes to an existing VM. Auto-generated UUID if omitted;
+                a new VM is provisioned.
+            endpoint_name: Endpoint qualifier (default: DEFAULT).
+            shell_id: Client-chosen shell name (1–128 chars, no ?, #, &).
+                Auto-generated UUID if omitted. **Store this value** — passing the same
+                ID reconnects to the same PTY, preserving shell state and up to 256 KB
+                of buffered output.
+
+        Returns:
+            ``(wss_url, headers)`` — pass both directly to any WebSocket library.
+
+        Raises:
+            ValueError: If the ARN format is invalid or ``shell_id`` is
+                outside the allowed character set.
+            RuntimeError: If no AWS credentials are found.
+
+        Example:
+            url, headers = client.connect_shell(
+                runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:runtime/r",
+                shell_id="my-debug-shell",
+            )
+            ws = await websockets.connect(url, additional_headers=headers)
+        """
+        parse_runtime_arn(runtime_arn)
+        if not session_id:
+            session_id = str(uuid.uuid4())
+        if not shell_id:
+            shell_id = str(uuid.uuid4())
+        validate_shell_id(shell_id)
+        ws_url = self._build_shell_url(runtime_arn, endpoint_name, shell_id)
+        headers = self._sigv4_sign(
+            ws_url.replace("wss://", "https://"),
+            signed_headers={"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id},
+            unsigned_headers={"User-Agent": build_user_agent_suffix(self.integration_source)},
+        )
+        self.logger.info(
+            "Generated shell connection (session=%s, shell_id=%s)",
+            session_id,
+            shell_id,
+        )
+        return ws_url, headers
+
+    def connect_shell_presigned(
+        self,
+        runtime_arn: str,
+        session_id: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        shell_id: Optional[str] = None,
+        expires: int = DEFAULT_PRESIGNED_URL_TIMEOUT,
+    ) -> str:
+        """Return a presigned wss:// URL for a shell session (auth in query string).
+
+        Useful when you need to hand a URL to another process or service without
+        sharing AWS credentials directly.
+
+        Args:
+            runtime_arn: Full agent runtime ARN.
+            session_id: Routes to an existing VM. Auto-generated if omitted.
+            endpoint_name: Endpoint qualifier (default: DEFAULT).
+            shell_id: Client-chosen shell name. Store this value for
+                reconnection. Auto-generated if omitted.
+            expires: Seconds until the URL expires (max 300).
+
+        Returns:
+            Presigned wss:// URL — open with any WebSocket client, no extra headers needed.
+
+        Raises:
+            ValueError: If ``expires`` exceeds the maximum, the ARN is invalid, or
+                ``shell_id`` contains forbidden characters.
+            RuntimeError: If no AWS credentials are found.
+
+        Example:
+            url = client.connect_shell_presigned(
+                runtime_arn="arn:aws:bedrock-agentcore:us-west-2:123:runtime/r",
+                shell_id="build-shell",
+                expires=120,
+            )
+            ws = await websockets.connect(url)
+        """
+        if expires > MAX_PRESIGNED_URL_TIMEOUT:
+            raise ValueError(f"Expiry timeout cannot exceed {MAX_PRESIGNED_URL_TIMEOUT} seconds, got {expires}")
+        parse_runtime_arn(runtime_arn)
+        if not session_id:
+            session_id = str(uuid.uuid4())
+        if not shell_id:
+            shell_id = str(uuid.uuid4())
+        validate_shell_id(shell_id)
+        ws_url = self._build_shell_url(runtime_arn, endpoint_name, shell_id)
+        https_url = ws_url.replace("wss://", "https://")
+        # session_id rides as a query param so it is covered by the signature
+        sep = "&" if "?" in https_url else "?"
+        https_url += sep + urlencode({"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id})
+        presigned = self._presign(https_url, expires)
+        self.logger.info(
+            "Generated presigned shell URL (expires=%ds, shell_id=%s)",
+            expires,
+            shell_id,
+        )
+        return presigned
+
+    def connect_shell_oauth(
+        self,
+        runtime_arn: str,
+        bearer_token: str,
+        session_id: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        shell_id: Optional[str] = None,
+    ) -> Tuple[str, List[str]]:
+        """Return (wss_url, subprotocols) for an OAuth-authenticated shell session.
+
+        This is the only valid auth path for browser clients: browsers cannot set
+        arbitrary headers on a WebSocket upgrade (RFC 6455), so the bearer
+        token is embedded in the ``Sec-WebSocket-Protocol`` handshake using the
+        ``base64UrlBearerAuthorization`` scheme instead.
+
+        Server-side Python callers should prefer ``connect_shell`` with
+        SigV4.  Use this method when building a browser relay or xterm.js
+        integration.
+
+        Args:
+            runtime_arn: Full agent runtime ARN.
+            bearer_token: OAuth bearer token obtained from your identity provider.
+            session_id: Routes to an existing VM. Auto-generated if omitted.
+            endpoint_name: Endpoint qualifier (default: DEFAULT).
+            shell_id: Client-chosen shell name. Store this value for
+                reconnection. Auto-generated if omitted.
+
+        Returns:
+            ``(wss_url, subprotocols)`` — pass both to the WebSocket constructor.
+            ``subprotocols`` contains the base64url-encoded token as
+            ``base64UrlBearerAuthorization.<token>`` plus the sentinel
+            ``base64UrlBearerAuthorization``.
+
+        Raises:
+            ValueError: If ``bearer_token`` is empty, the ARN is invalid, or
+                ``shell_id`` contains forbidden characters.
+
+        Example (server-side relay):
+            url, protos = client.connect_shell_oauth(
+                runtime_arn="arn:...",
+                bearer_token=await get_oauth_token(),
+                shell_id="inspector-shell",
+            )
+            ws = await websockets.connect(url, subprotocols=protos)
+
+        Example (browser):
+            # Backend returns (url, subprotocols); browser does:
+            # const ws = new WebSocket(url, subprotocols)
+        """
+        if not bearer_token:
+            raise ValueError("bearer_token cannot be empty")
+        parse_runtime_arn(runtime_arn)
+        if not session_id:
+            session_id = str(uuid.uuid4())
+        if not shell_id:
+            shell_id = str(uuid.uuid4())
+        validate_shell_id(shell_id)
+
+        ws_url = self._build_shell_url(runtime_arn, endpoint_name, shell_id)
+        sep = "&" if "?" in ws_url else "?"
+        ws_url += sep + urlencode({"X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": session_id})
+
+        # Bearer token embedded as a WebSocket subprotocol using the
+        # base64UrlBearerAuthorization scheme — the only mechanism available to
+        # browser clients for passing auth on a WS upgrade (RFC 6455).
+        encoded = base64.urlsafe_b64encode(bearer_token.encode()).decode().rstrip("=")
+        if len(encoded) > 4096:
+            raise ValueError(
+                f"bearer_token too large to embed in Sec-WebSocket-Protocol ({len(encoded)} chars encoded, max 4096)"
+            )
+        subprotocols: List[str] = [
+            f"base64UrlBearerAuthorization.{encoded}",
+            "base64UrlBearerAuthorization",
+        ]
+
+        self.logger.info("Generated OAuth shell connection (shell_id=%s)", shell_id)
+        return ws_url, subprotocols
+
+    def open_shell(
+        self,
+        runtime_arn: str,
+        session_id: Optional[str] = None,
+        shell_id: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        auth: "AuthMode" = "sigv4",
+        reconnect_config: Optional["ReconnectConfig"] = None,
+    ) -> "ShellSession":
+        r"""Create a ``ShellSession`` for interactive shell access to an agent VM.
+
+        Returns an async context manager that connects on ``__aenter__`` and
+        sends a graceful CLOSE frame on ``__aexit__``.
+
+        Args:
+            runtime_arn: Full agent runtime ARN.
+            session_id: Runtime session ID — routes to an existing VM. Auto-generated
+                UUID if omitted; a new VM is provisioned.
+            shell_id: Client-chosen shell name (1–128 UTF-8 chars, no
+                ``?``, ``#``, or ``&``). Auto-generated if omitted. **Store this
+                value** — passing the same ID reconnects to the same PTY, preserving
+                shell state and up to 256 KB of buffered output across network drops.
+            endpoint_name: Endpoint qualifier (default: DEFAULT).
+            auth: Authentication mode. One of:
+
+                - ``"sigv4"`` *(default)* — SigV4-signed headers from the boto3
+                  session. Correct for all server-side Python use cases.
+                - ``PresignedAuth(expires=N)`` — auth embedded in the URL query
+                  string; valid for up to ``expires`` seconds (max 300). Use when
+                  handing a URL to another process without sharing AWS credentials.
+                - ``OAuthAuth(bearer_token="…")`` — bearer token embedded as a
+                  WebSocket subprotocol. The only valid path for browser clients
+                  (browsers cannot set arbitrary headers on a WS upgrade).
+
+            reconnect_config: When provided, ``ShellSession`` automatically
+                reconnects on unexpected WebSocket disconnects using the same
+                ``shell_id``. The ``on_reconnect`` callback fires after each
+                successful reconnect with ``reconnected=True/False`` so callers can
+                react to the buffered-output burst. ``None`` (default) disables
+                auto-retry — callers handle reconnection explicitly.
+
+        Returns:
+            ``ShellSession`` async context manager.
+
+        Example — SigV4 (default):
+            async with client.open_shell(runtime_arn, session_id=sid) as shell:
+                await shell.send("cat /etc/os-release\\n")
+                async for frame in shell:
+                    if frame.channel == ShellChannel.STDOUT:
+                        print(frame.text, end="")
+                    elif frame.channel == ShellChannel.STATUS:
+                        # Termination frames have empty metadata (no commandSessionId).
+                        if not frame.json().get("metadata", {}).get("commandSessionId"):
+                            break
+
+        Example — presigned URL:
+            async with client.open_shell(
+                runtime_arn,
+                auth=PresignedAuth(expires=120),
+                shell_id="build-shell",
+            ) as shell:
+                ...
+
+        Example — OAuth (browser relay or OAuth-only environments):
+            async with client.open_shell(
+                runtime_arn,
+                auth=OAuthAuth(bearer_token=await get_oauth_token()),
+                shell_id="inspector-shell",
+            ) as shell:
+                ...
+
+        Example — auto-reconnect with callback:
+            async def on_reconnect(reconnected: bool) -> None:
+                print(f"reconnected={reconnected}")
+
+            config = ReconnectConfig(max_retries=5, on_reconnect=on_reconnect)
+            async with client.open_shell(
+                runtime_arn,
+                shell_id="debug",
+                reconnect_config=config,
+            ) as shell:
+                async for frame in shell:
+                    ...
+        """
+        from .shell import ShellSession
+
+        parsed = parse_runtime_arn(runtime_arn)
+        if parsed["region"] != self.region:
+            raise ValueError(
+                f"ARN region {parsed['region']!r} does not match client region {self.region!r}. "
+                "Create a client for the same region as the runtime ARN, or use the ARN's region."
+            )
+        return ShellSession(
+            client=self,
+            runtime_arn=runtime_arn,
+            session_id=session_id,
+            shell_id=shell_id,
+            endpoint_name=endpoint_name,
+            auth=auth,
+            reconnect_config=reconnect_config,
+        )
 
     # *_and_wait methods
     # -------------------------------------------------------------------------

--- a/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
+++ b/src/bedrock_agentcore/runtime/agent_core_runtime_client.py
@@ -682,8 +682,10 @@ class AgentCoreRuntimeClient:
                 UUID if omitted; a new VM is provisioned.
             shell_id: Client-chosen shell name (1–128 UTF-8 chars, no
                 ``?``, ``#``, or ``&``). Auto-generated if omitted. **Store this
-                value** — passing the same ID reconnects to the same PTY, preserving
-                shell state and up to 256 KB of buffered output across network drops.
+                value alongside** ``session_id`` — both are required to reconnect to
+                the same PTY. ``shell_id`` names the PTY; ``session_id`` routes to
+                the VM that hosts it. Passing either without the other will not
+                reconnect successfully.
             endpoint_name: Endpoint qualifier (default: DEFAULT).
             auth: Authentication mode. One of:
 

--- a/src/bedrock_agentcore/runtime/models.py
+++ b/src/bedrock_agentcore/runtime/models.py
@@ -15,6 +15,7 @@ class PingStatus(str, Enum):
 
 # Header constants
 SESSION_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"
+SHELL_ID_HEADER = "X-Amzn-Bedrock-AgentCore-Shell-Id"
 REQUEST_ID_HEADER = "X-Amzn-Bedrock-AgentCore-Runtime-Request-Id"
 ACCESS_TOKEN_HEADER = "WorkloadAccessToken"  # nosec
 OAUTH2_CALLBACK_URL_HEADER = "OAuth2CallbackUrl"

--- a/src/bedrock_agentcore/runtime/shell/__init__.py
+++ b/src/bedrock_agentcore/runtime/shell/__init__.py
@@ -1,0 +1,17 @@
+"""Shell subpackage for InvokeAgentRuntimeCommandShell interactive sessions."""
+
+from .auth import AuthMode, OAuthAuth, PresignedAuth
+from .config import ReconnectConfig
+from .protocol import ShellChannel, ShellFrame, ShellFramer
+from .session import ShellSession
+
+__all__ = [
+    "AuthMode",
+    "OAuthAuth",
+    "PresignedAuth",
+    "ReconnectConfig",
+    "ShellChannel",
+    "ShellFrame",
+    "ShellFramer",
+    "ShellSession",
+]

--- a/src/bedrock_agentcore/runtime/shell/_validation.py
+++ b/src/bedrock_agentcore/runtime/shell/_validation.py
@@ -1,0 +1,59 @@
+"""Validation helpers for shell ARNs and shell IDs."""
+
+import re
+from typing import Dict
+
+from ..utils import is_valid_partition
+
+# shell_id: alphanumeric start, then alphanumeric/hyphen/underscore.
+# \Z (not $) so a trailing \n is rejected — $ matches before \n in Python.
+_SHELL_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}\Z")
+
+
+def parse_runtime_arn(runtime_arn: str) -> Dict[str, str]:
+    """Parse and validate a runtime ARN, returning its components.
+
+    Args:
+        runtime_arn: Full runtime ARN in the form
+            ``arn:{partition}:bedrock-agentcore:{region}:{account}:runtime/{id}``.
+
+    Returns:
+        Dict with ``region``, ``account_id``, and ``runtime_id``.
+
+    Raises:
+        ValueError: If the ARN format is invalid or any component is empty.
+    """
+    parts = runtime_arn.split(":")
+    if len(parts) != 6:
+        raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
+    if parts[0] != "arn" or not is_valid_partition(parts[1]) or parts[2] != "bedrock-agentcore":
+        raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
+    resource = parts[5]
+    if not resource.startswith("runtime/"):
+        raise ValueError(f"Invalid runtime ARN format: {runtime_arn}")
+    runtime_id = resource.split("/", 1)[1]
+    region = parts[3]
+    account_id = parts[4]
+    if not region or not account_id or not runtime_id:
+        raise ValueError("ARN components cannot be empty")
+    return {"region": region, "account_id": account_id, "runtime_id": runtime_id}
+
+
+def validate_shell_id(shell_id: str) -> None:
+    """Validate shell_id against the API's constraint set.
+
+    Args:
+        shell_id: The value to validate.
+
+    Raises:
+        ValueError: If the value is not a str, is empty, is too long, or does not
+            match the pattern ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$.
+    """
+    if not isinstance(shell_id, str):
+        raise ValueError(f"shell_id must be str, got {type(shell_id).__name__!r}")
+    if not _SHELL_ID_RE.match(shell_id):
+        raise ValueError(
+            f"Invalid shell_id {shell_id!r}. "
+            "Must be 1–128 characters, start with alphanumeric, "
+            "and contain only alphanumeric, hyphen, or underscore."
+        )

--- a/src/bedrock_agentcore/runtime/shell/auth.py
+++ b/src/bedrock_agentcore/runtime/shell/auth.py
@@ -1,0 +1,54 @@
+"""Authentication modes for open_shell."""
+
+from dataclasses import dataclass
+from typing import Literal, Union
+
+
+@dataclass
+class OAuthAuth:
+    """OAuth bearer token authentication for ``open_shell``.
+
+    Use this when connecting from a browser relay or any context where an OAuth
+    token (not AWS IAM credentials) is the auth mechanism.  The token is
+    embedded in the ``Sec-WebSocket-Protocol`` header — the only auth mechanism
+    browsers can provide on a WebSocket upgrade (RFC 6455 §4.1).
+
+    Attributes:
+        bearer_token: OAuth bearer token obtained from your identity provider.
+
+    Example:
+        async with client.open_shell(
+            runtime_arn,
+            auth=OAuthAuth(bearer_token=await get_oauth_token()),
+        ) as shell:
+            ...
+    """
+
+    bearer_token: str
+
+
+@dataclass
+class PresignedAuth:
+    """Presigned URL authentication for ``open_shell``.
+
+    Use this when you want auth embedded in the URL query string — useful when
+    handing off to another process or service without sharing AWS credentials,
+    or when the WebSocket client cannot set custom headers.
+
+    Attributes:
+        expires: Seconds until the presigned URL expires (max 300).
+
+    Example:
+        async with client.open_shell(
+            runtime_arn,
+            auth=PresignedAuth(expires=120),
+        ) as shell:
+            ...
+    """
+
+    expires: int = 300
+
+
+# SigV4 is expressed as a string literal for brevity; the two dataclasses carry
+# the extra fields their auth paths need.
+AuthMode = Union[Literal["sigv4"], PresignedAuth, OAuthAuth]

--- a/src/bedrock_agentcore/runtime/shell/config.py
+++ b/src/bedrock_agentcore/runtime/shell/config.py
@@ -1,0 +1,61 @@
+"""Reconnection configuration for ShellSession."""
+
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Optional, Union
+
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_BASE_DELAY = 1.0
+_DEFAULT_MAX_DELAY = 15.0
+_DEFAULT_METADATA_TIMEOUT = 10.0
+_DEFAULT_RECONNECT_WINDOW = 900.0  # ~15 min — matches server-side KARP idle timeout
+_DEFAULT_OUTER_LOOP_DELAY = 30.0  # wait between inner loop exhaustion and next outer attempt
+
+
+@dataclass
+class ReconnectConfig:
+    """Configuration for automatic reconnection on WebSocket disconnect.
+
+    When provided to ``open_shell``, ``ShellSession`` will automatically
+    reconnect using the same ``shell_id`` after an unexpected
+    disconnect.  The shell process on the VM keeps running while detached, and
+    up to 256 KB of buffered output is replayed when the new WebSocket attaches.
+
+    Attributes:
+        max_retries: Maximum number of reconnect attempts per inner loop before
+            pausing and starting a fresh inner loop. The inner
+            loop is bounded at 5.  Use ``reconnect_window=None`` for unlimited
+            overall retries across outer loop cycles.
+        base_delay: Initial backoff delay in seconds.  Doubles on each attempt
+            up to ``max_delay``.
+        max_delay: Upper bound on backoff delay in seconds. The inner loop
+            caps at 15s (sequence: 1s, 2s, 4s, 8s, 15s).
+        reconnect_window: Total seconds to keep retrying after a disconnect
+            before giving up entirely.  Matches the server-side ~15 min
+            reconnection window (KARP idle timeout).  Set to ``None`` to retry
+            indefinitely.
+        outer_loop_delay: Seconds to wait between inner loop exhaustion and the
+            next outer retry cycle.
+        on_reconnect: Optional async or sync callback invoked after each
+            successful reconnect.  Receives ``reconnected: bool`` — ``True``
+            means the existing PTY was reattached (buffered output will follow
+            as STDOUT frames); ``False`` means a fresh shell was started.
+
+    Example — log reconnects and flush buffered output to a file:
+        async def on_reconnect(reconnected: bool) -> None:
+            if reconnected:
+                print("Reattached to existing PTY — replaying buffered output")
+            else:
+                print("New shell started")
+
+        config = ReconnectConfig(reconnect_window=None, on_reconnect=on_reconnect)  # None = unlimited
+        async with client.open_shell(arn, reconnect_config=config) as shell:
+            async for frame in shell:
+                ...
+    """
+
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    base_delay: float = _DEFAULT_BASE_DELAY
+    max_delay: float = _DEFAULT_MAX_DELAY
+    reconnect_window: Optional[float] = _DEFAULT_RECONNECT_WINDOW
+    outer_loop_delay: float = _DEFAULT_OUTER_LOOP_DELAY
+    on_reconnect: Optional[Callable[[bool], Union[Awaitable[None], None]]] = field(default=None, repr=False)

--- a/src/bedrock_agentcore/runtime/shell/protocol.py
+++ b/src/bedrock_agentcore/runtime/shell/protocol.py
@@ -1,0 +1,214 @@
+"""Binary channel-prefix framer for InvokeAgentRuntimeCommandShell.
+
+Wire format (identical to Kubernetes v5.channel.k8s.io):
+  [1-byte channel ID][payload bytes]
+
+Channels:
+  0x00  STDIN      Raw bytes, client → shell
+  0x01  STDOUT     Raw bytes, shell → client
+  0x02  STDERR     UTF-8 text (platform diagnostics), shell → client
+  0x03  STATUS     metav1.Status JSON (shell → client):
+                     Connection confirmation: metadata.commandSessionId present
+                     {"kind":"Status","apiVersion":"v1",
+                      "metadata":{"commandSessionId":"…","reconnected":bool},"status":"Success"}
+                     Shell exit (code 0):
+                     {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}
+                     Shell exit (non-zero):
+                     {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
+                      "reason":"NonZeroExitCode","message":"command terminated with exit code N",
+                      "details":{"causes":[{"reason":"ExitCode","message":"N"}]}}
+                     Shell killed by signal (e.g. SIGKILL/137):
+                     {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
+                      "reason":"NonZeroExitCode","message":"command terminated with exit code N",
+                      "details":{"causes":[{"reason":"ExitCode","message":"N"},
+                                           {"reason":"Signal","message":"<signum>"}]}}
+                     Transient platform error (e.g. init failure):
+                     {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
+                      "reason":"InternalError","message":"…","code":500}
+  0x04  RESIZE     JSON {"width":N,"height":N}, client → shell
+  0x05  HEARTBEAT  Empty payload, bidirectional — browser app-level keepalive (echo back)
+  0xFF  CLOSE      Empty payload, bidirectional — client → server to request graceful
+                   shutdown; server → client for platform-initiated shutdown (VM eviction,
+                   TTL expiry). Not sent on normal shell exit.
+"""
+
+import json
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, Dict, Union
+
+
+class ShellChannel(IntEnum):
+    """Wire channel identifiers for the binary channel-prefix protocol."""
+
+    STDIN = 0x00
+    STDOUT = 0x01
+    STDERR = 0x02
+    STATUS = 0x03
+    RESIZE = 0x04
+    HEARTBEAT = 0x05
+    CLOSE = 0xFF
+    UNKNOWN = -1  # sentinel for unrecognised channel bytes; not a wire value
+
+
+@dataclass
+class ShellFrame:
+    """A single decoded WebSocket frame from the shell stream.
+
+    Attributes:
+        channel: The channel this frame belongs to.  For unrecognised channel
+            bytes (future protocol extensions) this is ``ShellChannel.UNKNOWN``; use
+            ``raw_channel_byte`` to retrieve the original wire value.
+        raw_channel_byte: The original channel byte from the wire, always
+            present regardless of whether the byte maps to a known ShellChannel.
+        payload: Raw bytes of the frame payload (everything after the channel byte).
+    """
+
+    channel: ShellChannel
+    raw_channel_byte: int
+    payload: bytes
+
+    @property
+    def text(self) -> str:
+        """Decode payload as UTF-8 text (replacement char on invalid bytes)."""
+        return self.payload.decode("utf-8", errors="replace")
+
+    def json(self) -> Dict[str, Any]:
+        """Parse payload as JSON.
+
+        Returns:
+            Parsed JSON object.
+
+        Raises:
+            json.JSONDecodeError: If the payload is not valid JSON.
+        """
+        return json.loads(self.payload)
+
+
+class ShellFramer:
+    r"""Encodes and decodes binary channel-prefix WebSocket frames.
+
+    Stateless — a single instance is safe to reuse across frames.
+
+    Example:
+        framer = ShellFramer()
+
+        # Decode inbound frame
+        frame = framer.decode(raw_bytes)
+        if frame.channel == ShellChannel.STDOUT:
+            sys.stdout.write(frame.text)
+        elif frame.channel == ShellChannel.STATUS:
+            status = frame.json()
+            if status.get("metadata", {}).get("commandSessionId"):
+                print(f"connected: {status['metadata']['commandSessionId']}")
+            elif status.get("status") == "Failure":
+                causes = status.get("details", {}).get("causes", [])
+                code = next((c["message"] for c in causes if c["reason"] == "ExitCode"), None)
+                print(f"shell exited with code {code}")
+
+        # Encode outbound frames
+        ws.send(framer.encode_stdin("ls /workspace\\n"))
+        ws.send(framer.encode_resize(220, 50))
+        ws.send(framer.encode_close())
+    """
+
+    MAX_FRAME_SIZE = 64 * 1024  # matches DP WebSocketFlowController limit
+
+    def decode(self, frame: bytes) -> ShellFrame:
+        """Decode one raw WebSocket binary message into a ShellFrame.
+
+        Args:
+            frame: Raw bytes received from the WebSocket.
+
+        Returns:
+            Decoded ShellFrame.
+
+        Raises:
+            ValueError: If the frame is empty.
+        """
+        if not frame:
+            raise ValueError("Cannot decode empty frame")
+        raw_byte = frame[0]
+        try:
+            channel = ShellChannel(raw_byte)
+        except ValueError:
+            # Unknown channel byte — future protocol extension.  Preserve the
+            # payload so callers can inspect or forward it; use raw_channel_byte
+            # to recover the original wire value.
+            channel = ShellChannel.UNKNOWN
+        return ShellFrame(channel=channel, raw_channel_byte=raw_byte, payload=frame[1:])
+
+    def encode_stdin(self, data: Union[str, bytes]) -> bytes:
+        """Encode keyboard input or paste data as a STDIN frame.
+
+        Large pastes must be chunked into <64 KB segments before calling this
+        method; the server closes the connection on oversized frames.
+
+        Args:
+            data: Text (encoded as UTF-8) or raw bytes to send to the shell.
+
+        Returns:
+            Binary WebSocket frame ready to send.
+
+        Raises:
+            ValueError: If the encoded payload would exceed the 64 KB frame limit.
+        """
+        if isinstance(data, str):
+            data = data.encode("utf-8")
+        if len(data) > self.MAX_FRAME_SIZE - 1:
+            raise ValueError(
+                f"Payload {len(data)} bytes exceeds the 64 KB frame limit. "
+                "Split large pastes into multiple encode_stdin() calls."
+            )
+        return bytes([ShellChannel.STDIN]) + data
+
+    def encode_resize(self, width: int, height: int) -> bytes:
+        """Encode a terminal resize event as a RESIZE frame.
+
+        Send this whenever the terminal window changes size so the PTY
+        reflows output correctly (e.g., on xterm.js onResize).
+
+        Args:
+            width: New terminal width in columns.
+            height: New terminal height in rows.
+
+        Returns:
+            Binary WebSocket frame ready to send.
+
+        Raises:
+            ValueError: If width or height is not a positive integer.
+        """
+        if not isinstance(width, int) or not isinstance(height, int):
+            raise ValueError(
+                f"width and height must be integers, got {type(width).__name__} and {type(height).__name__}"
+            )
+        if width <= 0 or height <= 0:
+            raise ValueError(f"width and height must be positive integers, got width={width}, height={height}")
+        payload = json.dumps({"width": width, "height": height}).encode("utf-8")
+        return bytes([ShellChannel.RESIZE]) + payload
+
+    def encode_heartbeat(self) -> bytes:
+        """Encode an app-level heartbeat frame (channel 0x05, empty payload).
+
+        Browser clients cannot send RFC 6455 Ping frames, so the spec defines
+        channel 0x05 as an application-level keepalive: the client sends this
+        every 30 seconds, and the server echoes a single [0x05] back.  Both
+        directions reset the KARP idle timer, preventing the ~15-minute proxy
+        timeout on quiet connections.
+
+        SDK/CLI clients should prefer RFC 6455 Ping frames (handled automatically
+        by all standard WebSocket libraries).  Use this only when building a
+        browser relay.
+
+        Returns:
+            Binary WebSocket frame ready to send.
+        """
+        return bytes([ShellChannel.HEARTBEAT])
+
+    def encode_close(self) -> bytes:
+        """Encode a graceful-shutdown CLOSE frame (empty payload).
+
+        Returns:
+            Binary WebSocket frame ready to send.
+        """
+        return bytes([ShellChannel.CLOSE])

--- a/src/bedrock_agentcore/runtime/shell/protocol.py
+++ b/src/bedrock_agentcore/runtime/shell/protocol.py
@@ -8,9 +8,9 @@ Channels:
   0x01  STDOUT     Raw bytes, shell → client
   0x02  STDERR     UTF-8 text (platform diagnostics), shell → client
   0x03  STATUS     metav1.Status JSON (shell → client):
-                     Connection confirmation: metadata.commandSessionId present
+                     Connection confirmation: metadata.shellId present
                      {"kind":"Status","apiVersion":"v1",
-                      "metadata":{"commandSessionId":"…","reconnected":bool},"status":"Success"}
+                      "metadata":{"shellId":"…","reconnected":bool},"status":"Success"}
                      Shell exit (code 0):
                      {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Success"}
                      Shell exit (non-zero):
@@ -99,8 +99,8 @@ class ShellFramer:
             sys.stdout.write(frame.text)
         elif frame.channel == ShellChannel.STATUS:
             status = frame.json()
-            if status.get("metadata", {}).get("commandSessionId"):
-                print(f"connected: {status['metadata']['commandSessionId']}")
+            if status.get("metadata", {}).get("shellId"):
+                print(f"connected: {status['metadata']['shellId']}")
             elif status.get("status") == "Failure":
                 causes = status.get("details", {}).get("causes", [])
                 code = next((c["message"] for c in causes if c["reason"] == "ExitCode"), None)

--- a/src/bedrock_agentcore/runtime/shell/session.py
+++ b/src/bedrock_agentcore/runtime/shell/session.py
@@ -1,0 +1,657 @@
+"""High-level async context manager for an interactive shell session."""
+
+import asyncio
+import json
+import logging
+import random
+import uuid
+from collections import deque
+from typing import TYPE_CHECKING, AsyncIterator, Deque, Optional
+
+import websockets
+import websockets.exceptions
+
+from ._validation import parse_runtime_arn, validate_shell_id
+from .auth import AuthMode, OAuthAuth, PresignedAuth
+from .config import _DEFAULT_METADATA_TIMEOUT, ReconnectConfig
+from .protocol import ShellChannel, ShellFrame, ShellFramer
+
+if TYPE_CHECKING:
+    from ..agent_core_runtime_client import AgentCoreRuntimeClient
+
+logger = logging.getLogger(__name__)
+
+
+class ShellSession:
+    r"""Async context manager wrapping a live interactive shell WebSocket session.
+
+    Connects on ``__aenter__``, reads the mandatory metadata frame that carries
+    ``commandSessionId`` and ``reconnected``, and exposes typed send/resize/iterate/close.
+    When ``reconnect_config`` is provided, transparently reconnects on unexpected
+    disconnects using the same ``shell_id`` so the shell's working
+    directory, environment, background jobs, and up to 256 KB of buffered output
+    are preserved.
+
+    Usage — SigV4 (default, server-side Python):
+        client = AgentCoreRuntimeClient("us-west-2")
+        async with client.open_shell(runtime_arn) as shell:
+            await shell.send("cat /etc/os-release\\n")
+            async for frame in shell:
+                if frame.channel == ShellChannel.STDOUT:
+                    print(frame.text, end="", flush=True)
+                elif frame.channel == ShellChannel.STATUS:
+                    # Termination: empty metadata (no commandSessionId).
+                    if not frame.json().get("metadata", {}).get("commandSessionId"):
+                        break
+
+    Usage — presigned URL:
+        async with client.open_shell(
+            runtime_arn,
+            auth=PresignedAuth(expires=120),
+        ) as shell:
+            ...
+
+    Usage — OAuth (browser relay or OAuth-only environments):
+        async with client.open_shell(
+            runtime_arn,
+            auth=OAuthAuth(bearer_token=await get_oauth_token()),
+        ) as shell:
+            ...
+
+    Usage — auto-reconnect:
+        config = ReconnectConfig(max_retries=5, on_reconnect=my_callback)
+        async with client.open_shell(
+            runtime_arn,
+            shell_id="debug",
+            reconnect_config=config,
+        ) as shell:
+            async for frame in shell:      # iterator survives network blips
+                ...
+
+    Usage — manual reconnect after network drop:
+        sid = "debug"   # saved from first session
+        async with client.open_shell(runtime_arn, shell_id=sid) as shell:
+            assert shell.reconnected       # True → up to 256 KB buffered output follows
+            async for frame in shell:
+                ...
+
+    Attributes:
+        shell_id: Confirmed shell identifier echoed by the server in
+            the initial STATUS frame.  Preserve this value across your process
+            restarts — passing the same ID to ``open_shell`` reconnects to the
+            same PTY.
+        session_id: Runtime session ID that routes to the VM hosting this shell.
+            Preserve this alongside ``shell_id`` when reconnecting across process
+            restarts — omitting it may cause the platform to provision a fresh VM
+            where the PTY no longer exists.
+        reconnected: ``True`` when the session resumed an existing PTY (buffered
+            output will arrive as STDOUT frames immediately after connect);
+            ``False`` for a fresh shell.
+        kicked: ``True`` when iteration stopped because another client connected
+            with the same ``shell_id`` (close code 4000).  The PTY is
+            still alive — a new ``open_shell`` call with the same ID will
+            reconnect to it.
+        bytes_dropped: Number of bytes lost from the PTY ring buffer during the
+            most recent disconnect.  Non-zero only when the 256 KB ring buffer
+            overflowed before reconnection completed.  Set after the post-drain
+            STATUS confirmation frame arrives (which follows the buffered STDOUT
+            burst).  Zero if no overflow occurred or on a fresh connection.
+        exit_code: Exit code of the shell process.  ``None`` until the shell
+            exits or if the platform terminated the session without providing an
+            exit code (e.g. an InternalError).  ``0`` for a clean exit;
+            non-zero for a failed command or a signal-killed process.  Set when
+            the termination STATUS frame is processed — check this after the
+            ``async for`` loop ends.
+
+    Example::
+
+        async with client.open_shell(runtime_arn) as shell:
+            await shell.send("make build\\n")
+            async for frame in shell:
+                if frame.channel == ShellChannel.STDOUT:
+                    print(frame.text, end="", flush=True)
+
+        if shell.exit_code:  # None = no code available; 0 = clean exit
+            raise RuntimeError(f"Build failed with exit code {shell.exit_code}")
+    """
+
+    def __init__(
+        self,
+        client: "AgentCoreRuntimeClient",
+        runtime_arn: str,
+        session_id: Optional[str] = None,
+        shell_id: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        auth: AuthMode = "sigv4",
+        reconnect_config: Optional[ReconnectConfig] = None,
+    ) -> None:
+        """Validate inputs and initialise session state; does not connect."""
+        parsed = parse_runtime_arn(runtime_arn)
+        client_region = getattr(client, "region", None)
+        if isinstance(client_region, str) and parsed["region"] != client_region:
+            raise ValueError(
+                f"ARN region {parsed['region']!r} does not match client region {client_region!r}. "
+                "Create a client for the same region as the runtime ARN, or use the ARN's region."
+            )
+        self._client = client
+        self._runtime_arn = runtime_arn
+        self._session_id = session_id
+        # Auto-generate so callers always have a stable reconnect handle even
+        # when they do not supply one up front.
+        if shell_id is not None:
+            validate_shell_id(shell_id)
+            self._shell_id = shell_id
+        else:
+            self._shell_id = str(uuid.uuid4())
+        self._endpoint_name = endpoint_name
+        self._auth = auth
+        self._reconnect_config = reconnect_config
+        self._framer = ShellFramer()
+        self._ws: Optional[object] = None
+        self._closed = False
+        # Frames received during _read_metadata_frame that arrived before the
+        # 0x03 confirmation (e.g. first shell prompt on 0x01).
+        self._pending_frames: Deque[ShellFrame] = deque()
+
+        self.shell_id: str = self._shell_id
+        self.session_id: Optional[str] = self._session_id
+        self.reconnected: bool = False
+        self.kicked: bool = False
+        self.bytes_dropped: int = 0
+        self.exit_code: Optional[int] = None
+
+    async def __aenter__(self) -> "ShellSession":
+        """Connect and read the initial metadata frame."""
+        try:
+            await self._connect()
+        except Exception as exc:
+            logger.error("Failed to connect (shell_id=%r): %s", self._shell_id, exc)
+            self._closed = True
+            self._ws = None
+            raise
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        """Send a graceful CLOSE frame and close the WebSocket."""
+        await self.close()
+
+    # ── Connection management ─────────────────────────────────────────────────
+
+    async def _connect(self) -> None:
+        """Open the WebSocket and consume the initial STATUS metadata frame."""
+        self._pending_frames.clear()
+        self.reconnected = False
+        self.kicked = False
+
+        auth = self._auth
+        try:
+            if isinstance(auth, OAuthAuth):
+                url, subprotocols = self._client.connect_shell_oauth(
+                    self._runtime_arn,
+                    bearer_token=auth.bearer_token,
+                    session_id=self._session_id,
+                    endpoint_name=self._endpoint_name,
+                    shell_id=self._shell_id,
+                )
+                self._ws = await websockets.connect(url, subprotocols=subprotocols)
+            elif isinstance(auth, PresignedAuth):
+                url = self._client.connect_shell_presigned(
+                    self._runtime_arn,
+                    session_id=self._session_id,
+                    endpoint_name=self._endpoint_name,
+                    shell_id=self._shell_id,
+                    expires=auth.expires,
+                )
+                self._ws = await websockets.connect(url)
+            else:
+                # "sigv4" — default path
+                url, headers = self._client.connect_shell(
+                    self._runtime_arn,
+                    session_id=self._session_id,
+                    endpoint_name=self._endpoint_name,
+                    shell_id=self._shell_id,
+                )
+                self._ws = await websockets.connect(url, additional_headers=headers)
+        except websockets.exceptions.InvalidStatus as exc:
+            body = exc.response.body.decode("utf-8", errors="replace")
+            logger.error(
+                "Server rejected WebSocket connection: HTTP %d %s%s (shell_id=%r)",
+                exc.response.status_code,
+                exc.response.reason_phrase,
+                f" — {body}" if body else "",
+                self._shell_id,
+            )
+            raise
+
+        # read commandSessionId from the 101 response header (primary
+        # path for non-browser clients). The 0x03 frame is the fallback for
+        # browser clients that cannot read 101 headers.
+        header_csid = getattr(self._ws.response, "headers", {}).get("X-Command-Session-Id")
+        if header_csid:
+            self.shell_id = header_csid
+            logger.debug("commandSessionId from 101 header: %r", header_csid)
+
+        await self._read_metadata_frame()
+        if self._ws is not None:
+            self._closed = False
+
+    async def _read_metadata_frame(self) -> None:
+        """Consume the first STATUS frame carrying connection confirmation.
+
+        Both the 0x03 confirmation and the first 0x01 stdout
+        frame are sent after upgrade but their order is non-deterministic.  We
+        wait for a 0x03 frame with metadata.commandSessionId.  Any 0x01 frames
+        that arrive first are stashed in self._pending_frames so __anext__ can
+        yield them in order.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _DEFAULT_METADATA_TIMEOUT
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                logger.warning(
+                    "STATUS confirmation not received within %.1fs (deadline exceeded "
+                    "processing earlier frames). Proceeding with client-generated "
+                    "shell_id=%r — reconnected flag may be incorrect.",
+                    _DEFAULT_METADATA_TIMEOUT,
+                    self._shell_id,
+                )
+                return
+            try:
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=remaining)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Timed out waiting for STATUS confirmation after %.1fs "
+                    "(server did not respond). Proceeding with client-generated "
+                    "shell_id=%r — reconnected flag may be incorrect.",
+                    _DEFAULT_METADATA_TIMEOUT,
+                    self._shell_id,
+                )
+                return
+            except (websockets.exceptions.ConnectionClosedOK, websockets.exceptions.ConnectionClosedError) as exc:
+                # Server closed before sending STATUS confirmation — session never became usable.
+                logger.warning("WebSocket closed before STATUS confirmation (shell_id=%r): %s", self._shell_id, exc)
+                self._ws = None
+                self._closed = True
+                raise
+            except Exception as exc:
+                logger.error("Unexpected error waiting for STATUS frame (shell_id=%r): %s", self._shell_id, exc)
+                self._ws = None
+                self._closed = True
+                raise
+            if not isinstance(raw, bytes):
+                continue
+            frame = self._framer.decode(raw)
+            if frame.channel == ShellChannel.STATUS:
+                try:
+                    status = frame.json()
+                    meta = status.get("metadata", {})
+                    if meta.get("commandSessionId"):
+                        # This is the connection confirmation frame.
+                        self.shell_id = meta["commandSessionId"]
+                        self.reconnected = bool(meta.get("reconnected", False))
+                        return
+                    else:
+                        # Termination status — stash for __anext__.
+                        self._pending_frames.append(frame)
+                        return
+                except (json.JSONDecodeError, KeyError):
+                    logger.warning("Received malformed STATUS frame during connect; skipping: %r", raw)
+            else:
+                # Non-STATUS frame (e.g. first stdout prompt) — stash for __anext__.
+                self._pending_frames.append(frame)
+
+    async def _run_inner_retry_loop(self, cfg: ReconnectConfig) -> bool:
+        """Run one inner retry loop (up to max_retries attempts with exponential backoff).
+
+        Returns True if a reconnect succeeded, False if all attempts failed.
+        """
+        delay = cfg.base_delay
+        attempt = 0
+
+        while attempt < cfg.max_retries:
+            attempt += 1
+            logger.info("Reconnect attempt %d (shell_id=%s)", attempt, self._shell_id)
+            try:
+                await self._connect()
+                logger.info("Reconnected (reconnected=%s)", self.reconnected)
+                if cfg.on_reconnect is not None:
+                    result = cfg.on_reconnect(self.reconnected)
+                    if asyncio.iscoroutine(result):
+                        await result
+                return True
+            except Exception as exc:
+                logger.info("Reconnect attempt %d failed: %s", attempt, exc)
+                if attempt >= cfg.max_retries:
+                    break
+                jitter = random.uniform(-0.25 * delay, 0.25 * delay)
+                await asyncio.sleep(min(delay + jitter, cfg.max_delay))
+                delay = min(delay * 2, cfg.max_delay)
+
+        return False
+
+    async def _reconnect_with_backoff(self) -> bool:
+        """Attempt to reconnect using a two-layer retry strategy.
+
+        Inner loop: exponential backoff up to max_retries attempts.
+        Outer loop: after inner loop exhaustion, wait outer_loop_delay seconds
+            and run a fresh inner loop — until reconnect_window seconds have
+            elapsed since the first disconnect.
+
+        Returns:
+            True if reconnect succeeded, False if the reconnection window expired.
+        """
+        cfg = self._reconnect_config
+        if cfg is None:
+            return False
+
+        if cfg.reconnect_window is not None and cfg.reconnect_window <= 0:
+            logger.warning(
+                "reconnect_window=%.1f — reconnection disabled (shell_id=%s)",
+                cfg.reconnect_window,
+                self._shell_id,
+            )
+            return False
+
+        loop = asyncio.get_running_loop()
+        window_start = loop.time()
+        outer_attempt = 0
+
+        while True:
+            outer_attempt += 1
+            if outer_attempt > 1:
+                logger.info(
+                    "Starting outer retry cycle %d (shell_id=%s)",
+                    outer_attempt,
+                    self._shell_id,
+                )
+            if await self._run_inner_retry_loop(cfg):
+                return True
+
+            # Inner loop exhausted — check if the reconnection window allows another cycle.
+            if cfg.reconnect_window is not None:
+                elapsed = loop.time() - window_start
+                if elapsed >= cfg.reconnect_window:
+                    logger.warning(
+                        "Reconnection window of %.0fs expired after %.0fs, giving up (shell_id=%s)",
+                        cfg.reconnect_window,
+                        elapsed,
+                        self._shell_id,
+                    )
+                    return False
+
+            logger.info(
+                "Inner loop exhausted, waiting %.0fs before next outer retry cycle (shell_id=%s)",
+                cfg.outer_loop_delay,
+                self._shell_id,
+            )
+            await asyncio.sleep(cfg.outer_loop_delay)
+
+    # ── Outbound ──────────────────────────────────────────────────────────────
+
+    async def send(self, data: str) -> None:
+        """Send keystrokes or paste text to the shell as a STDIN frame.
+
+        Args:
+            data: Text to send.  Encoded as UTF-8 before framing.
+        """
+        if self._ws is None:
+            logger.error("send() called on a closed ShellSession (shell_id=%r)", self._shell_id)
+            raise RuntimeError("Cannot send on a closed ShellSession")
+        try:
+            await self._ws.send(self._framer.encode_stdin(data))
+        except Exception as exc:
+            logger.error("Failed to send STDIN frame (shell_id=%r): %s", self._shell_id, exc)
+            raise
+
+    async def send_bytes(self, data: bytes) -> None:
+        """Send raw bytes to the shell as a STDIN frame (e.g. escape sequences).
+
+        Args:
+            data: Raw bytes to send.
+        """
+        if self._ws is None:
+            logger.error(
+                "send_bytes() called on a closed ShellSession (shell_id=%r)",
+                self._shell_id,
+            )
+            raise RuntimeError("Cannot send on a closed ShellSession")
+        try:
+            await self._ws.send(self._framer.encode_stdin(data))
+        except Exception as exc:
+            logger.error(
+                "Failed to send STDIN (bytes) frame (shell_id=%r): %s",
+                self._shell_id,
+                exc,
+            )
+            raise
+
+    async def resize(self, width: int, height: int) -> None:
+        """Notify the PTY of a terminal resize.
+
+        Args:
+            width: New terminal width in columns.
+            height: New terminal height in rows.
+        """
+        if self._ws is None:
+            logger.error(
+                "resize() called on a closed ShellSession (shell_id=%r)",
+                self._shell_id,
+            )
+            raise RuntimeError("Cannot send on a closed ShellSession")
+        try:
+            await self._ws.send(self._framer.encode_resize(width, height))
+        except Exception as exc:
+            logger.error("Failed to send RESIZE frame (shell_id=%r): %s", self._shell_id, exc)
+            raise
+
+    async def close(self) -> None:
+        """Send a graceful CLOSE frame and close the underlying WebSocket."""
+        self._closed = True
+        if self._ws is not None:
+            try:
+                await self._ws.send(self._framer.encode_close())
+            except Exception as exc:
+                # Best-effort — the connection may already be gone.
+                logger.debug("Failed to send CLOSE frame during close() (shell_id=%r): %s", self._shell_id, exc)
+            try:
+                await self._ws.close()
+            except Exception as exc:
+                # Best-effort — swallow so close() never raises.
+                logger.debug("Failed to close WebSocket during close() (shell_id=%r): %s", self._shell_id, exc)
+            self._ws = None
+
+    # ── Inbound ───────────────────────────────────────────────────────────────
+
+    def __aiter__(self) -> AsyncIterator[ShellFrame]:
+        """Return self as the async iterator."""
+        return self
+
+    @staticmethod
+    def _is_termination_status(status: dict) -> bool:
+        """Return True if a parsed STATUS frame payload signals shell exit or error.
+
+        Connection confirmation frames have metadata.commandSessionId present.
+        Termination frames have an empty metadata dict.
+        """
+        meta = status.get("metadata", {})
+        if meta.get("commandSessionId"):
+            # This is a connection confirmation frame, not a termination.
+            return False
+        # Empty metadata → shell exit (Success = code 0, Failure = non-zero / error).
+        return True
+
+    @staticmethod
+    def _is_confirmation_status(status: dict) -> bool:
+        """Return True if a parsed STATUS frame is a connection confirmation."""
+        return bool(status.get("metadata", {}).get("commandSessionId"))
+
+    @staticmethod
+    def _parse_exit_code(status: dict) -> Optional[int]:
+        """Extract the integer exit code from a termination STATUS payload.
+
+        Returns 0 for a successful exit, or the integer code from the ExitCode
+        cause for a non-zero exit.  Returns None if the payload is missing the
+        expected fields (e.g. a platform InternalError without an ExitCode cause)
+        so callers can distinguish "exited cleanly" from "no exit code available".
+        """
+        if status.get("status") == "Success":
+            return 0
+        causes = status.get("details", {}).get("causes", [])
+        for cause in causes:
+            if cause.get("reason") == "ExitCode":
+                try:
+                    return int(cause["message"])
+                except (ValueError, KeyError):
+                    pass
+        return None
+
+    async def __anext__(self) -> ShellFrame:
+        """Yield the next inbound frame, reconnecting on drop if configured.
+
+        When ``reconnect_config`` is set, a WebSocket disconnect triggers an
+        automatic reconnect attempt using the same ``shell_id``.  The
+        iterator resumes transparently — callers do not need to re-enter the
+        context manager.  The ``on_reconnect`` callback fires after each
+        successful reconnect so callers can react to the ``reconnected`` flag
+        and the incoming buffered-output burst.
+
+        close code 4000 ("kicked by new connection") MUST NOT trigger auto-reconnect.
+        The iterator stops and sets ``self.kicked = True`` so callers can distinguish this case.
+
+        Raises:
+            StopAsyncIteration: When the shell exits cleanly (CLOSE frame or
+                STATUS frame with empty metadata), when ``close()`` has been
+                called, or when reconnect attempts are exhausted.
+        """
+        while True:
+            # Drain any frames buffered during the metadata handshake first.
+            if self._pending_frames:
+                frame = self._pending_frames.popleft()
+                if frame.channel == ShellChannel.CLOSE:
+                    logger.debug(
+                        "CLOSE frame received from pending queue (shell_id=%r)",
+                        self._shell_id,
+                    )
+                    raise StopAsyncIteration from None
+                if frame.channel == ShellChannel.STATUS:
+                    try:
+                        status = frame.json()
+                        if self._is_termination_status(status):
+                            self.exit_code = self._parse_exit_code(status)
+                            self._closed = True
+                            return frame
+                    except (json.JSONDecodeError, KeyError):
+                        logger.warning(
+                            "Received malformed STATUS frame in pending queue; skipping termination check: %r",
+                            frame,
+                        )
+                return frame
+
+            if self._closed or self._ws is None:
+                logger.debug("Session already closed or disconnected (shell_id=%r)", self._shell_id)
+                raise StopAsyncIteration from None
+
+            try:
+                raw = await self._ws.recv()
+            except Exception as exc:
+                if self._closed:
+                    logger.debug(
+                        "WebSocket error after close() (shell_id=%r): %s",
+                        self._shell_id,
+                        exc,
+                    )
+                    raise StopAsyncIteration from None
+                # Detect close code 4000 (kicked by new connection) — must NOT reconnect.
+                if isinstance(exc, websockets.exceptions.ConnectionClosedOK):
+                    if exc.rcvd is not None and exc.rcvd.code == 1001:
+                        # Code 1001 "Going Away" — DP/proxy restarting; MUST reconnect.
+                        if self._reconnect_config is None:
+                            logger.warning(
+                                "Server sent 1001 Going Away but no reconnect_config "
+                                "provided — stopping iteration. Reconnect with the same "
+                                "shell_id=%r to resume the PTY.",
+                                self._shell_id,
+                            )
+                            self._ws = None
+                            self._closed = True
+                            raise StopAsyncIteration from None
+                        logger.info(
+                            "WebSocket closed with 1001 Going Away — will reconnect (shell_id=%r)",
+                            self._shell_id,
+                        )
+                    else:
+                        # Code 1000 "Normal Closure" — shell exited or graceful shutdown.
+                        logger.info(
+                            "WebSocket closed cleanly (shell_id=%r): %s",
+                            self._shell_id,
+                            exc,
+                        )
+                        self._ws = None
+                        self._closed = True
+                        raise StopAsyncIteration from None
+                if isinstance(exc, websockets.exceptions.ConnectionClosedError):
+                    if exc.rcvd is not None and exc.rcvd.code == 4000:
+                        logger.info(
+                            "Shell session kicked (close code 4000) — will not reconnect (shell_id=%r)",
+                            self._shell_id,
+                        )
+                        self._ws = None
+                        self.kicked = True
+                        raise StopAsyncIteration from None
+                    logger.warning(
+                        "WebSocket closed unexpectedly (shell_id=%r): %s",
+                        self._shell_id,
+                        exc,
+                    )
+                reconnected = await self._reconnect_with_backoff()
+                if not reconnected:
+                    logger.warning(
+                        "Reconnect exhausted, stopping iteration (shell_id=%r)",
+                        self._shell_id,
+                    )
+                    self._ws = None
+                    self._closed = True
+                    raise StopAsyncIteration from None
+                # Iterator resumes from the top of the loop with the new WebSocket.
+                continue
+
+            if not isinstance(raw, bytes):
+                continue
+
+            frame = self._framer.decode(raw)
+
+            if frame.channel == ShellChannel.CLOSE:
+                logger.debug("CLOSE frame received (shell_id=%r)", self._shell_id)
+                raise StopAsyncIteration from None
+
+            if frame.channel == ShellChannel.HEARTBEAT:
+                # Wire-level keepalive — swallow the server echo, don't surface to caller.
+                continue
+
+            if frame.channel == ShellChannel.STATUS:
+                try:
+                    status = frame.json()
+                    if self._is_confirmation_status(status):
+                        # Second confirmation frame (post-drain) — carries
+                        # bytesDropped when the 256 KB ring buffer overflowed.
+                        # Swallow it; surface bytesDropped via attribute + warning.
+                        dropped = status.get("metadata", {}).get("bytesDropped", 0)
+                        if dropped:
+                            self.bytes_dropped = dropped
+                            logger.warning(
+                                "%d bytes of PTY output lost during disconnect (ring buffer overflow) (shell_id=%r)",
+                                dropped,
+                                self._shell_id,
+                            )
+                        continue
+                    if self._is_termination_status(status):
+                        # Shell exited — mark closed so the next __anext__ call
+                        # stops immediately instead of triggering auto-reconnect.
+                        self.exit_code = self._parse_exit_code(status)
+                        self._closed = True
+                        return frame
+                except (json.JSONDecodeError, KeyError):
+                    logger.warning("Received malformed STATUS frame; skipping termination check: %r", frame)
+
+            return frame

--- a/src/bedrock_agentcore/runtime/shell/session.py
+++ b/src/bedrock_agentcore/runtime/shell/session.py
@@ -29,9 +29,9 @@ class ShellSession:
     Connects on ``__aenter__``, reads the mandatory metadata frame that carries
     ``shellId`` and ``reconnected``, and exposes typed send/resize/iterate/close.
     When ``reconnect_config`` is provided, transparently reconnects on unexpected
-    disconnects using the same ``shell_id`` so the shell's working
-    directory, environment, background jobs, and up to 256 KB of buffered output
-    are preserved.
+    disconnects using the same ``shell_id`` and ``session_id`` so the shell's
+    working directory, environment, background jobs, and up to 256 KB of buffered
+    output are preserved.
 
     Usage — SigV4 (default, server-side Python):
         client = AgentCoreRuntimeClient("us-west-2")
@@ -70,8 +70,22 @@ class ShellSession:
                 ...
 
     Usage — manual reconnect after network drop:
-        sid = "debug"   # saved from first session
-        async with client.open_shell(runtime_arn, shell_id=sid) as shell:
+        # Both shell_id AND session_id are required.  shell_id names the PTY;
+        # session_id routes to the VM that hosts it.
+        # After an abrupt drop _ws is None, so __aexit__ skips the CLOSE frame
+        # and the PTY stays alive on the server for the reconnect.
+        shell_id = "debug"
+        session_id = str(uuid.uuid4())   # generate once, reuse on every reconnect
+
+        async with client.open_shell(
+            runtime_arn, shell_id=shell_id, session_id=session_id
+        ) as shell:
+            async for frame in shell:
+                ...   # StopAsyncIteration when the network drops
+
+        async with client.open_shell(
+            runtime_arn, shell_id=shell_id, session_id=session_id
+        ) as shell:
             assert shell.reconnected       # True → up to 256 KB buffered output follows
             async for frame in shell:
                 ...

--- a/src/bedrock_agentcore/runtime/shell/session.py
+++ b/src/bedrock_agentcore/runtime/shell/session.py
@@ -81,8 +81,9 @@ class ShellSession:
             restarts — passing the same ID to ``open_shell`` reconnects to the
             same PTY.
         session_id: Runtime session ID that routes to the VM hosting this shell.
-            Preserve this alongside ``shell_id`` when reconnecting across process
-            restarts — omitting it may cause the platform to provision a fresh VM
+            Auto-generated if not supplied.  Preserve this alongside ``shell_id``
+            when reconnecting across process restarts — passing a different (or
+            omitted) session ID may cause the platform to provision a fresh VM
             where the PTY no longer exists.
         reconnected: ``True`` when the session resumed an existing PTY (buffered
             output will arrive as STDOUT frames immediately after connect);
@@ -135,14 +136,6 @@ class ShellSession:
             )
         self._client = client
         self._runtime_arn = runtime_arn
-        self._session_id = session_id
-        # Auto-generate so callers always have a stable reconnect handle even
-        # when they do not supply one up front.
-        if shell_id is not None:
-            validate_shell_id(shell_id)
-            self._shell_id = shell_id
-        else:
-            self._shell_id = str(uuid.uuid4())
         self._endpoint_name = endpoint_name
         self._auth = auth
         self._reconnect_config = reconnect_config
@@ -153,8 +146,13 @@ class ShellSession:
         # 0x03 confirmation (e.g. first shell prompt on 0x01).
         self._pending_frames: Deque[ShellFrame] = deque()
 
-        self.shell_id: str = self._shell_id
-        self.session_id: Optional[str] = self._session_id
+        if shell_id is not None:
+            validate_shell_id(shell_id)
+        # Auto-generate stable reconnect handles when the caller omits them.
+        # Without a fixed session_id, each _connect() would route to a different
+        # VM and shell_id would never be found → reconnected=False always.
+        self.shell_id: str = shell_id or str(uuid.uuid4())
+        self.session_id: str = session_id or str(uuid.uuid4())
         self.reconnected: bool = False
         self.kicked: bool = False
         self.bytes_dropped: int = 0
@@ -165,7 +163,7 @@ class ShellSession:
         try:
             await self._connect()
         except Exception as exc:
-            logger.error("Failed to connect (shell_id=%r): %s", self._shell_id, exc)
+            logger.error("Failed to connect (shell_id=%r): %s", self.shell_id, exc)
             self._closed = True
             self._ws = None
             raise
@@ -189,17 +187,17 @@ class ShellSession:
                 url, subprotocols = self._client.connect_shell_oauth(
                     self._runtime_arn,
                     bearer_token=auth.bearer_token,
-                    session_id=self._session_id,
+                    session_id=self.session_id,
                     endpoint_name=self._endpoint_name,
-                    shell_id=self._shell_id,
+                    shell_id=self.shell_id,
                 )
                 self._ws = await websockets.connect(url, subprotocols=subprotocols)
             elif isinstance(auth, PresignedAuth):
                 url = self._client.connect_shell_presigned(
                     self._runtime_arn,
-                    session_id=self._session_id,
+                    session_id=self.session_id,
                     endpoint_name=self._endpoint_name,
-                    shell_id=self._shell_id,
+                    shell_id=self.shell_id,
                     expires=auth.expires,
                 )
                 self._ws = await websockets.connect(url)
@@ -207,9 +205,9 @@ class ShellSession:
                 # "sigv4" — default path
                 url, headers = self._client.connect_shell(
                     self._runtime_arn,
-                    session_id=self._session_id,
+                    session_id=self.session_id,
                     endpoint_name=self._endpoint_name,
-                    shell_id=self._shell_id,
+                    shell_id=self.shell_id,
                 )
                 self._ws = await websockets.connect(url, additional_headers=headers)
         except websockets.exceptions.InvalidStatus as exc:
@@ -219,17 +217,22 @@ class ShellSession:
                 exc.response.status_code,
                 exc.response.reason_phrase,
                 f" — {body}" if body else "",
-                self._shell_id,
+                self.shell_id,
             )
             raise
 
         # read commandSessionId from the 101 response header (primary
         # path for non-browser clients). The 0x03 frame is the fallback for
         # browser clients that cannot read 101 headers.
-        header_csid = getattr(self._ws.response, "headers", {}).get("X-Command-Session-Id")
+        response_headers = getattr(self._ws.response, "headers", {})
+        header_csid = response_headers.get("X-Command-Session-Id")
         if header_csid:
             self.shell_id = header_csid
             logger.debug("commandSessionId from 101 header: %r", header_csid)
+        header_sid = response_headers.get("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id")
+        if header_sid:
+            self.session_id = header_sid
+            logger.debug("sessionId from 101 header: %r", header_sid)
 
         await self._read_metadata_frame()
         if self._ws is not None:
@@ -254,7 +257,7 @@ class ShellSession:
                     "processing earlier frames). Proceeding with client-generated "
                     "shell_id=%r — reconnected flag may be incorrect.",
                     _DEFAULT_METADATA_TIMEOUT,
-                    self._shell_id,
+                    self.shell_id,
                 )
                 return
             try:
@@ -265,17 +268,17 @@ class ShellSession:
                     "(server did not respond). Proceeding with client-generated "
                     "shell_id=%r — reconnected flag may be incorrect.",
                     _DEFAULT_METADATA_TIMEOUT,
-                    self._shell_id,
+                    self.shell_id,
                 )
                 return
             except (websockets.exceptions.ConnectionClosedOK, websockets.exceptions.ConnectionClosedError) as exc:
                 # Server closed before sending STATUS confirmation — session never became usable.
-                logger.warning("WebSocket closed before STATUS confirmation (shell_id=%r): %s", self._shell_id, exc)
+                logger.warning("WebSocket closed before STATUS confirmation (shell_id=%r): %s", self.shell_id, exc)
                 self._ws = None
                 self._closed = True
                 raise
             except Exception as exc:
-                logger.error("Unexpected error waiting for STATUS frame (shell_id=%r): %s", self._shell_id, exc)
+                logger.error("Unexpected error waiting for STATUS frame (shell_id=%r): %s", self.shell_id, exc)
                 self._ws = None
                 self._closed = True
                 raise
@@ -311,7 +314,7 @@ class ShellSession:
 
         while attempt < cfg.max_retries:
             attempt += 1
-            logger.info("Reconnect attempt %d (shell_id=%s)", attempt, self._shell_id)
+            logger.info("Reconnect attempt %d (shell_id=%s)", attempt, self.shell_id)
             try:
                 await self._connect()
                 logger.info("Reconnected (reconnected=%s)", self.reconnected)
@@ -349,7 +352,7 @@ class ShellSession:
             logger.warning(
                 "reconnect_window=%.1f — reconnection disabled (shell_id=%s)",
                 cfg.reconnect_window,
-                self._shell_id,
+                self.shell_id,
             )
             return False
 
@@ -363,7 +366,7 @@ class ShellSession:
                 logger.info(
                     "Starting outer retry cycle %d (shell_id=%s)",
                     outer_attempt,
-                    self._shell_id,
+                    self.shell_id,
                 )
             if await self._run_inner_retry_loop(cfg):
                 return True
@@ -376,14 +379,14 @@ class ShellSession:
                         "Reconnection window of %.0fs expired after %.0fs, giving up (shell_id=%s)",
                         cfg.reconnect_window,
                         elapsed,
-                        self._shell_id,
+                        self.shell_id,
                     )
                     return False
 
             logger.info(
                 "Inner loop exhausted, waiting %.0fs before next outer retry cycle (shell_id=%s)",
                 cfg.outer_loop_delay,
-                self._shell_id,
+                self.shell_id,
             )
             await asyncio.sleep(cfg.outer_loop_delay)
 
@@ -396,12 +399,12 @@ class ShellSession:
             data: Text to send.  Encoded as UTF-8 before framing.
         """
         if self._ws is None:
-            logger.error("send() called on a closed ShellSession (shell_id=%r)", self._shell_id)
+            logger.error("send() called on a closed ShellSession (shell_id=%r)", self.shell_id)
             raise RuntimeError("Cannot send on a closed ShellSession")
         try:
             await self._ws.send(self._framer.encode_stdin(data))
         except Exception as exc:
-            logger.error("Failed to send STDIN frame (shell_id=%r): %s", self._shell_id, exc)
+            logger.error("Failed to send STDIN frame (shell_id=%r): %s", self.shell_id, exc)
             raise
 
     async def send_bytes(self, data: bytes) -> None:
@@ -413,7 +416,7 @@ class ShellSession:
         if self._ws is None:
             logger.error(
                 "send_bytes() called on a closed ShellSession (shell_id=%r)",
-                self._shell_id,
+                self.shell_id,
             )
             raise RuntimeError("Cannot send on a closed ShellSession")
         try:
@@ -421,7 +424,7 @@ class ShellSession:
         except Exception as exc:
             logger.error(
                 "Failed to send STDIN (bytes) frame (shell_id=%r): %s",
-                self._shell_id,
+                self.shell_id,
                 exc,
             )
             raise
@@ -436,13 +439,13 @@ class ShellSession:
         if self._ws is None:
             logger.error(
                 "resize() called on a closed ShellSession (shell_id=%r)",
-                self._shell_id,
+                self.shell_id,
             )
             raise RuntimeError("Cannot send on a closed ShellSession")
         try:
             await self._ws.send(self._framer.encode_resize(width, height))
         except Exception as exc:
-            logger.error("Failed to send RESIZE frame (shell_id=%r): %s", self._shell_id, exc)
+            logger.error("Failed to send RESIZE frame (shell_id=%r): %s", self.shell_id, exc)
             raise
 
     async def close(self) -> None:
@@ -453,12 +456,12 @@ class ShellSession:
                 await self._ws.send(self._framer.encode_close())
             except Exception as exc:
                 # Best-effort — the connection may already be gone.
-                logger.debug("Failed to send CLOSE frame during close() (shell_id=%r): %s", self._shell_id, exc)
+                logger.debug("Failed to send CLOSE frame during close() (shell_id=%r): %s", self.shell_id, exc)
             try:
                 await self._ws.close()
             except Exception as exc:
                 # Best-effort — swallow so close() never raises.
-                logger.debug("Failed to close WebSocket during close() (shell_id=%r): %s", self._shell_id, exc)
+                logger.debug("Failed to close WebSocket during close() (shell_id=%r): %s", self.shell_id, exc)
             self._ws = None
 
     # ── Inbound ───────────────────────────────────────────────────────────────
@@ -531,7 +534,7 @@ class ShellSession:
                 if frame.channel == ShellChannel.CLOSE:
                     logger.debug(
                         "CLOSE frame received from pending queue (shell_id=%r)",
-                        self._shell_id,
+                        self.shell_id,
                     )
                     raise StopAsyncIteration from None
                 if frame.channel == ShellChannel.STATUS:
@@ -549,7 +552,7 @@ class ShellSession:
                 return frame
 
             if self._closed or self._ws is None:
-                logger.debug("Session already closed or disconnected (shell_id=%r)", self._shell_id)
+                logger.debug("Session already closed or disconnected (shell_id=%r)", self.shell_id)
                 raise StopAsyncIteration from None
 
             try:
@@ -558,7 +561,7 @@ class ShellSession:
                 if self._closed:
                     logger.debug(
                         "WebSocket error after close() (shell_id=%r): %s",
-                        self._shell_id,
+                        self.shell_id,
                         exc,
                     )
                     raise StopAsyncIteration from None
@@ -571,20 +574,20 @@ class ShellSession:
                                 "Server sent 1001 Going Away but no reconnect_config "
                                 "provided — stopping iteration. Reconnect with the same "
                                 "shell_id=%r to resume the PTY.",
-                                self._shell_id,
+                                self.shell_id,
                             )
                             self._ws = None
                             self._closed = True
                             raise StopAsyncIteration from None
                         logger.info(
                             "WebSocket closed with 1001 Going Away — will reconnect (shell_id=%r)",
-                            self._shell_id,
+                            self.shell_id,
                         )
                     else:
                         # Code 1000 "Normal Closure" — shell exited or graceful shutdown.
                         logger.info(
                             "WebSocket closed cleanly (shell_id=%r): %s",
-                            self._shell_id,
+                            self.shell_id,
                             exc,
                         )
                         self._ws = None
@@ -594,21 +597,21 @@ class ShellSession:
                     if exc.rcvd is not None and exc.rcvd.code == 4000:
                         logger.info(
                             "Shell session kicked (close code 4000) — will not reconnect (shell_id=%r)",
-                            self._shell_id,
+                            self.shell_id,
                         )
                         self._ws = None
                         self.kicked = True
                         raise StopAsyncIteration from None
                     logger.warning(
                         "WebSocket closed unexpectedly (shell_id=%r): %s",
-                        self._shell_id,
+                        self.shell_id,
                         exc,
                     )
                 reconnected = await self._reconnect_with_backoff()
                 if not reconnected:
                     logger.warning(
                         "Reconnect exhausted, stopping iteration (shell_id=%r)",
-                        self._shell_id,
+                        self.shell_id,
                     )
                     self._ws = None
                     self._closed = True
@@ -622,7 +625,7 @@ class ShellSession:
             frame = self._framer.decode(raw)
 
             if frame.channel == ShellChannel.CLOSE:
-                logger.debug("CLOSE frame received (shell_id=%r)", self._shell_id)
+                logger.debug("CLOSE frame received (shell_id=%r)", self.shell_id)
                 raise StopAsyncIteration from None
 
             if frame.channel == ShellChannel.HEARTBEAT:
@@ -642,7 +645,7 @@ class ShellSession:
                             logger.warning(
                                 "%d bytes of PTY output lost during disconnect (ring buffer overflow) (shell_id=%r)",
                                 dropped,
-                                self._shell_id,
+                                self.shell_id,
                             )
                         continue
                     if self._is_termination_status(status):

--- a/src/bedrock_agentcore/runtime/shell/session.py
+++ b/src/bedrock_agentcore/runtime/shell/session.py
@@ -15,6 +15,7 @@ from ._validation import parse_runtime_arn, validate_shell_id
 from .auth import AuthMode, OAuthAuth, PresignedAuth
 from .config import _DEFAULT_METADATA_TIMEOUT, ReconnectConfig
 from .protocol import ShellChannel, ShellFrame, ShellFramer
+from ..models import SESSION_HEADER, SHELL_ID_HEADER
 
 if TYPE_CHECKING:
     from ..agent_core_runtime_client import AgentCoreRuntimeClient
@@ -26,7 +27,7 @@ class ShellSession:
     r"""Async context manager wrapping a live interactive shell WebSocket session.
 
     Connects on ``__aenter__``, reads the mandatory metadata frame that carries
-    ``commandSessionId`` and ``reconnected``, and exposes typed send/resize/iterate/close.
+    ``shellId`` and ``reconnected``, and exposes typed send/resize/iterate/close.
     When ``reconnect_config`` is provided, transparently reconnects on unexpected
     disconnects using the same ``shell_id`` so the shell's working
     directory, environment, background jobs, and up to 256 KB of buffered output
@@ -40,8 +41,8 @@ class ShellSession:
                 if frame.channel == ShellChannel.STDOUT:
                     print(frame.text, end="", flush=True)
                 elif frame.channel == ShellChannel.STATUS:
-                    # Termination: empty metadata (no commandSessionId).
-                    if not frame.json().get("metadata", {}).get("commandSessionId"):
+                    # Termination: empty metadata (no shellId).
+                    if not frame.json().get("metadata", {}).get("shellId"):
                         break
 
     Usage — presigned URL:
@@ -221,15 +222,15 @@ class ShellSession:
             )
             raise
 
-        # read commandSessionId from the 101 response header (primary
-        # path for non-browser clients). The 0x03 frame is the fallback for
-        # browser clients that cannot read 101 headers.
+        # read shellId from the 101 response header (primary path for
+        # non-browser clients). The 0x03 frame is the fallback for browser
+        # clients that cannot read 101 headers.
         response_headers = getattr(self._ws.response, "headers", {})
-        header_csid = response_headers.get("X-Command-Session-Id")
+        header_csid = response_headers.get(SHELL_ID_HEADER)
         if header_csid:
             self.shell_id = header_csid
-            logger.debug("commandSessionId from 101 header: %r", header_csid)
-        header_sid = response_headers.get("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id")
+            logger.debug("shellId from 101 header: %r", header_csid)
+        header_sid = response_headers.get(SESSION_HEADER)
         if header_sid:
             self.session_id = header_sid
             logger.debug("sessionId from 101 header: %r", header_sid)
@@ -243,7 +244,7 @@ class ShellSession:
 
         Both the 0x03 confirmation and the first 0x01 stdout
         frame are sent after upgrade but their order is non-deterministic.  We
-        wait for a 0x03 frame with metadata.commandSessionId.  Any 0x01 frames
+        wait for a 0x03 frame with metadata.shellId.  Any 0x01 frames
         that arrive first are stashed in self._pending_frames so __anext__ can
         yield them in order.
         """
@@ -289,9 +290,9 @@ class ShellSession:
                 try:
                     status = frame.json()
                     meta = status.get("metadata", {})
-                    if meta.get("commandSessionId"):
+                    if meta.get("shellId"):
                         # This is the connection confirmation frame.
-                        self.shell_id = meta["commandSessionId"]
+                        self.shell_id = meta["shellId"]
                         self.reconnected = bool(meta.get("reconnected", False))
                         return
                     else:
@@ -474,11 +475,11 @@ class ShellSession:
     def _is_termination_status(status: dict) -> bool:
         """Return True if a parsed STATUS frame payload signals shell exit or error.
 
-        Connection confirmation frames have metadata.commandSessionId present.
+        Connection confirmation frames have metadata.shellId present.
         Termination frames have an empty metadata dict.
         """
         meta = status.get("metadata", {})
-        if meta.get("commandSessionId"):
+        if meta.get("shellId"):
             # This is a connection confirmation frame, not a termination.
             return False
         # Empty metadata → shell exit (Success = code 0, Failure = non-zero / error).
@@ -487,7 +488,7 @@ class ShellSession:
     @staticmethod
     def _is_confirmation_status(status: dict) -> bool:
         """Return True if a parsed STATUS frame is a connection confirmation."""
-        return bool(status.get("metadata", {}).get("commandSessionId"))
+        return bool(status.get("metadata", {}).get("shellId"))
 
     @staticmethod
     def _parse_exit_code(status: dict) -> Optional[int]:

--- a/src/bedrock_agentcore/runtime/shell/session.py
+++ b/src/bedrock_agentcore/runtime/shell/session.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING, AsyncIterator, Deque, Optional
 import websockets
 import websockets.exceptions
 
+from ..models import SESSION_HEADER, SHELL_ID_HEADER
 from ._validation import parse_runtime_arn, validate_shell_id
 from .auth import AuthMode, OAuthAuth, PresignedAuth
 from .config import _DEFAULT_METADATA_TIMEOUT, ReconnectConfig
 from .protocol import ShellChannel, ShellFrame, ShellFramer
-from ..models import SESSION_HEADER, SHELL_ID_HEADER
 
 if TYPE_CHECKING:
     from ..agent_core_runtime_client import AgentCoreRuntimeClient

--- a/tests/unit/runtime/test_agent_core_runtime_client.py
+++ b/tests/unit/runtime/test_agent_core_runtime_client.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 
 import pytest
 
-from bedrock_agentcore.runtime.agent_core_runtime_client import AgentCoreRuntimeClient
+from bedrock_agentcore.runtime.agent_core_runtime_client import AgentCoreRuntimeClient, parse_runtime_arn
 
 
 class TestAgentCoreRuntimeClientInit:
@@ -23,77 +23,45 @@ class TestAgentCoreRuntimeClientInit:
 
 
 class TestParseRuntimeArn:
-    """Tests for _parse_runtime_arn helper."""
+    """Tests for parse_runtime_arn module-level helper."""
 
     def test_parse_valid_arn(self):
-        """Test parsing a valid runtime ARN."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
         arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime-abc123"
-
-        result = client._parse_runtime_arn(arn)
-
+        result = parse_runtime_arn(arn)
         assert result["region"] == "us-west-2"
         assert result["account_id"] == "123456789012"
         assert result["runtime_id"] == "my-runtime-abc123"
 
     def test_parse_valid_gov_arn(self):
-        """Test parsing a valid govcloud runtime ARN."""
-        client = AgentCoreRuntimeClient(region="us-gov-west-1")
         arn = "arn:aws-us-gov:bedrock-agentcore:us-gov-west-1:123456789012:runtime/my-runtime-abc123"
-
-        result = client._parse_runtime_arn(arn)
-
+        result = parse_runtime_arn(arn)
         assert result["region"] == "us-gov-west-1"
         assert result["account_id"] == "123456789012"
         assert result["runtime_id"] == "my-runtime-abc123"
 
     def test_parse_invalid_arn_partition(self):
-        """Test parsing an invalid runtime ARN."""
-        client = AgentCoreRuntimeClient(region="us-iso-east-1")
-        invalid_arn = "arn:aws-iso:bedrock-agentcore:us-iso-east-1:123456789012:runtime/my-runtime-abc123"
-
         with pytest.raises(ValueError, match="Invalid runtime ARN format"):
-            client._parse_runtime_arn(invalid_arn)
+            parse_runtime_arn("arn:aws-iso:bedrock-agentcore:us-iso-east-1:123456789012:runtime/my-runtime-abc123")
 
     def test_parse_invalid_arn_raises_error(self):
-        """Test that invalid ARN format raises ValueError."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
-        invalid_arn = "not-a-valid-arn"
-
         with pytest.raises(ValueError, match="Invalid runtime ARN format"):
-            client._parse_runtime_arn(invalid_arn)
+            parse_runtime_arn("not-a-valid-arn")
 
     def test_parse_wrong_service_raises_error(self):
-        """Test that wrong service in ARN raises ValueError."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
-        wrong_service = "arn:aws:s3:us-west-2:123456789012:bucket/my-bucket"
-
         with pytest.raises(ValueError, match="Invalid runtime ARN format"):
-            client._parse_runtime_arn(wrong_service)
+            parse_runtime_arn("arn:aws:s3:us-west-2:123456789012:bucket/my-bucket")
 
     def test_parse_empty_region_raises_error(self):
-        """Test that empty region in ARN raises ValueError."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
-        empty_region = "arn:aws:bedrock-agentcore::123456789012:runtime/my-runtime"
-
         with pytest.raises(ValueError, match="ARN components cannot be empty"):
-            client._parse_runtime_arn(empty_region)
+            parse_runtime_arn("arn:aws:bedrock-agentcore::123456789012:runtime/my-runtime")
 
     def test_parse_empty_account_id_raises_error(self):
-        """Test that empty account_id in ARN raises ValueError."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
-        empty_account = "arn:aws:bedrock-agentcore:us-west-2::runtime/my-runtime"
-
         with pytest.raises(ValueError, match="ARN components cannot be empty"):
-            client._parse_runtime_arn(empty_account)
+            parse_runtime_arn("arn:aws:bedrock-agentcore:us-west-2::runtime/my-runtime")
 
     def test_parse_empty_runtime_id_raises_error(self):
-        """Test that empty runtime_id in ARN raises ValueError."""
-        client = AgentCoreRuntimeClient(region="us-west-2")
-        empty_runtime = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/"
-
         with pytest.raises(ValueError, match="ARN components cannot be empty"):
-            client._parse_runtime_arn(empty_runtime)
+            parse_runtime_arn("arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/")
 
 
 class TestBuildWebsocketUrl:

--- a/tests/unit/runtime/test_connect_shell.py
+++ b/tests/unit/runtime/test_connect_shell.py
@@ -30,7 +30,7 @@ class TestBuildShellUrl:
     def test_path_contains_ws_commands(self):
         client = _client()
         url = client._build_shell_url(FAKE_ARN)
-        assert "/ws/commands" in url
+        assert "/ws/shells" in url
         assert url.startswith("wss://")
 
     def test_arn_is_url_encoded(self):
@@ -45,11 +45,11 @@ class TestBuildShellUrl:
         assert qs["qualifier"] == ["prod"]
 
     def test_shell_id_maps_to_command_session_id_param(self):
-        """shell_id must be sent as commandSessionId (wire format unchanged)."""
+        """shell_id must be sent as shellId query param."""
         client = _client()
         url = client._build_shell_url(FAKE_ARN, shell_id="my-shell")
         qs = parse_qs(urlparse(url).query)
-        assert qs["commandSessionId"] == ["my-shell"]
+        assert qs["shellId"] == ["my-shell"]
 
     def test_no_params_no_query_string(self):
         client = _client()
@@ -119,7 +119,7 @@ class TestConnectShell:
                 url, headers = client.connect_shell(FAKE_ARN)
 
         assert url.startswith("wss://")
-        assert "/ws/commands" in url
+        assert "/ws/shells" in url
         assert "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id" in headers
         assert "Authorization" in headers
 
@@ -131,7 +131,7 @@ class TestConnectShell:
                 url, _ = client.connect_shell(FAKE_ARN, shell_id="my-shell")
 
         qs = parse_qs(urlparse(url).query)
-        assert qs["commandSessionId"] == ["my-shell"]
+        assert qs["shellId"] == ["my-shell"]
 
     def test_autogenerates_shell_id_when_absent(self):
         client = _client()
@@ -141,7 +141,7 @@ class TestConnectShell:
                 url, _ = client.connect_shell(FAKE_ARN)
 
         qs = parse_qs(urlparse(url).query)
-        assert "commandSessionId" in qs
+        assert "shellId" in qs
 
     def test_includes_security_token_when_present(self):
         client = _client()
@@ -191,7 +191,7 @@ class TestConnectShellPresigned:
             with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4QueryAuth") as mock_auth:
                 mock_request = MagicMock()
                 mock_request.url = (
-                    "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/x/ws/commands?X-Amz-Algorithm=AWS4"
+                    "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/x/ws/shells?X-Amz-Algorithm=AWS4"
                 )
                 mock_auth.return_value.add_auth = MagicMock(side_effect=lambda r: setattr(r, "url", mock_request.url))
                 url = client.connect_shell_presigned(FAKE_ARN)
@@ -274,7 +274,7 @@ class TestConnectShellOAuth:
         client = _client()
         url, protos = client.connect_shell_oauth(FAKE_ARN, bearer_token="tok123")
         assert url.startswith("wss://")
-        assert "/ws/commands" in url
+        assert "/ws/shells" in url
         encoded = base64.urlsafe_b64encode(b"tok123").decode().rstrip("=")
         assert f"base64UrlBearerAuthorization.{encoded}" in protos
         assert "base64UrlBearerAuthorization" in protos

--- a/tests/unit/runtime/test_connect_shell.py
+++ b/tests/unit/runtime/test_connect_shell.py
@@ -322,7 +322,7 @@ class TestOpenShell:
     def test_passes_shell_id(self):
         client = _client()
         session = client.open_shell(FAKE_ARN, shell_id="my-shell")
-        assert session._shell_id == "my-shell"
+        assert session.shell_id == "my-shell"
 
     def test_default_auth_is_sigv4(self):
         client = _client()

--- a/tests/unit/runtime/test_connect_shell.py
+++ b/tests/unit/runtime/test_connect_shell.py
@@ -1,0 +1,378 @@
+"""Tests for the connect_shell* auth helpers on AgentCoreRuntimeClient."""
+
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, quote, urlparse
+
+import pytest
+
+from bedrock_agentcore.runtime.agent_core_runtime_client import AgentCoreRuntimeClient, validate_shell_id
+
+FAKE_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime"
+ENCODED_ARN = quote(FAKE_ARN, safe="")
+
+
+def _client() -> AgentCoreRuntimeClient:
+    return AgentCoreRuntimeClient(region="us-west-2")
+
+
+def _mock_credentials(token: str = "") -> MagicMock:
+    creds = MagicMock()
+    frozen = MagicMock()
+    frozen.token = token
+    creds.get_frozen_credentials.return_value = frozen
+    return creds
+
+
+# ── _build_shell_url ──────────────────────────────────────────────────────────
+
+
+class TestBuildShellUrl:
+    def test_path_contains_ws_commands(self):
+        client = _client()
+        url = client._build_shell_url(FAKE_ARN)
+        assert "/ws/commands" in url
+        assert url.startswith("wss://")
+
+    def test_arn_is_url_encoded(self):
+        client = _client()
+        url = client._build_shell_url(FAKE_ARN)
+        assert ENCODED_ARN in url
+
+    def test_qualifier_param(self):
+        client = _client()
+        url = client._build_shell_url(FAKE_ARN, endpoint_name="prod")
+        qs = parse_qs(urlparse(url).query)
+        assert qs["qualifier"] == ["prod"]
+
+    def test_shell_id_maps_to_command_session_id_param(self):
+        """shell_id must be sent as commandSessionId (wire format unchanged)."""
+        client = _client()
+        url = client._build_shell_url(FAKE_ARN, shell_id="my-shell")
+        qs = parse_qs(urlparse(url).query)
+        assert qs["commandSessionId"] == ["my-shell"]
+
+    def test_no_params_no_query_string(self):
+        client = _client()
+        url = client._build_shell_url(FAKE_ARN)
+        assert "?" not in url
+
+
+# ── validate_shell_id ─────────────────────────────────────────────────────────
+
+
+class TestValidateShellId:
+    def test_valid_simple(self):
+        validate_shell_id("my-shell")
+
+    def test_valid_single_char(self):
+        validate_shell_id("x")
+
+    def test_valid_128_chars(self):
+        validate_shell_id("a" * 128)
+
+    def test_valid_with_underscore(self):
+        validate_shell_id("debug_session_01")
+
+    def test_valid_alphanumeric_start(self):
+        validate_shell_id("abc123")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            validate_shell_id("")
+
+    def test_too_long_raises(self):
+        with pytest.raises(ValueError):
+            validate_shell_id("a" * 129)
+
+    def test_starts_with_hyphen_raises(self):
+        with pytest.raises(ValueError):
+            validate_shell_id("-shell")
+
+    def test_starts_with_underscore_raises(self):
+        with pytest.raises(ValueError):
+            validate_shell_id("_shell")
+
+    @pytest.mark.parametrize("char", ["?", "#", "&", ".", "/", " "])
+    def test_forbidden_char_raises(self, char):
+        with pytest.raises(ValueError):
+            validate_shell_id(f"shell{char}bad")
+
+    @pytest.mark.parametrize("bad", [0, False, True, b"foo", 1.5, [], {}])
+    def test_non_string_raises_value_error(self, bad):
+        with pytest.raises(ValueError, match="must be str"):
+            validate_shell_id(bad)
+
+    def test_trailing_newline_raises(self):
+        with pytest.raises(ValueError):
+            validate_shell_id("my-shell\n")
+
+
+# ── connect_shell ─────────────────────────────────────────────────────────────
+
+
+class TestConnectShell:
+    def test_returns_wss_url_and_headers(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4Auth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock()
+                url, headers = client.connect_shell(FAKE_ARN)
+
+        assert url.startswith("wss://")
+        assert "/ws/commands" in url
+        assert "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id" in headers
+        assert "Authorization" in headers
+
+    def test_uses_provided_shell_id(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4Auth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock()
+                url, _ = client.connect_shell(FAKE_ARN, shell_id="my-shell")
+
+        qs = parse_qs(urlparse(url).query)
+        assert qs["commandSessionId"] == ["my-shell"]
+
+    def test_autogenerates_shell_id_when_absent(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4Auth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock()
+                url, _ = client.connect_shell(FAKE_ARN)
+
+        qs = parse_qs(urlparse(url).query)
+        assert "commandSessionId" in qs
+
+    def test_includes_security_token_when_present(self):
+        client = _client()
+        creds = _mock_credentials(token="SESSION-TOKEN")
+        with patch.object(client.session, "get_credentials", return_value=creds):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4Auth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock()
+                _, headers = client.connect_shell(FAKE_ARN)
+
+        assert headers.get("X-Amz-Security-Token") == "SESSION-TOKEN"
+
+    def test_invalid_arn_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell("not-an-arn")
+
+    def test_invalid_shell_id_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell(FAKE_ARN, shell_id="bad?id")
+
+    def test_no_credentials_raises(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=None):
+            with pytest.raises(RuntimeError, match="No AWS credentials"):
+                client.connect_shell(FAKE_ARN)
+
+    def test_user_agent_includes_integration_source(self):
+        from bedrock_agentcore.runtime.agent_core_runtime_client import AgentCoreRuntimeClient
+
+        client = AgentCoreRuntimeClient(region="us-west-2", integration_source="mycli")
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4Auth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock()
+                _, headers = client.connect_shell(FAKE_ARN)
+
+        assert "mycli" in headers.get("User-Agent", "")
+
+
+# ── connect_shell_presigned ───────────────────────────────────────────────────
+
+
+class TestConnectShellPresigned:
+    def test_returns_presigned_wss_url(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4QueryAuth") as mock_auth:
+                mock_request = MagicMock()
+                mock_request.url = (
+                    "https://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/x/ws/commands?X-Amz-Algorithm=AWS4"
+                )
+                mock_auth.return_value.add_auth = MagicMock(side_effect=lambda r: setattr(r, "url", mock_request.url))
+                url = client.connect_shell_presigned(FAKE_ARN)
+
+        assert url.startswith("wss://")
+
+    def test_session_id_embedded_before_signing(self):
+        """X-Amzn-Bedrock-AgentCore-Runtime-Session-Id must be in the URL that
+        SigV4QueryAuth signs, so it is covered by the signature."""
+        from urllib.parse import parse_qs, urlparse
+
+        client = _client()
+        signed_url = None
+
+        def capture_and_sign(request):
+            nonlocal signed_url
+            signed_url = request.url
+            request.url = request.url + "&X-Amz-Signature=fakesig"
+
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4QueryAuth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock(side_effect=capture_and_sign)
+                client.connect_shell_presigned(FAKE_ARN, session_id="test-session-99")
+
+        assert signed_url is not None
+        qs = parse_qs(urlparse(signed_url).query)
+        assert qs.get("X-Amzn-Bedrock-AgentCore-Runtime-Session-Id") == ["test-session-99"]
+
+    def test_session_id_autogenerated_and_embedded_before_signing(self):
+        """When session_id is omitted an auto-generated one must still be
+        embedded in the URL before signing."""
+        from urllib.parse import parse_qs, urlparse
+
+        client = _client()
+        signed_url = None
+
+        def capture_and_sign(request):
+            nonlocal signed_url
+            signed_url = request.url
+            request.url = request.url + "&X-Amz-Signature=fakesig"
+
+        with patch.object(client.session, "get_credentials", return_value=_mock_credentials()):
+            with patch("bedrock_agentcore.runtime.agent_core_runtime_client.SigV4QueryAuth") as mock_auth:
+                mock_auth.return_value.add_auth = MagicMock(side_effect=capture_and_sign)
+                client.connect_shell_presigned(FAKE_ARN)
+
+        assert signed_url is not None
+        qs = parse_qs(urlparse(signed_url).query)
+        assert "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id" in qs
+
+    def test_expires_too_large_raises(self):
+        client = _client()
+        with pytest.raises(ValueError, match="Expiry timeout cannot exceed"):
+            client.connect_shell_presigned(FAKE_ARN, expires=301)
+
+    def test_invalid_arn_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell_presigned("bad-arn")
+
+    def test_invalid_shell_id_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell_presigned(FAKE_ARN, shell_id="bad#id")
+
+    def test_no_credentials_raises(self):
+        client = _client()
+        with patch.object(client.session, "get_credentials", return_value=None):
+            with pytest.raises(RuntimeError, match="No AWS credentials"):
+                client.connect_shell_presigned(FAKE_ARN)
+
+
+# ── connect_shell_oauth ───────────────────────────────────────────────────────
+
+
+class TestConnectShellOAuth:
+    def test_returns_url_and_subprotocols(self):
+        import base64
+
+        client = _client()
+        url, protos = client.connect_shell_oauth(FAKE_ARN, bearer_token="tok123")
+        assert url.startswith("wss://")
+        assert "/ws/commands" in url
+        encoded = base64.urlsafe_b64encode(b"tok123").decode().rstrip("=")
+        assert f"base64UrlBearerAuthorization.{encoded}" in protos
+        assert "base64UrlBearerAuthorization" in protos
+
+    def test_token_embedded_in_subprotocol(self):
+        import base64
+
+        client = _client()
+        _, protos = client.connect_shell_oauth(FAKE_ARN, bearer_token="my-token")
+        encoded = base64.urlsafe_b64encode(b"my-token").decode().rstrip("=")
+        assert protos == [f"base64UrlBearerAuthorization.{encoded}", "base64UrlBearerAuthorization"]
+
+    def test_session_id_in_query_string(self):
+        client = _client()
+        url, _ = client.connect_shell_oauth(FAKE_ARN, bearer_token="tok", session_id="sid-123")
+        assert "sid-123" in url
+
+    def test_empty_token_raises(self):
+        client = _client()
+        with pytest.raises(ValueError, match="bearer_token"):
+            client.connect_shell_oauth(FAKE_ARN, bearer_token="")
+
+    def test_invalid_arn_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell_oauth("bad-arn", bearer_token="tok")
+
+    def test_invalid_shell_id_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.connect_shell_oauth(FAKE_ARN, bearer_token="tok", shell_id="a&b")
+
+
+# ── open_shell ────────────────────────────────────────────────────────────────
+
+
+class TestOpenShell:
+    def test_returns_shell_session(self):
+        from bedrock_agentcore.runtime.shell import ShellSession
+
+        client = _client()
+        session = client.open_shell(FAKE_ARN)
+        assert isinstance(session, ShellSession)
+
+    def test_passes_shell_id(self):
+        client = _client()
+        session = client.open_shell(FAKE_ARN, shell_id="my-shell")
+        assert session._shell_id == "my-shell"
+
+    def test_default_auth_is_sigv4(self):
+        client = _client()
+        session = client.open_shell(FAKE_ARN)
+        assert session._auth == "sigv4"
+
+    def test_passes_presigned_auth(self):
+        from bedrock_agentcore.runtime.shell import PresignedAuth
+
+        client = _client()
+        auth = PresignedAuth(expires=120)
+        session = client.open_shell(FAKE_ARN, auth=auth)
+        assert session._auth is auth
+
+    def test_passes_oauth_auth(self):
+        from bedrock_agentcore.runtime.shell import OAuthAuth
+
+        client = _client()
+        auth = OAuthAuth(bearer_token="tok")
+        session = client.open_shell(FAKE_ARN, auth=auth)
+        assert session._auth is auth
+
+    def test_passes_reconnect_config(self):
+        from bedrock_agentcore.runtime.shell import ReconnectConfig
+
+        client = _client()
+        config = ReconnectConfig(max_retries=3)
+        session = client.open_shell(FAKE_ARN, reconnect_config=config)
+        assert session._reconnect_config is config
+
+    def test_no_reconnect_config_by_default(self):
+        client = _client()
+        session = client.open_shell(FAKE_ARN)
+        assert session._reconnect_config is None
+
+    def test_invalid_shell_id_raises(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.open_shell(FAKE_ARN, shell_id="bad?id")
+
+    def test_invalid_arn_raises_eagerly(self):
+        client = _client()
+        with pytest.raises(ValueError):
+            client.open_shell("not-an-arn")
+
+    def test_region_mismatch_raises(self):
+        client = AgentCoreRuntimeClient(region="us-east-1")
+        east_arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-runtime"
+        west_arn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime"
+        session = client.open_shell(east_arn)
+        assert session is not None
+        with pytest.raises(ValueError, match="does not match client region"):
+            client.open_shell(west_arn)

--- a/tests/unit/runtime/test_shell.py
+++ b/tests/unit/runtime/test_shell.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # websockets.connect is awaited in _connect(), so patches must be AsyncMock.
 import pytest
 
+from bedrock_agentcore.runtime.models import SESSION_HEADER, SHELL_ID_HEADER
 from bedrock_agentcore.runtime.shell import (
     OAuthAuth,
     PresignedAuth,
@@ -17,7 +18,7 @@ from bedrock_agentcore.runtime.shell import (
 )
 
 FAKE_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime"
-FAKE_URL = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/FAKE/ws/commands"
+FAKE_URL = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/FAKE/ws/shells"
 FAKE_HEADERS = {"Authorization": "AWS4-HMAC…", "Host": "bedrock-agentcore.us-west-2.amazonaws.com"}
 
 
@@ -62,7 +63,7 @@ def _metadata_frame(shell_id: str = "test-session", reconnected: bool = False) -
         {
             "kind": "Status",
             "apiVersion": "v1",
-            "metadata": {"commandSessionId": shell_id, "reconnected": reconnected},
+            "metadata": {"shellId": shell_id, "reconnected": reconnected},
             "status": "Success",
         }
     ).encode()
@@ -205,8 +206,8 @@ class TestShellSessionConnect:
         client = _make_client()
         ws = _make_ws(_metadata_frame("my-shell"))
         ws.response.headers = {
-            "X-Command-Session-Id": "my-shell",
-            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": "server-session-99",
+            SHELL_ID_HEADER: "my-shell",
+            SESSION_HEADER: "server-session-99",
         }
 
         with patch("websockets.connect", new=AsyncMock(return_value=ws)):
@@ -472,7 +473,7 @@ class TestShellSessionIterate:
         assert ShellChannel.STATUS in channels
         # The exit STATUS frame has empty metadata (not a connection confirmation).
         status_frames = [f for f in frames if f.channel == ShellChannel.STATUS]
-        assert all(not f.json().get("metadata", {}).get("commandSessionId") for f in status_frames)
+        assert all(not f.json().get("metadata", {}).get("shellId") for f in status_frames)
 
     @pytest.mark.asyncio
     async def test_stops_on_close_frame(self):
@@ -1043,7 +1044,7 @@ class TestShellSessionBytesDropped:
             {
                 "kind": "Status",
                 "apiVersion": "v1",
-                "metadata": {"commandSessionId": shell_id, "reconnected": True, "bytesDropped": bytes_dropped},
+                "metadata": {"shellId": shell_id, "reconnected": True, "bytesDropped": bytes_dropped},
                 "status": "Success",
             }
         ).encode()
@@ -1091,7 +1092,7 @@ class TestShellSessionBytesDropped:
             {
                 "kind": "Status",
                 "apiVersion": "v1",
-                "metadata": {"commandSessionId": "s", "reconnected": True},
+                "metadata": {"shellId": "s", "reconnected": True},
                 "status": "Success",
             }
         ).encode()
@@ -1130,7 +1131,7 @@ class TestShellSessionAuthModes:
 
     @pytest.mark.asyncio
     async def test_presigned_uses_connect_shell_presigned(self):
-        presigned_url = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/X/ws/commands?X-Amz-Signature=abc"
+        presigned_url = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/X/ws/shells?X-Amz-Signature=abc"
         client = MagicMock()
         client.connect_shell_presigned.return_value = presigned_url
         ws = _make_ws(_metadata_frame())

--- a/tests/unit/runtime/test_shell.py
+++ b/tests/unit/runtime/test_shell.py
@@ -1,0 +1,1158 @@
+"""Tests for ShellSession and ReconnectConfig."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# websockets.connect is awaited in _connect(), so patches must be AsyncMock.
+import pytest
+
+from bedrock_agentcore.runtime.shell import (
+    OAuthAuth,
+    PresignedAuth,
+    ReconnectConfig,
+    ShellChannel,
+    ShellFramer,
+    ShellSession,
+)
+
+FAKE_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/my-runtime"
+FAKE_URL = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/FAKE/ws/commands"
+FAKE_HEADERS = {"Authorization": "AWS4-HMAC…", "Host": "bedrock-agentcore.us-west-2.amazonaws.com"}
+
+
+def _make_client(url=FAKE_URL, headers=FAKE_HEADERS):
+    client = MagicMock()
+    client.connect_shell.return_value = (url, headers)
+    return client
+
+
+def _make_ws(*frames, end_with=None):
+    """Build a mock WebSocket that yields the given raw frames then raises end_with.
+
+    end_with defaults to ConnectionClosedOK — signals clean close to __anext__,
+    which raises StopAsyncIteration without triggering reconnect.
+    """
+    import websockets.exceptions
+
+    if end_with is None:
+        end_with = websockets.exceptions.ConnectionClosedOK(None, None)
+
+    ws = AsyncMock()
+    call_count = 0
+
+    async def recv():
+        nonlocal call_count
+        if call_count < len(frames):
+            result = frames[call_count]
+            call_count += 1
+            return result
+        raise end_with
+
+    ws.recv = recv
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+def _metadata_frame(shell_id: str = "test-session", reconnected: bool = False) -> bytes:
+    payload = json.dumps(
+        {
+            "kind": "Status",
+            "apiVersion": "v1",
+            "metadata": {"commandSessionId": shell_id, "reconnected": reconnected},
+            "status": "Success",
+        }
+    ).encode()
+    return bytes([ShellChannel.STATUS]) + payload
+
+
+def _stdout_frame(text: str) -> bytes:
+    return bytes([ShellChannel.STDOUT]) + text.encode()
+
+
+def _exit_frame(exit_code: int = 0) -> bytes:
+    if exit_code == 0:
+        payload = json.dumps({"kind": "Status", "apiVersion": "v1", "metadata": {}, "status": "Success"}).encode()
+    else:
+        payload = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {},
+                "status": "Failure",
+                "reason": "NonZeroExitCode",
+                "details": {"causes": [{"reason": "ExitCode", "message": str(exit_code)}]},
+            }
+        ).encode()
+    return bytes([ShellChannel.STATUS]) + payload
+
+
+def _close_frame() -> bytes:
+    return bytes([ShellChannel.CLOSE])
+
+
+class TestShellSessionConnect:
+    @pytest.mark.asyncio
+    async def test_connect_reads_metadata_frame(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame("my-shell", reconnected=False))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN, shell_id="my-shell")
+            await session._connect()
+
+        assert session.shell_id == "my-shell"
+        assert session.reconnected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_sets_reconnected_true(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame("my-shell", reconnected=True))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN, shell_id="my-shell")
+            await session._connect()
+
+        assert session.reconnected is True
+
+    @pytest.mark.asyncio
+    async def test_connect_tolerates_missing_metadata_frame(self):
+        client = _make_client()
+        ws = AsyncMock()
+        ws.recv = AsyncMock(side_effect=asyncio.TimeoutError)
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN)
+            await session._connect()  # must not raise
+
+        assert session.shell_id is not None
+
+    @pytest.mark.asyncio
+    async def test_connect_ignores_non_status_first_frame(self):
+        """STDOUT frames arriving before STATUS are stashed; STATUS is still found."""
+        client = _make_client()
+        ws = _make_ws(_stdout_frame("some output"), _metadata_frame("x"))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN, shell_id="x")
+            await session._connect()
+
+        assert session.reconnected is False
+        assert session.shell_id == "x"
+        assert len(session._pending_frames) == 1  # stdout frame was stashed
+
+    @pytest.mark.asyncio
+    async def test_connect_raises_on_connection_closed_error_before_status(self):
+        """ConnectionClosedError before STATUS arrives propagates out of __aenter__."""
+        import websockets.exceptions
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.recv = AsyncMock(side_effect=websockets.exceptions.ConnectionClosedError(None, None))
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN)
+            with pytest.raises(websockets.exceptions.ConnectionClosedError):
+                await session._connect()
+
+        assert session._ws is None
+
+    @pytest.mark.asyncio
+    async def test_connect_raises_on_connection_closed_ok_before_status(self):
+        """ConnectionClosedOK before STATUS arrives propagates out of __aenter__."""
+        import websockets.exceptions
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.recv = AsyncMock(side_effect=websockets.exceptions.ConnectionClosedOK(None, None))
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN)
+            with pytest.raises(websockets.exceptions.ConnectionClosedOK):
+                await session._connect()
+
+        assert session._ws is None
+
+    @pytest.mark.asyncio
+    async def test_connect_timeout_proceeds_with_warning(self, caplog):
+        """TimeoutError waiting for STATUS logs a warning but session stays usable."""
+        import logging
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.recv = AsyncMock(side_effect=asyncio.TimeoutError)
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            with caplog.at_level(logging.WARNING, logger="bedrock_agentcore.runtime.shell"):
+                session = ShellSession(client, FAKE_ARN)
+                await session._connect()  # must not raise
+
+        assert session._ws is ws  # connection still alive
+        assert "server did not respond" in caplog.text
+
+
+class TestShellSessionInit:
+    def test_invalid_arn_raises_at_construction(self):
+        client = _make_client()
+        with pytest.raises(ValueError):
+            ShellSession(client, "not-an-arn")
+
+    def test_none_shell_id_autogenerates_uuid(self):
+        client = _make_client()
+        session = ShellSession(client, FAKE_ARN, shell_id=None)
+        assert session._shell_id is not None
+        assert len(session._shell_id) > 0
+
+    @pytest.mark.parametrize("bad", [0, False, b"", 1.5])
+    def test_non_string_shell_id_raises_at_construction(self, bad):
+        """Non-string values must be rejected immediately in __init__, not silently
+        replaced with a UUID or deferred until __aenter__."""
+        client = _make_client()
+        with pytest.raises(ValueError, match="must be str"):
+            ShellSession(client, FAKE_ARN, shell_id=bad)
+
+    def test_region_mismatch_raises_at_construction(self):
+        client = MagicMock()
+        client.region = "us-east-1"
+        with pytest.raises(ValueError, match="does not match client region"):
+            ShellSession(client, FAKE_ARN)  # FAKE_ARN is us-west-2
+
+    def test_region_match_does_not_raise(self):
+        client = MagicMock()
+        client.region = "us-west-2"
+        session = ShellSession(client, FAKE_ARN)
+        assert session is not None
+
+
+class TestShellSessionConnectInvalidStatus:
+    @pytest.mark.asyncio
+    async def test_invalid_status_logs_body_and_reraises(self, caplog):
+        import logging
+
+        import websockets.datastructures
+        import websockets.exceptions
+        import websockets.http11
+
+        client = _make_client()
+        response = websockets.http11.Response(
+            status_code=404,
+            reason_phrase="Not Found",
+            headers=websockets.datastructures.Headers(),
+            body=b"No endpoint found for qualifier 'DEFAULT'",
+        )
+        exc = websockets.exceptions.InvalidStatus(response)
+
+        with patch("websockets.connect", new=AsyncMock(side_effect=exc)):
+            session = ShellSession(client, FAKE_ARN)
+            with caplog.at_level(logging.ERROR, logger="bedrock_agentcore.runtime.shell"):
+                with pytest.raises(websockets.exceptions.InvalidStatus):
+                    await session._connect()
+
+        assert "404" in caplog.text
+        assert "No endpoint found" in caplog.text
+
+
+class TestShellSessionAenterFailure:
+    @pytest.mark.asyncio
+    async def test_aenter_failure_marks_closed(self):
+        """If _connect() raises, __aenter__ must leave _closed=True so the session
+        cannot be iterated."""
+        client = _make_client()
+
+        with patch("websockets.connect", new=AsyncMock(side_effect=ConnectionRefusedError("refused"))):
+            session = ShellSession(client, FAKE_ARN)
+            with pytest.raises(ConnectionRefusedError):
+                await session.__aenter__()
+
+        assert session._closed is True
+        assert session._ws is None
+
+
+class TestShellSessionContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager_closes_on_exit(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                assert shell._ws is not None
+            assert shell._ws is None
+            ws.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_sends_close_frame(self):
+        framer = ShellFramer()
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as _:
+                pass
+
+        sent_frames = [call.args[0] for call in ws.send.call_args_list]
+        assert framer.encode_close() in sent_frames
+
+
+class TestShellSessionSend:
+    @pytest.mark.asyncio
+    async def test_send_encodes_stdin_frame(self):
+        framer = ShellFramer()
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                await shell.send("ls\n")
+
+        sent = [call.args[0] for call in ws.send.call_args_list]
+        assert framer.encode_stdin("ls\n") in sent
+
+    @pytest.mark.asyncio
+    async def test_send_bytes(self):
+        framer = ShellFramer()
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                await shell.send_bytes(b"\x1b[A")
+
+        sent = [call.args[0] for call in ws.send.call_args_list]
+        assert framer.encode_stdin(b"\x1b[A") in sent
+
+    @pytest.mark.asyncio
+    async def test_resize(self):
+        framer = ShellFramer()
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                await shell.resize(220, 50)
+
+        sent = [call.args[0] for call in ws.send.call_args_list]
+        assert framer.encode_resize(220, 50) in sent
+
+
+class TestShellSessionSendAfterClose:
+    @pytest.mark.asyncio
+    async def test_send_raises_after_close(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                pass
+        with pytest.raises(RuntimeError, match="closed"):
+            await shell.send("ls\n")
+
+    @pytest.mark.asyncio
+    async def test_send_bytes_raises_after_close(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                pass
+        with pytest.raises(RuntimeError, match="closed"):
+            await shell.send_bytes(b"\x1b[A")
+
+    @pytest.mark.asyncio
+    async def test_resize_raises_after_close(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                pass
+        with pytest.raises(RuntimeError, match="closed"):
+            await shell.resize(80, 24)
+
+
+class TestShellSessionIterate:
+    @pytest.mark.asyncio
+    async def test_iterates_stdout_frames(self):
+        client = _make_client()
+        ws = _make_ws(
+            _metadata_frame(),
+            _stdout_frame("hello"),
+            _stdout_frame(" world"),
+            _close_frame(),
+        )
+
+        output = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for frame in shell:
+                    if frame.channel == ShellChannel.STDOUT:
+                        output.append(frame.text)
+
+        assert output == ["hello", " world"]
+
+    @pytest.mark.asyncio
+    async def test_stops_on_exit_status_frame(self):
+        client = _make_client()
+        ws = _make_ws(
+            _metadata_frame(),
+            _stdout_frame("output"),
+            _exit_frame(0),
+        )
+
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        channels = [f.channel for f in frames]
+        assert ShellChannel.STDOUT in channels
+        # The exit STATUS frame is yielded (so caller can read exit code), then iteration stops.
+        assert ShellChannel.STATUS in channels
+        # The exit STATUS frame has empty metadata (not a connection confirmation).
+        status_frames = [f for f in frames if f.channel == ShellChannel.STATUS]
+        assert all(not f.json().get("metadata", {}).get("commandSessionId") for f in status_frames)
+
+    @pytest.mark.asyncio
+    async def test_stops_on_close_frame(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), _close_frame())
+
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        assert frames == []
+
+    @pytest.mark.asyncio
+    async def test_stops_on_connection_closed_without_reconnect(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())  # ConnectionClosed raised on next recv
+
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        assert frames == []
+
+
+class TestShellSessionCleanClose:
+    @pytest.mark.asyncio
+    async def test_connection_closed_ok_stops_without_reconnect(self):
+        """ConnectionClosedOK (server graceful close, code 1000) must not trigger auto-reconnect."""
+        import websockets.exceptions
+
+        client = _make_client()
+        reconnect_calls = []
+
+        async def on_reconnect(reconnected: bool) -> None:
+            reconnect_calls.append(reconnected)
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        call_count = 0
+
+        async def recv():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _metadata_frame()
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+        ws.recv = recv
+
+        config = ReconnectConfig(max_retries=3, base_delay=0.0, on_reconnect=on_reconnect)
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        assert frames == []
+        assert reconnect_calls == []  # no reconnect attempted
+
+    @pytest.mark.asyncio
+    async def test_termination_status_prevents_reconnect(self):
+        """Shell exit STATUS frame must set _closed so reconnect_config does not reopen the shell."""
+        import websockets.exceptions
+
+        client = _make_client()
+        reconnect_calls = []
+
+        async def on_reconnect(reconnected: bool) -> None:
+            reconnect_calls.append(reconnected)
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        call_count = 0
+
+        async def recv():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _metadata_frame()
+            if call_count == 2:
+                return _exit_frame(0)
+            # If _closed wasn't set, __anext__ would hit this and try to reconnect
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+        ws.recv = recv
+
+        config = ReconnectConfig(max_retries=3, base_delay=0.0, on_reconnect=on_reconnect)
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        # The exit STATUS frame was yielded
+        assert len(frames) == 1
+        assert frames[0].channel == ShellChannel.STATUS
+        # No reconnect was attempted after the shell exited
+        assert reconnect_calls == []
+
+    @pytest.mark.asyncio
+    async def test_close_code_1001_triggers_reconnect(self):
+        """Close code 1001 (Going Away — DP/proxy restart) MUST trigger auto-reconnect per spec §6."""
+        import websockets.exceptions
+        from websockets.frames import Close
+
+        client = _make_client()
+        reconnect_calls = []
+
+        async def on_reconnect(reconnected: bool) -> None:
+            reconnect_calls.append(reconnected)
+
+        # First WebSocket: metadata then close 1001.
+        # Second WebSocket: metadata then clean close 1000.
+        ws1 = AsyncMock()
+        ws1.send = AsyncMock()
+        ws1.close = AsyncMock()
+        ws1_count = 0
+
+        async def recv1():
+            nonlocal ws1_count
+            ws1_count += 1
+            if ws1_count == 1:
+                return _metadata_frame("session-1")
+            raise websockets.exceptions.ConnectionClosedOK(Close(1001, "Going Away"), None)
+
+        ws1.recv = recv1
+
+        ws2 = AsyncMock()
+        ws2.send = AsyncMock()
+        ws2.close = AsyncMock()
+        ws2_count = 0
+
+        async def recv2():
+            nonlocal ws2_count
+            ws2_count += 1
+            if ws2_count == 1:
+                return _metadata_frame("session-1", reconnected=True)
+            if ws2_count == 2:
+                return _stdout_frame("hello")
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+        ws2.recv = recv2
+
+        connect_calls = iter([ws1, ws2])
+        config = ReconnectConfig(max_retries=2, base_delay=0.0, reconnect_window=60.0, on_reconnect=on_reconnect)
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(side_effect=lambda *a, **kw: next(connect_calls))):
+            async with ShellSession(client, FAKE_ARN, shell_id="session-1", reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        assert len(frames) == 1
+        assert frames[0].channel == ShellChannel.STDOUT
+        assert frames[0].text == "hello"
+        assert len(reconnect_calls) == 1  # reconnected once after 1001
+
+
+class TestShellSessionKicked:
+    @pytest.mark.asyncio
+    async def test_close_code_4000_stops_without_reconnect(self):
+        """Close code 4000 (kicked by new connection) must NOT trigger auto-reconnect."""
+        import websockets.exceptions
+        from websockets.frames import Close
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        call_count = 0
+
+        async def recv():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _metadata_frame()
+            # Simulate kicked close code 4000
+            close_obj = Close(code=4000, reason="replaced by new connection")
+            raise websockets.exceptions.ConnectionClosedError(close_obj, None)
+
+        ws.recv = recv
+
+        config = ReconnectConfig(max_retries=3, base_delay=0.0)
+        frames = []
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        # Iteration stopped and no reconnect was attempted (only one connect call)
+        assert frames == []
+
+    @pytest.mark.asyncio
+    async def test_close_code_4000_sets_kicked(self):
+        """shell.kicked is True after close code 4000; shell.kicked is False for a clean close."""
+        import websockets.exceptions
+        from websockets.frames import Close
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        call_count = 0
+
+        async def recv():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _metadata_frame()
+            close_obj = Close(code=4000, reason="replaced by new connection")
+            raise websockets.exceptions.ConnectionClosedError(close_obj, None)
+
+        ws.recv = recv
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.kicked is True
+
+    @pytest.mark.asyncio
+    async def test_clean_close_does_not_set_kicked(self):
+        """shell.kicked remains False when the session ends normally."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())  # metadata frame then ConnectionClosedOK
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.kicked is False
+
+
+class TestShellSessionAutoReconnect:
+    @pytest.mark.asyncio
+    async def test_reconnects_and_resumes_iteration(self):
+        import websockets.exceptions
+
+        client = _make_client()
+
+        ws1 = _make_ws(
+            _metadata_frame("s", reconnected=False),
+            _stdout_frame("before"),
+            end_with=websockets.exceptions.ConnectionClosedError(None, None),
+        )
+        ws2 = _make_ws(_metadata_frame("s", reconnected=True), _stdout_frame("after"), _close_frame())
+
+        connect_calls = [ws1, ws2]
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            return connect_calls.pop(0)
+
+        on_reconnect_calls = []
+
+        async def on_reconnect(reconnected: bool) -> None:
+            on_reconnect_calls.append(reconnected)
+
+        config = ReconnectConfig(max_retries=3, on_reconnect=on_reconnect)
+        output = []
+
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, shell_id="s", reconnect_config=config) as shell:
+                async for frame in shell:
+                    if frame.channel == ShellChannel.STDOUT:
+                        output.append(frame.text)
+
+        assert output == ["before", "after"]
+        assert on_reconnect_calls == [True]
+
+    @pytest.mark.asyncio
+    async def test_exhausts_retries_and_stops(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())  # drops immediately after metadata
+
+        async def fail_connect(url, extra_headers=None):
+            raise ConnectionRefusedError("server down")
+
+        async def first_connect(url, extra_headers=None):
+            return ws
+
+        call_count = 0
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ws
+            raise ConnectionRefusedError("server down")
+
+        config = ReconnectConfig(max_retries=2, base_delay=0.0, max_delay=0.0, reconnect_window=0.0)
+
+        frames = []
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        # All reconnect attempts failed — iteration stopped gracefully
+        assert frames == []
+
+    @pytest.mark.asyncio
+    async def test_pending_frames_cleared_on_reconnect(self):
+        """_pending_frames must be cleared at the start of _connect() so frames
+        buffered during a previous metadata handshake cannot bleed into a new session.
+
+        Directly verifies the invariant: after __aenter__ plants a stale frame in
+        _pending_frames, calling _connect() again must empty it.
+        """
+        client = _make_client()
+
+        from bedrock_agentcore.runtime.shell.protocol import ShellFrame
+
+        ws1 = _make_ws(_metadata_frame("s"))
+        ws2 = _make_ws(_metadata_frame("s", reconnected=True), _stdout_frame("fresh"), _close_frame())
+        connect_seq = [ws1, ws2]
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            return connect_seq.pop(0)
+
+        with patch("websockets.connect", side_effect=fake_connect):
+            session = ShellSession(client, FAKE_ARN, shell_id="s")
+            await session.__aenter__()
+
+            # Plant a stale frame as if left over from a prior metadata handshake.
+            session._pending_frames.append(
+                ShellFrame(channel=ShellChannel.STDOUT, raw_channel_byte=ShellChannel.STDOUT, payload=b"stale")
+            )
+            assert len(session._pending_frames) == 1
+
+            # _connect() must clear it.
+            await session._connect()
+            assert len(session._pending_frames) == 0
+
+            await session.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_sync_on_reconnect_callback_accepted(self):
+        """A synchronous on_reconnect callback must also be accepted."""
+        import websockets.exceptions
+
+        client = _make_client()
+        ws1 = _make_ws(_metadata_frame("s"), end_with=websockets.exceptions.ConnectionClosedError(None, None))
+        ws2 = _make_ws(_metadata_frame("s", reconnected=True), _close_frame())
+        connect_calls = [ws1, ws2]
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            return connect_calls.pop(0)
+
+        sync_calls = []
+
+        def sync_callback(reconnected: bool) -> None:
+            sync_calls.append(reconnected)
+
+        config = ReconnectConfig(max_retries=1, base_delay=0.0, on_reconnect=sync_callback)
+
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, shell_id="s", reconnect_config=config) as shell:
+                async for _ in shell:
+                    pass
+
+        assert sync_calls == [True]
+
+    @pytest.mark.asyncio
+    async def test_outer_loop_retries_after_inner_exhaustion(self):
+        """After inner loop exhaustion, outer loop waits then runs a fresh inner loop."""
+        import websockets.exceptions
+
+        client = _make_client()
+        ws1 = _make_ws(_metadata_frame("s"), end_with=websockets.exceptions.ConnectionClosedError(None, None))
+        ws2 = _make_ws(_metadata_frame("s", reconnected=True), _close_frame())
+
+        call_count = 0
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ws1
+            if call_count == 2:
+                # Fail the inner loop's first attempt so outer loop kicks in
+                raise ConnectionRefusedError("transient")
+            return ws2
+
+        config = ReconnectConfig(
+            max_retries=1,  # inner loop gives up after 1 failed attempt
+            base_delay=0.0,
+            max_delay=0.0,
+            reconnect_window=60.0,
+            outer_loop_delay=0.0,  # no real sleep in tests
+        )
+        output = []
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, shell_id="s", reconnect_config=config) as shell:
+                async for frame in shell:
+                    if frame.channel == ShellChannel.STDOUT:
+                        output.append(frame.text)
+
+        # ws2 succeeded on the second outer cycle
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_reconnect_window_zero_skips_inner_loop(self):
+        """reconnect_window=0.0 must give up immediately — no inner retry attempts at all."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+        connect_count = 0
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            nonlocal connect_count
+            connect_count += 1
+            if connect_count == 1:
+                return ws
+            raise ConnectionRefusedError("should never be reached")
+
+        config = ReconnectConfig(max_retries=5, base_delay=0.0, reconnect_window=0.0)
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for _ in shell:
+                    pass
+
+        assert connect_count == 1  # no retries attempted
+
+    @pytest.mark.asyncio
+    async def test_reconnect_window_expiry_stops_iteration(self):
+        """When reconnect_window=0.0 the outer loop gives up immediately after inner exhaustion."""
+
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        call_count = 0
+
+        async def fake_connect(url, extra_headers=None, additional_headers=None, **_kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return ws
+            raise ConnectionRefusedError("server down")
+
+        config = ReconnectConfig(
+            max_retries=2,
+            base_delay=0.0,
+            max_delay=0.0,
+            reconnect_window=0.0,  # window already expired — no outer loop
+        )
+        frames = []
+        with patch("websockets.connect", side_effect=fake_connect):
+            async with ShellSession(client, FAKE_ARN, reconnect_config=config) as shell:
+                async for frame in shell:
+                    frames.append(frame)
+
+        assert frames == []
+
+
+class TestShellSessionExitCode:
+    @pytest.mark.asyncio
+    async def test_exit_code_zero_on_clean_exit(self):
+        """exit_code is 0 after a clean shell exit (status=Success)."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), _exit_frame(0))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.exit_code == 0
+
+    @pytest.mark.asyncio
+    async def test_exit_code_nonzero(self):
+        """exit_code reflects non-zero exit status from ExitCode cause."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), _exit_frame(42))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.exit_code == 42
+
+    @pytest.mark.asyncio
+    async def test_exit_code_none_before_exit(self):
+        """exit_code is None until the termination STATUS frame is processed."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), _stdout_frame("hi"), _exit_frame(1))
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                exit_code_mid_loop = None
+                async for frame in shell:
+                    if frame.channel == ShellChannel.STDOUT:
+                        exit_code_mid_loop = shell.exit_code
+
+        assert exit_code_mid_loop is None  # not set yet during STDOUT frame
+        assert shell.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_exit_code_set_via_pending_frames_path(self):
+        """exit_code is set when the termination STATUS is drained from _pending_frames."""
+        import websockets.exceptions
+
+        client = _make_client()
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.close = AsyncMock()
+        call_count = 0
+
+        async def recv():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First recv during _connect() returns a STDOUT frame — stashed as pending
+                return _stdout_frame("stashed")
+            if call_count == 2:
+                # Second recv during _connect() returns the metadata confirmation
+                return _metadata_frame()
+            if call_count == 3:
+                return _exit_frame(5)
+            raise websockets.exceptions.ConnectionClosedOK(None, None)
+
+        ws.recv = recv
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                frames = [frame async for frame in shell]
+
+        # stashed STDOUT frame drained first, then the exit STATUS frame
+        assert frames[0].channel == ShellChannel.STDOUT
+        assert frames[1].channel == ShellChannel.STATUS
+        assert shell.exit_code == 5
+
+    @pytest.mark.asyncio
+    async def test_exit_code_platform_error_without_exit_code_cause(self):
+        """exit_code is None when a Failure STATUS has no ExitCode cause (e.g. InternalError)."""
+        import json
+
+        platform_error = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {},
+                "status": "Failure",
+                "reason": "InternalError",
+                "message": "init container failed",
+                "code": 500,
+            }
+        ).encode()
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), bytes([ShellChannel.STATUS]) + platform_error)
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.exit_code is None
+
+
+class TestShellSessionBytesDropped:
+    def _second_confirmation_frame(self, shell_id: str = "test-session", bytes_dropped: int = 1024) -> bytes:
+        payload = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {"commandSessionId": shell_id, "reconnected": True, "bytesDropped": bytes_dropped},
+                "status": "Success",
+            }
+        ).encode()
+        return bytes([0x03]) + payload
+
+    @pytest.mark.asyncio
+    async def test_bytes_dropped_set_on_second_confirmation(self):
+        """Second confirmation frame with bytesDropped sets shell.bytes_dropped."""
+        client = _make_client()
+        ws = _make_ws(
+            _metadata_frame("s"),
+            _stdout_frame("output"),
+            self._second_confirmation_frame("s", bytes_dropped=512),
+            _close_frame(),
+        )
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, shell_id="s") as shell:
+                frames = [frame async for frame in shell]
+
+        assert shell.bytes_dropped == 512
+        # Second confirmation must be swallowed — only stdout frame yielded
+        assert len(frames) == 1
+        assert frames[0].channel == ShellChannel.STDOUT
+
+    @pytest.mark.asyncio
+    async def test_bytes_dropped_zero_when_no_overflow(self):
+        """bytes_dropped stays 0 when no second confirmation arrives."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame(), _close_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN) as shell:
+                async for _ in shell:
+                    pass
+
+        assert shell.bytes_dropped == 0
+
+    @pytest.mark.asyncio
+    async def test_second_confirmation_without_bytes_dropped_swallowed(self):
+        """Second confirmation with no bytesDropped field is still swallowed."""
+        client = _make_client()
+        # Second confirmation without bytesDropped (single overflow frame edge case)
+        second_conf = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {"commandSessionId": "s", "reconnected": True},
+                "status": "Success",
+            }
+        ).encode()
+        ws = _make_ws(
+            _metadata_frame("s"),
+            bytes([0x03]) + second_conf,
+            _close_frame(),
+        )
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, shell_id="s") as shell:
+                frames = [frame async for frame in shell]
+
+        assert shell.bytes_dropped == 0
+        assert frames == []  # second confirmation swallowed, close frame stops iteration
+
+
+class TestShellSessionAuthModes:
+    """open_shell routes to the correct auth helper based on the auth= argument."""
+
+    @pytest.mark.asyncio
+    async def test_sigv4_default_uses_connect_shell(self):
+        client = _make_client()
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)) as mock_connect:
+            async with ShellSession(client, FAKE_ARN, auth="sigv4") as _:
+                pass
+
+        client.connect_shell.assert_called_once()
+        client.connect_shell_presigned.assert_not_called()
+        client.connect_shell_oauth.assert_not_called()
+        # SigV4 path passes additional_headers (websockets ≥13) or extra_headers (≤12)
+        _, kwargs = mock_connect.call_args
+        assert "additional_headers" in kwargs or "extra_headers" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_presigned_uses_connect_shell_presigned(self):
+        presigned_url = "wss://bedrock-agentcore.us-west-2.amazonaws.com/runtimes/X/ws/commands?X-Amz-Signature=abc"
+        client = MagicMock()
+        client.connect_shell_presigned.return_value = presigned_url
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)) as mock_connect:
+            async with ShellSession(client, FAKE_ARN, auth=PresignedAuth(expires=120)) as _:
+                pass
+
+        client.connect_shell_presigned.assert_called_once()
+        client.connect_shell.assert_not_called()
+        client.connect_shell_oauth.assert_not_called()
+        # Presigned path passes NO headers or subprotocols
+        _, kwargs = mock_connect.call_args
+        assert "extra_headers" not in kwargs
+        assert "additional_headers" not in kwargs
+        assert "subprotocols" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_presigned_forwards_expires(self):
+        client = MagicMock()
+        client.connect_shell_presigned.return_value = FAKE_URL
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, auth=PresignedAuth(expires=60)) as _:
+                pass
+
+        _, kwargs = client.connect_shell_presigned.call_args
+        assert kwargs["expires"] == 60
+
+    @pytest.mark.asyncio
+    async def test_oauth_uses_connect_shell_oauth(self):
+        client = MagicMock()
+        import base64
+
+        encoded = base64.urlsafe_b64encode(b"tok").decode().rstrip("=")
+        expected_protos = [f"base64UrlBearerAuthorization.{encoded}", "base64UrlBearerAuthorization"]
+        client.connect_shell_oauth.return_value = (FAKE_URL, expected_protos)
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)) as mock_connect:
+            async with ShellSession(client, FAKE_ARN, auth=OAuthAuth(bearer_token="tok")) as _:
+                pass
+
+        client.connect_shell_oauth.assert_called_once()
+        client.connect_shell.assert_not_called()
+        client.connect_shell_presigned.assert_not_called()
+        # OAuth path passes subprotocols
+        _, kwargs = mock_connect.call_args
+        assert kwargs.get("subprotocols") == expected_protos
+
+    @pytest.mark.asyncio
+    async def test_oauth_forwards_bearer_token(self):
+        client = MagicMock()
+        import base64
+
+        encoded = base64.urlsafe_b64encode(b"my-token").decode().rstrip("=")
+        protos = [f"base64UrlBearerAuthorization.{encoded}", "base64UrlBearerAuthorization"]
+        client.connect_shell_oauth.return_value = (FAKE_URL, protos)
+        ws = _make_ws(_metadata_frame())
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            async with ShellSession(client, FAKE_ARN, auth=OAuthAuth(bearer_token="my-token")) as _:
+                pass
+
+        _, kwargs = client.connect_shell_oauth.call_args
+        assert kwargs["bearer_token"] == "my-token"
+
+
+class TestReconnectConfig:
+    def test_defaults(self):
+        config = ReconnectConfig()
+        assert config.max_retries == 5
+        assert config.base_delay == 1.0
+        assert config.max_delay == 15.0
+        assert config.on_reconnect is None
+
+    def test_unlimited_retries_with_none_window(self):
+        config = ReconnectConfig(reconnect_window=None)
+        assert config.reconnect_window is None

--- a/tests/unit/runtime/test_shell.py
+++ b/tests/unit/runtime/test_shell.py
@@ -52,6 +52,8 @@ def _make_ws(*frames, end_with=None):
     ws.recv = recv
     ws.send = AsyncMock()
     ws.close = AsyncMock()
+    ws.response = MagicMock()
+    ws.response.headers = {}
     return ws
 
 
@@ -181,6 +183,39 @@ class TestShellSessionConnect:
         assert session._ws is None
 
     @pytest.mark.asyncio
+    async def test_session_id_stable_across_two_connect_calls(self):
+        """session_id must not change between _connect() calls — same value routes to same VM."""
+        client = _make_client()
+        ws1 = _make_ws(_metadata_frame("my-shell"))
+        ws2 = _make_ws(_metadata_frame("my-shell"))
+
+        with patch("websockets.connect", new=AsyncMock(side_effect=[ws1, ws2])):
+            session = ShellSession(client, FAKE_ARN, shell_id="my-shell")
+            first_session_id = session.session_id
+
+            await session._connect()
+            assert session.session_id == first_session_id
+
+            await session._connect()
+            assert session.session_id == first_session_id
+
+    @pytest.mark.asyncio
+    async def test_connect_reads_session_id_from_101_header(self):
+        """X-Amzn-Bedrock-AgentCore-Runtime-Session-Id in 101 response updates session_id."""
+        client = _make_client()
+        ws = _make_ws(_metadata_frame("my-shell"))
+        ws.response.headers = {
+            "X-Command-Session-Id": "my-shell",
+            "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id": "server-session-99",
+        }
+
+        with patch("websockets.connect", new=AsyncMock(return_value=ws)):
+            session = ShellSession(client, FAKE_ARN, shell_id="my-shell")
+            await session._connect()
+
+        assert session.session_id == "server-session-99"
+
+    @pytest.mark.asyncio
     async def test_connect_timeout_proceeds_with_warning(self, caplog):
         """TimeoutError waiting for STATUS logs a warning but session stays usable."""
         import logging
@@ -190,6 +225,8 @@ class TestShellSessionConnect:
         ws.recv = AsyncMock(side_effect=asyncio.TimeoutError)
         ws.send = AsyncMock()
         ws.close = AsyncMock()
+        ws.response = MagicMock()
+        ws.response.headers = {}
 
         with patch("websockets.connect", new=AsyncMock(return_value=ws)):
             with caplog.at_level(logging.WARNING, logger="bedrock_agentcore.runtime.shell"):
@@ -209,8 +246,26 @@ class TestShellSessionInit:
     def test_none_shell_id_autogenerates_uuid(self):
         client = _make_client()
         session = ShellSession(client, FAKE_ARN, shell_id=None)
-        assert session._shell_id is not None
-        assert len(session._shell_id) > 0
+        assert session.shell_id is not None
+        assert len(session.shell_id) > 0
+
+    def test_none_session_id_autogenerates_uuid(self):
+        client = _make_client()
+        session = ShellSession(client, FAKE_ARN, session_id=None)
+        assert session.session_id is not None
+        assert len(session.session_id) > 0
+
+    def test_empty_string_session_id_autogenerates_uuid(self):
+        """Empty string is treated as omitted — auto-generate a UUID."""
+        client = _make_client()
+        session = ShellSession(client, FAKE_ARN, session_id="")
+        assert session.session_id != ""
+        assert len(session.session_id) > 0
+
+    def test_explicit_session_id_preserved(self):
+        client = _make_client()
+        session = ShellSession(client, FAKE_ARN, session_id="my-session")
+        assert session.session_id == "my-session"
 
     @pytest.mark.parametrize("bad", [0, False, b"", 1.5])
     def test_non_string_shell_id_raises_at_construction(self, bad):

--- a/tests/unit/runtime/test_shell_protocol.py
+++ b/tests/unit/runtime/test_shell_protocol.py
@@ -1,0 +1,166 @@
+"""Tests for ShellFramer and related types."""
+
+import json
+
+import pytest
+
+from bedrock_agentcore.runtime.shell import ShellChannel, ShellFrame, ShellFramer
+
+
+class TestShellChannel:
+    def test_values(self):
+        assert ShellChannel.STDIN == 0x00
+        assert ShellChannel.STDOUT == 0x01
+        assert ShellChannel.STDERR == 0x02
+        assert ShellChannel.STATUS == 0x03
+        assert ShellChannel.RESIZE == 0x04
+        assert ShellChannel.HEARTBEAT == 0x05
+        assert ShellChannel.CLOSE == 0xFF
+
+
+class TestShellFrame:
+    def test_text_property(self):
+        frame = ShellFrame(channel=ShellChannel.STDOUT, raw_channel_byte=0x01, payload=b"hello")
+        assert frame.text == "hello"
+
+    def test_text_property_replaces_invalid_bytes(self):
+        frame = ShellFrame(channel=ShellChannel.STDOUT, raw_channel_byte=0x01, payload=b"\xff\xfe")
+        assert "�" in frame.text
+
+    def test_json_property(self):
+        payload = json.dumps({"exitCode": 0}).encode()
+        frame = ShellFrame(channel=ShellChannel.STATUS, raw_channel_byte=0x03, payload=payload)
+        assert frame.json() == {"exitCode": 0}
+
+    def test_json_raises_on_invalid_payload(self):
+        frame = ShellFrame(channel=ShellChannel.STATUS, raw_channel_byte=0x03, payload=b"not json")
+        with pytest.raises(json.JSONDecodeError):
+            frame.json()
+
+
+class TestShellFramerDecode:
+    def setup_method(self):
+        self.framer = ShellFramer()
+
+    def test_decode_stdout(self):
+        raw = bytes([ShellChannel.STDOUT]) + b"hello"
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.STDOUT
+        assert frame.payload == b"hello"
+
+    def test_decode_stdin(self):
+        raw = bytes([ShellChannel.STDIN]) + b"ls\n"
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.STDIN
+        assert frame.payload == b"ls\n"
+
+    def test_decode_status_exit(self):
+        payload = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {},
+                "status": "Failure",
+                "reason": "NonZeroExitCode",
+                "details": {"causes": [{"reason": "ExitCode", "message": "1"}]},
+            }
+        ).encode()
+        raw = bytes([ShellChannel.STATUS]) + payload
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.STATUS
+        causes = frame.json()["details"]["causes"]
+        assert causes[0]["message"] == "1"
+
+    def test_decode_status_confirmation(self):
+        payload = json.dumps(
+            {
+                "kind": "Status",
+                "apiVersion": "v1",
+                "metadata": {"commandSessionId": "my-shell", "reconnected": False},
+                "status": "Success",
+            }
+        ).encode()
+        raw = bytes([ShellChannel.STATUS]) + payload
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.STATUS
+        assert frame.json()["metadata"]["commandSessionId"] == "my-shell"
+
+    def test_decode_resize(self):
+        payload = json.dumps({"width": 80, "height": 24}).encode()
+        raw = bytes([ShellChannel.RESIZE]) + payload
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.RESIZE
+
+    def test_decode_close_empty_payload(self):
+        raw = bytes([ShellChannel.CLOSE])
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.CLOSE
+        assert frame.payload == b""
+
+    def test_decode_unknown_channel_preserved(self):
+        raw = bytes([0x42]) + b"future data"
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.UNKNOWN
+        assert frame.raw_channel_byte == 0x42
+        assert frame.payload == b"future data"
+
+    def test_decode_known_channel_raw_byte_matches(self):
+        raw = bytes([ShellChannel.STDOUT]) + b"hello"
+        frame = self.framer.decode(raw)
+        assert frame.channel == ShellChannel.STDOUT
+        assert frame.raw_channel_byte == ShellChannel.STDOUT
+
+    def test_decode_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            self.framer.decode(b"")
+
+
+class TestShellFramerEncode:
+    def setup_method(self):
+        self.framer = ShellFramer()
+
+    def test_encode_stdin_str(self):
+        frame = self.framer.encode_stdin("ls\n")
+        assert frame[0] == ShellChannel.STDIN
+        assert frame[1:] == b"ls\n"
+
+    def test_encode_stdin_bytes(self):
+        frame = self.framer.encode_stdin(b"\x1b[A")
+        assert frame[0] == ShellChannel.STDIN
+        assert frame[1:] == b"\x1b[A"
+
+    def test_encode_stdin_exceeds_limit_raises(self):
+        big = "x" * (ShellFramer.MAX_FRAME_SIZE)
+        with pytest.raises(ValueError, match="64 KB"):
+            self.framer.encode_stdin(big)
+
+    def test_encode_stdin_at_limit_ok(self):
+        data = b"x" * (ShellFramer.MAX_FRAME_SIZE - 1)
+        frame = self.framer.encode_stdin(data)
+        assert len(frame) == ShellFramer.MAX_FRAME_SIZE
+
+    def test_encode_resize(self):
+        frame = self.framer.encode_resize(220, 50)
+        assert frame[0] == ShellChannel.RESIZE
+        payload = json.loads(frame[1:])
+        assert payload == {"width": 220, "height": 50}
+
+    @pytest.mark.parametrize("width,height", [(0, 24), (80, 0), (-1, 24), (80, -1), (0, 0)])
+    def test_encode_resize_invalid_dimensions_raises(self, width, height):
+        with pytest.raises(ValueError, match="positive integers"):
+            self.framer.encode_resize(width, height)
+
+    def test_encode_heartbeat(self):
+        frame = self.framer.encode_heartbeat()
+        assert frame == bytes([ShellChannel.HEARTBEAT])
+
+    def test_encode_close(self):
+        frame = self.framer.encode_close()
+        assert frame == bytes([ShellChannel.CLOSE])
+
+    def test_round_trip_stdin(self):
+        original = "echo hello\n"
+        encoded = self.framer.encode_stdin(original)
+        decoded = self.framer.decode(encoded)
+        assert decoded.channel == ShellChannel.STDIN
+        assert decoded.text == original

--- a/tests/unit/runtime/test_shell_protocol.py
+++ b/tests/unit/runtime/test_shell_protocol.py
@@ -76,14 +76,14 @@ class TestShellFramerDecode:
             {
                 "kind": "Status",
                 "apiVersion": "v1",
-                "metadata": {"commandSessionId": "my-shell", "reconnected": False},
+                "metadata": {"shellId": "my-shell", "reconnected": False},
                 "status": "Success",
             }
         ).encode()
         raw = bytes([ShellChannel.STATUS]) + payload
         frame = self.framer.decode(raw)
         assert frame.channel == ShellChannel.STATUS
-        assert frame.json()["metadata"]["commandSessionId"] == "my-shell"
+        assert frame.json()["metadata"]["shellId"] == "my-shell"
 
     def test_decode_resize(self):
         payload = json.dumps({"width": 80, "height": 24}).encode()

--- a/uv.lock
+++ b/uv.lock
@@ -443,7 +443,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.13.2,<5.0.0" },
     { name = "urllib3", specifier = ">=1.26.0" },
     { name = "uvicorn", specifier = ">=0.34.2" },
-    { name = "websockets", specifier = ">=12.0" },
+    { name = "websockets", specifier = ">=13.0" },
 ]
 provides-extras = ["a2a", "ag-ui", "strands-agents", "strands-agents-evals", "simulation"]
 


### PR DESCRIPTION
# Description:
  
## Summary

Adds SDK support for the invoke runtime shell API — a WebSocket-based interactive PTY session running inside the agent VM.

**New**: runtime/shell/ subpackage
session.py - ShellSession async context manager — connect, send, iterate frames, reconnect
protocol.py - ShellFramer — encode/decode the binary channel-prefix wire protocol   
auth.py - AuthMode union: "sigv4" (default), PresignedAuth, OAuthAuth 
config.py - ReconnectConfig — backoff parameters, reconnect window, callback
_validation.py - ARN parsing, shell_id character-set validation       

**Wire protocol**
Frames use the Kubernetes v5.channel.k8s.io binary prefix scheme:

**Key behaviours**

  - Auth: SigV4 (server default), presigned URL (hand-off to another process), OAuth bearer token (browser clients via Sec-WebSocket-Protocol).
  - Reconnect: Two-layer exponential backoff with jitter. Inner loop retries up to max_retries; outer loop cycles until reconnect_window expires. Both shell_id and session_id must be pinned — shell_id names the
  PTY, session_id routes to the VM.
  - Auto-generated IDs: ShellSession.__init__ generates stable UUIDs for both shell_id and session_id upfront so reconnects always route to the same VM.
  - Exit code: ShellSession.exit_code is set from the termination STATUS frame after the async for loop drains.
  - Graceful vs abrupt close: __aexit__ sends a CLOSE frame (terminates PTY). An abrupt network drop sets _ws = None so __aexit__ skips the CLOSE frame, leaving the PTY alive for reconnection.
  - Kicked detection: Close code 4000 sets shell.kicked = True and suppresses auto-reconnect.

  AgentCoreRuntimeClient additions

  - open_shell() — main entry point, returns ShellSession
  - connect_shell() — SigV4 URL + headers (raw WebSocket use)
  - connect_shell_presigned() — presigned wss:// URL
  - connect_shell_oauth() — URL + subprotocols list

**Tests**

new unit tests across three files (test_shell.py, test_connect_shell.py, test_shell_protocol.py) covering auth flows, reconnect logic, frame queue, exit codes, kicked detection, and wire encode/decode. 

**Test plan**

  - [ ] pytest tests/unit/runtime/test_shell.py tests/unit/runtime/test_connect_shell.py tests/unit/runtime/test_shell_protocol.py — all pass
  - [ ] pytest tests/unit/runtime/test_agent_core_runtime_client.py — no regressions
  - [ ] Manual integ test: connect to a runtime ARN, send a command, iterate STDOUT frames, verify shell.exit_code after exit
  - [ ] Manual reconnect test: pin shell_id + session_id, drop the connection abruptly, reconnect and verify shell.reconnected = True

## Dependencies

websockets>=13.0  runtime dependency (required for the binary frame WebSocket protocol used by invoke runtime shell api

