### PR TITLE
fix(payments): correct "extension" typo to "extensions" in x402 v2 he…

### DIFF
--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -1452,7 +1452,7 @@ class PaymentManager:
                     "x402Version": 2,
                     "resource": x402_payload.get("resource"),
                     "accepted": selected_accept,
-                    "extension": x402_payload.get("extension", {}),
+                    "extensions": x402_payload.get("extensions", {}),
                     "payload": crypto_x402_proof.get("payload"),
                 }
                 header_json = json.dumps(payment_signature)

--- a/tests/bedrock_agentcore/payments/test_payment_manager.py
+++ b/tests/bedrock_agentcore/payments/test_payment_manager.py
@@ -2524,7 +2524,7 @@ class TestGeneratePaymentHeaderIntegration:
         assert header_json["resource"] == "https://example.com/resource"
         assert header_json["payload"] == "v2-proof"
         assert "accepted" in header_json
-        assert "extension" in header_json
+        assert "extensions" in header_json
 
         # Verify mocks were called correctly
         mock_client.get_payment_instrument.assert_called_once()

--- a/tests_integ/payments/test_payment_manager.py
+++ b/tests_integ/payments/test_payment_manager.py
@@ -539,7 +539,7 @@ class TestGeneratePaymentHeaderWorkflow:
         assert header_json["accepted"] is not None
         assert "payload" in header_json
         assert header_json["payload"] is not None
-        assert "extension" in header_json
+        assert "extensions" in header_json
 
         # Step 8: Verify scheme and network match the x402_response
         import json as json_module


### PR DESCRIPTION
…ader

The payment signature field name should be "extensions" (plural) to match the x402 protocol specification.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
