### PR TITLE
fix: declare requests as optional 'datasets' extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,3 +173,6 @@ simulation = [
     "jinja2>=3.1.0",
     "strands-agents-evals>=0.1.0",
 ]
+datasets = [
+    "requests>=2.31.0",
+]

--- a/src/bedrock_agentcore/evaluation/runner/dataset_providers.py
+++ b/src/bedrock_agentcore/evaluation/runner/dataset_providers.py
@@ -4,8 +4,6 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
-import requests
-
 from bedrock_agentcore.evaluation.dataset_client import DatasetClient
 
 from .dataset_types import (
@@ -128,6 +126,14 @@ class DatasetManagementServiceProvider(DatasetProvider):
         download_url = response.get("downloadUrl")
         if not download_url:
             raise ValueError(f"Dataset {self._dataset_id} has no downloadUrl. Status: {response.get('status')}")
+
+        try:
+            import requests
+        except ImportError as e:
+            raise ImportError(
+                "DatasetManagementServiceProvider requires the 'datasets' extra. "
+                "Install it with: pip install 'bedrock-agentcore[datasets]'"
+            ) from e
 
         try:
             r = requests.get(download_url, timeout=60, stream=True)

--- a/tests/bedrock_agentcore/evaluation/test_service_dataset_provider.py
+++ b/tests/bedrock_agentcore/evaluation/test_service_dataset_provider.py
@@ -11,7 +11,10 @@ from bedrock_agentcore.evaluation.runner.dataset_types import (
     SimulatedScenario,
 )
 
-PATCH_REQUESTS = "bedrock_agentcore.evaluation.runner.dataset_providers.requests"
+# requests is imported lazily inside get_dataset (it's an optional 'datasets'
+# extra), so we patch the real module's attribute rather than a module-level
+# attribute on dataset_providers.
+PATCH_REQUESTS_GET = "requests.get"
 
 
 def _jsonl(*examples):
@@ -37,12 +40,12 @@ class TestDatasetManagementServiceProvider:
         mock_response.iter_lines.return_value = [line.encode("utf-8") for line in jsonl_content.split("\n") if line]
         mock_response.raise_for_status = MagicMock()
 
-        with patch(PATCH_REQUESTS) as mock_requests:
-            mock_requests.get.return_value = mock_response
+        with patch(PATCH_REQUESTS_GET) as mock_get:
+            mock_get.return_value = mock_response
             provider = DatasetManagementServiceProvider(
                 dataset_id=dataset_id, version_id=version_id, client=mock_client
             )
-            return provider.get_dataset(), mock_client, mock_requests
+            return provider.get_dataset(), mock_client, mock_get
 
     def test_get_dataset_predefined(self):
         content = _jsonl(
@@ -60,7 +63,7 @@ class TestDatasetManagementServiceProvider:
             },
         )
 
-        dataset, mock_client, mock_requests = self._run_provider(content)
+        dataset, mock_client, mock_get = self._run_provider(content)
 
         assert isinstance(dataset, Dataset)
         assert len(dataset.scenarios) == 2
@@ -110,10 +113,10 @@ class TestDatasetManagementServiceProvider:
     def test_downloads_from_presigned_url(self):
         content = _jsonl({"scenario_id": "s1", "turns": [{"input": "hi"}]})
 
-        _, mock_client, mock_requests = self._run_provider(content)
+        _, mock_client, mock_get = self._run_provider(content)
 
         mock_client.get_dataset.assert_called_once_with(datasetId="ds-123")
-        mock_requests.get.assert_called_once_with("https://example.com/dataset.jsonl", timeout=60, stream=True)
+        mock_get.assert_called_once_with("https://example.com/dataset.jsonl", timeout=60, stream=True)
 
     def test_get_dataset_with_version_id(self):
         content = _jsonl({"scenario_id": "s1", "turns": [{"input": "hi"}]})
@@ -147,8 +150,8 @@ class TestDatasetManagementServiceProvider:
         mock_response.iter_lines.return_value = []
         mock_response.raise_for_status = MagicMock()
 
-        with patch(PATCH_REQUESTS) as mock_requests:
-            mock_requests.get.return_value = mock_response
+        with patch(PATCH_REQUESTS_GET) as mock_get:
+            mock_get.return_value = mock_response
             provider = DatasetManagementServiceProvider(dataset_id="ds-empty", client=mock_client)
             with pytest.raises(ValueError, match="scenarios must not be empty"):
                 provider.get_dataset()
@@ -166,6 +169,24 @@ class TestDatasetManagementServiceProvider:
         with pytest.raises(ValueError, match="not supported by the evaluation runners"):
             provider.get_dataset()
 
+    def test_missing_requests_raises_helpful_import_error(self):
+        import sys
+
+        mock_client = MagicMock()
+        mock_client.get_dataset.return_value = {
+            "datasetId": "ds-123",
+            "status": "ACTIVE",
+            "schemaType": "AGENTCORE_EVALUATION_PREDEFINED_V1",
+            "downloadUrl": "https://example.com/dataset.jsonl",
+        }
+
+        # Setting the entry to None makes `import requests` raise ImportError,
+        # simulating an install without the optional 'datasets' extra.
+        with patch.dict(sys.modules, {"requests": None}):
+            provider = DatasetManagementServiceProvider(dataset_id="ds-123", client=mock_client)
+            with pytest.raises(ImportError, match=r"bedrock-agentcore\[datasets\]"):
+                provider.get_dataset()
+
     def test_download_failure_raises_runtime_error(self):
         import requests as real_requests
 
@@ -180,9 +201,8 @@ class TestDatasetManagementServiceProvider:
         mock_response = MagicMock()
         mock_response.raise_for_status.side_effect = real_requests.HTTPError("403 Forbidden")
 
-        with patch(PATCH_REQUESTS) as mock_requests:
-            mock_requests.get.return_value = mock_response
-            mock_requests.RequestException = real_requests.RequestException
+        with patch(PATCH_REQUESTS_GET) as mock_get:
+            mock_get.return_value = mock_response
             provider = DatasetManagementServiceProvider(dataset_id="ds-123", client=mock_client)
             with pytest.raises(RuntimeError, match="Couldn't download dataset"):
                 provider.get_dataset()


### PR DESCRIPTION
## Problem

On a fresh install, importing from `bedrock_agentcore.evaluation` and downloading a dataset from the Dataset Management service fails with `ModuleNotFoundError: No module named 'requests'`. `requests` was imported at module top level in `dataset_providers.py` but was never declared as a dependency.

## Fix

Declare `requests` as a new optional `datasets` extra, matching the repo's existing pattern for optional features (`strands-agents-evals`, `simulation`, `a2a`, `ag-ui`):

- **`pyproject.toml`** — add `datasets = ["requests>=2.31.0"]` under `[project.optional-dependencies]`, keeping `requests` out of the base install for users who never download datasets.
- **`dataset_providers.py`** — import `requests` lazily inside `get_dataset()`, raising a clear `ImportError` that points users at `pip install 'bedrock-agentcore[datasets]'` when the extra is not installed.
- **tests** — patch `requests.get` (the lazy import target) and add a test covering the missing-dependency path.

## Why this over a bare lazy import

A lazy import alone never declares the dependency, so a fresh install still fails — just later, at call time. This approach declares the dependency, fails with actionable install guidance when it's absent, and follows the convention already used elsewhere in the SDK.

## Testing

`test_service_dataset_provider.py` passes (9 tests, including the new missing-dependency case); `ruff check` clean.
