### PR TITLE
fix: remove invalid CLI entrypoint from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,6 @@ dependencies = [
     "websockets>=13.0",
 ]
 
-[project.scripts]
-bedrock-agentcore = "bedrock_agentcore.cli:main"
-
 [tool.hatch.metadata]
 allow-direct-references = true
 


### PR DESCRIPTION
## Summary

The `[project.scripts]` section in `pyproject.toml` declared a `bedrock-agentcore` CLI command pointing to `bedrock_agentcore.cli:main`, but no `cli` module exists in the package. Running the installed command failed immediately with:

```
ModuleNotFoundError: No module named 'bedrock_agentcore.cli'
```

This PR removes the invalid entrypoint. There is no CLI implementation in the source tree and no associated tests, so the declaration is simply incorrect.

Fixes #364

## Changes

- `pyproject.toml`: remove `[project.scripts]` section containing the broken `bedrock-agentcore` entrypoint