### PR TITLE
fix: lazy import requests in dataset_providers to fix ModuleNotFoundE…

### DIFF
--- a/src/bedrock_agentcore/evaluation/runner/dataset_providers.py
+++ b/src/bedrock_agentcore/evaluation/runner/dataset_providers.py
@@ -4,7 +4,7 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-import requests
+
 
 from bedrock_agentcore.evaluation.dataset_client import DatasetClient
 
@@ -130,6 +130,7 @@ class DatasetManagementServiceProvider(DatasetProvider):
             raise ValueError(f"Dataset {self._dataset_id} has no downloadUrl. Status: {response.get('status')}")
 
         try:
+            import requests
             r = requests.get(download_url, timeout=60, stream=True)
             r.raise_for_status()
         except requests.RequestException as e:


### PR DESCRIPTION
Problem:
importing anything from bedrock_agentcore.evaluation on a fresh install
failed with ModuleNotFoundError: No module named 'requests' because
requests was imported at the top of dataset_providers.py but was not
declared as a runtime dependency in pyproject.toml.

Fix:
Moved `import requests` from the module-level into the body of
DatasetManagementServiceProvider.get_dataset(), so it is only imported
when actually needed. Users who never download datasets from a URL are
not affected and no longer require requests to be installed.

Files changed:
src/bedrock_agentcore/evaluation/runner/dataset_providers.py