### PR TITLE
fix(a2a): cap a2a-sdk below 1.0 to restore A2A server startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,13 +154,13 @@ dev = [
     "wheel>=0.45.1",
     "strands-agents>=1.20.0",
     "strands-agents-evals>=0.1.0",
-    "a2a-sdk[http-server]>=0.3",
+    "a2a-sdk[http-server]>=0.3,<1.0",
     "ag-ui-protocol>=0.1.10",
     "mcp-proxy-for-aws>=0.1.0",
 ]
 
 [project.optional-dependencies]
-a2a = ["a2a-sdk[http-server]>=0.3"]
+a2a = ["a2a-sdk[http-server]>=0.3,<1.0"]
 ag-ui = ["ag-ui-protocol>=0.1.10"]
 strands-agents = [
     "strands-agents>=1.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -429,7 +429,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a'", specifier = ">=0.3" },
+    { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a'", specifier = ">=0.3,<1.0" },
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
     { name = "boto3", specifier = ">=1.43.0" },
     { name = "botocore", specifier = ">=1.43.0" },
@@ -449,7 +449,7 @@ provides-extras = ["a2a", "ag-ui", "strands-agents", "strands-agents-evals", "si
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3" },
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3,<1.0" },
     { name = "ag-ui-protocol", specifier = ">=0.1.10" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp-proxy-for-aws", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Problem

`pip install "bedrock-agentcore[a2a]"` fails to start the A2A server with `No module named 'a2a.server.apps'` (and a related `cannot import name 'DataPart' from 'a2a.types'`). The `a2a` extra and dev dependency pinned `a2a-sdk[http-server]>=0.3` with no upper bound, so fresh installs now resolve to a2a-sdk **1.x**, whose server API was redesigned in v1.0.0 and is incompatible with `runtime/a2a.py` (which targets 0.3.x).

Verified against a2a-sdk 1.1.0:
- `a2a.server.apps` module removed
- `A2AStarletteApplication` and `CallContextBuilder` removed
- `a2a.types.DataPart` moved to `a2a.compat.v0_3.types`

## Fix

Cap the dependency to the supported API in both the `a2a` extra and the dev dependency:

```
a2a-sdk[http-server]>=0.3,<1.0
```

This restores a working install immediately, with no code change. Migrating `runtime/a2a.py` to the a2a-sdk v1.x API (which would lift this cap) is a larger effort tracked in #509.

## Testing

Confirmed in a clean venv that a2a-sdk 1.1.0 raises `No module named 'a2a.server.apps'` on the import path used by `serve_a2a`, and that `<1.0` resolves to the 0.3.x line the integration supports.

Fixes #438.
Follow-up migration: #509.
