### PR TITLE
fix: use ConfigDict instead of class-based Config in RequestContext

### DIFF
--- a/src/bedrock_agentcore/runtime/context.py
+++ b/src/bedrock_agentcore/runtime/context.py
@@ -7,7 +7,7 @@ import logging
 from contextvars import ContextVar
 from typing import Any, Callable, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from ..config_bundle.bundle import ConfigBundleRef
 
@@ -21,10 +21,7 @@ class RequestContext(BaseModel):
     request_headers: Optional[Dict[str, str]] = Field(None)
     request: Optional[Any] = Field(None, description="The underlying Starlette request object")
 
-    class Config:
-        """Allow non-serializable types like Starlette Request."""
-
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 class BedrockAgentCoreContext:

--- a/tests/bedrock_agentcore/runtime/test_context.py
+++ b/tests/bedrock_agentcore/runtime/test_context.py
@@ -253,6 +253,22 @@ class TestRequestContext:
 
         assert context.request is mock_request
 
+    def test_request_context_no_pydantic_v1_deprecation_warning(self):
+        """RequestContext must not raise PydanticDeprecatedSince20 on instantiation.
+
+        Regression guard: class-based Config triggers this warning in Pydantic v2;
+        ConfigDict does not.  If someone reverts the fix, this test will fail.
+        """
+        import warnings
+
+        from pydantic import PydanticDeprecatedSince20
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", PydanticDeprecatedSince20)
+            context = RequestContext(session_id="regression-check", request_headers={"X-Test": "1"})
+
+        assert context.session_id == "regression-check"
+
 
 class TestBedrockAgentCoreContextConfigBundles:
     """Tests for config bundle ContextVar methods on BedrockAgentCoreContext."""


### PR DESCRIPTION
## Summary

`RequestContext` in `src/bedrock_agentcore/runtime/context.py` uses the Pydantic V1-style inner `class Config` to set `arbitrary_types_allowed = True`. Pydantic V2 deprecated this pattern and emits a `PydanticDeprecatedSince20` warning on every import of `BedrockAgentCoreApp`, adding noise to user applications and test suites.

Replace the inner `Config` class with `model_config = ConfigDict(arbitrary_types_allowed=True)` — the idiomatic Pydantic V2 pattern — so the warning is no longer emitted.

Fixes #320

## Changes

- `src/bedrock_agentcore/runtime/context.py`: import `ConfigDict` from `pydantic`; replace `class Config` with `model_config = ConfigDict(arbitrary_types_allowed=True)`