### PR TITLE
fix(ci): make security review robust to shallow-clone restoration

### DIFF
--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -178,191 +178,12 @@ jobs:
           echo "files=$FILES" >> "$GITHUB_OUTPUT"
           echo "Diff: $BYTES bytes across $FILES files"
 
-      - name: Build prompt
-        if: steps.diff.outputs.bytes != '0'
-        run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/prompt"
-          cat > "$RUNNER_TEMP/prompt/prompt.md" <<'PROMPT_EOF'
-          You are performing a HIGH-CONFIDENCE security code review of a pull
-          request. The complete diff is at `/tmp/pr.diff` — read it first
-          using the Read tool. That file is the ground truth for what the
-          PR changes; do not run `git diff` or any other git commands. To
-          understand context — callers of a changed function, existing
-          sanitization patterns, the project's threat model — use Grep,
-          Glob, and Read against the repository working tree. Do not use
-          Bash.
-
-          # OBJECTIVE
-
-          Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
-          by this PR that have real exploitation potential. This is NOT a
-          general code review. Focus ONLY on security implications added by
-          the PR. Do not comment on pre-existing issues.
-
-          # CRITICAL INSTRUCTIONS
-
-          1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
-             confident of actual exploitability.
-          2. AVOID NOISE: Skip theoretical issues, style concerns, or
-             low-impact findings.
-          3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
-             unauthorized access, data breach, or system compromise.
-          4. DO NOT report any of:
-             - Denial of service / resource exhaustion / rate limiting
-             - Secrets at rest on disk (handled by other tooling)
-             - Memory consumption or CPU exhaustion
-
-          # CATEGORIES TO EXAMINE
-
-          **Input validation**: SQL injection, command injection, XXE,
-          template injection, NoSQL injection, path traversal.
-          **AuthN/AuthZ**: authentication bypass, privilege escalation,
-          session/JWT flaws, authorization-logic bypasses.
-          **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
-          algorithms, improper key storage, weak randomness, certificate
-          validation bypass.
-          **Code execution**: deserialization RCE (pickle, YAML, etc.),
-          eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
-          (see precedents).
-          **Data exposure**: sensitive logging, PII handling violations,
-          API leakage, debug-info exposure.
-
-          A finding can still be HIGH severity if only exploitable from the
-          local network.
-
-          # METHODOLOGY
-
-          Phase 1 — Repository context: identify existing security
-          libraries/frameworks, sanitization patterns, the project's threat
-          model. Use search tools.
-
-          Phase 2 — Comparative analysis: compare new changes against
-          established patterns; flag deviations and net-new attack surface.
-
-          Phase 3 — Vulnerability assessment: for each modified file,
-          trace user input → sensitive operations, look for unsafe privilege
-          boundary crossings, identify injection points.
-
-          # FALSE-POSITIVE FILTER (apply hard)
-
-          Read the code (Read/Grep/Glob); do not run commands to reproduce
-          or write files.
-
-          HARD EXCLUSIONS — drop any finding matching:
-          1. DoS / resource exhaustion.
-          2. Secrets/credentials on disk if otherwise secured.
-          3. Rate limiting or service overload.
-          4. Memory/CPU exhaustion.
-          5. Missing input validation on non-security-critical fields.
-          6. Input sanitization in GitHub Actions workflows unless clearly
-             triggerable via untrusted input.
-          7. Lack of hardening; only flag concrete vulns.
-          8. Theoretical race conditions or timing attacks.
-          9. Outdated third-party libraries (handled separately).
-          10. Memory-safety issues in memory-safe languages (Rust, Go,
-              JS/TS, Python).
-          11. Files that are unit tests or test-only.
-          12. Log spoofing — un-sanitized user input to logs is not a vuln.
-          13. SSRF that only controls the path (host/protocol control is
-              required).
-          14. User-controlled content in AI system prompts is not a vuln.
-          15. Regex injection.
-          16. Regex DoS.
-          17. Insecure documentation (.md and similar).
-          18. Lack of audit logs.
-
-          PRECEDENTS:
-          1. Plaintext-logging high-value secrets IS a vuln; logging URLs
-             is assumed safe.
-          2. UUIDs are unguessable and need no validation.
-          3. Env vars and CLI flags are trusted inputs.
-          4. Resource leaks (memory, fd) are not vulns.
-          5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
-             only with extremely high confidence.
-          6. React / Angular: do not report XSS in components or .tsx files
-             unless using `dangerouslySetInnerHTML`,
-             `bypassSecurityTrustHtml`, or equivalents.
-          7. GitHub Actions workflow vulns: only when a concrete attack
-             path through untrusted input exists.
-          8. Missing AuthN/AuthZ in client-side code is not a vuln —
-             validation is the server's job.
-          9. MEDIUM findings only when obvious and concrete.
-          10. .ipynb notebook vulns: only with a concrete attack path
-              through untrusted input.
-          11. Logging non-PII data is not a vuln. Only flag when the data
-              is secrets, passwords, or PII.
-          12. Command injection in shell scripts: only when there is a
-              concrete attack path through untrusted input.
-
-          For each surviving finding, score confidence 1–10:
-          - 1–3: low / likely noise — drop
-          - 4–6: medium — drop unless obvious and concrete
-          - 7–10: high — keep
-
-          # PROCESS
-
-          Run this in three steps, exactly:
-
-          1. Spawn a Task sub-agent to identify candidate vulnerabilities.
-             Pass the full instructions above (objective, categories,
-             methodology, hard exclusions, precedents). Have it return a
-             structured list of candidates with file/line/category/
-             description/exploit/fix.
-
-          2. For EACH candidate from step 1, spawn an independent Task
-             sub-agent IN PARALLEL to adversarially verify it. Each
-             verifier gets the full FALSE-POSITIVE FILTER above and is
-             told to default to "drop" if uncertain. Each returns a
-             confidence score 1–10.
-
-          3. Drop any finding with confidence < 8. For every finding that
-             survives, call:
-
-                 mcp__github_inline_comment__create_inline_comment
-
-             with `{ path, line, body }` pointing at the exact file and
-             line in the diff. The body should follow:
-
-                 **<Severity>: <Category>**
-                 <One-paragraph description of the issue and concrete
-                 exploit scenario.>
-                 **Recommendation:** <One-sentence fix.>
-
-             Do NOT post a single summary comment listing all findings —
-             the workflow handles a top-level summary after this run
-             completes. If zero findings survive Phase 3, exit without
-             calling any tool.
-
-          Begin.
-          PROMPT_EOF
-
       - name: Configure AWS credentials
         if: steps.diff.outputs.bytes != '0'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
           aws-region: us-west-2
-
-      - name: Load prompt into env
-        id: load-prompt
-        if: steps.diff.outputs.bytes != '0'
-        # The action only accepts `prompt:` (a string), not a file path —
-        # passing prompt_file silently no-ops, leaves the action with no
-        # trigger, and skips the run with "No trigger found". Read the
-        # built prompt into an environment variable so we can pass it
-        # inline below. Using GITHUB_ENV with a randomized heredoc
-        # sentinel is the standard Actions idiom for multi-line values.
-        env:
-          PROMPT_FILE: ${{ runner.temp }}/prompt/prompt.md
-        run: |
-          set -euo pipefail
-          DELIM="EOF_$(uuidgen)"
-          {
-            echo "PROMPT_BODY<<$DELIM"
-            cat "$PROMPT_FILE"
-            echo "$DELIM"
-          } >> "$GITHUB_ENV"
 
       - name: Run Claude Code
         id: review
@@ -371,7 +192,158 @@ jobs:
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"
-          prompt: ${{ env.PROMPT_BODY }}
+          prompt: |
+            You are performing a HIGH-CONFIDENCE security code review of a pull
+            request. The complete diff is at `/tmp/pr.diff` — read it first
+            using the Read tool. That file is the ground truth for what the
+            PR changes; do not run `git diff` or any other git commands. To
+            understand context — callers of a changed function, existing
+            sanitization patterns, the project's threat model — use Grep,
+            Glob, and Read against the repository working tree. Do not use
+            Bash.
+
+            # OBJECTIVE
+
+            Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
+            by this PR that have real exploitation potential. This is NOT a
+            general code review. Focus ONLY on security implications added by
+            the PR. Do not comment on pre-existing issues.
+
+            # CRITICAL INSTRUCTIONS
+
+            1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
+               confident of actual exploitability.
+            2. AVOID NOISE: Skip theoretical issues, style concerns, or
+               low-impact findings.
+            3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
+               unauthorized access, data breach, or system compromise.
+            4. DO NOT report any of:
+               - Denial of service / resource exhaustion / rate limiting
+               - Secrets at rest on disk (handled by other tooling)
+               - Memory consumption or CPU exhaustion
+
+            # CATEGORIES TO EXAMINE
+
+            **Input validation**: SQL injection, command injection, XXE,
+            template injection, NoSQL injection, path traversal.
+            **AuthN/AuthZ**: authentication bypass, privilege escalation,
+            session/JWT flaws, authorization-logic bypasses.
+            **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
+            algorithms, improper key storage, weak randomness, certificate
+            validation bypass.
+            **Code execution**: deserialization RCE (pickle, YAML, etc.),
+            eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
+            (see precedents).
+            **Data exposure**: sensitive logging, PII handling violations,
+            API leakage, debug-info exposure.
+
+            A finding can still be HIGH severity if only exploitable from the
+            local network.
+
+            # METHODOLOGY
+
+            Phase 1 — Repository context: identify existing security
+            libraries/frameworks, sanitization patterns, the project's threat
+            model. Use search tools.
+
+            Phase 2 — Comparative analysis: compare new changes against
+            established patterns; flag deviations and net-new attack surface.
+
+            Phase 3 — Vulnerability assessment: for each modified file,
+            trace user input → sensitive operations, look for unsafe privilege
+            boundary crossings, identify injection points.
+
+            # FALSE-POSITIVE FILTER (apply hard)
+
+            Read the code (Read/Grep/Glob); do not run commands to reproduce
+            or write files.
+
+            HARD EXCLUSIONS — drop any finding matching:
+            1. DoS / resource exhaustion.
+            2. Secrets/credentials on disk if otherwise secured.
+            3. Rate limiting or service overload.
+            4. Memory/CPU exhaustion.
+            5. Missing input validation on non-security-critical fields.
+            6. Input sanitization in GitHub Actions workflows unless clearly
+               triggerable via untrusted input.
+            7. Lack of hardening; only flag concrete vulns.
+            8. Theoretical race conditions or timing attacks.
+            9. Outdated third-party libraries (handled separately).
+            10. Memory-safety issues in memory-safe languages (Rust, Go,
+                JS/TS, Python).
+            11. Files that are unit tests or test-only.
+            12. Log spoofing — un-sanitized user input to logs is not a vuln.
+            13. SSRF that only controls the path (host/protocol control is
+                required).
+            14. User-controlled content in AI system prompts is not a vuln.
+            15. Regex injection.
+            16. Regex DoS.
+            17. Insecure documentation (.md and similar).
+            18. Lack of audit logs.
+
+            PRECEDENTS:
+            1. Plaintext-logging high-value secrets IS a vuln; logging URLs
+               is assumed safe.
+            2. UUIDs are unguessable and need no validation.
+            3. Env vars and CLI flags are trusted inputs.
+            4. Resource leaks (memory, fd) are not vulns.
+            5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
+               only with extremely high confidence.
+            6. React / Angular: do not report XSS in components or .tsx files
+               unless using `dangerouslySetInnerHTML`,
+               `bypassSecurityTrustHtml`, or equivalents.
+            7. GitHub Actions workflow vulns: only when a concrete attack
+               path through untrusted input exists.
+            8. Missing AuthN/AuthZ in client-side code is not a vuln —
+               validation is the server's job.
+            9. MEDIUM findings only when obvious and concrete.
+            10. .ipynb notebook vulns: only with a concrete attack path
+                through untrusted input.
+            11. Logging non-PII data is not a vuln. Only flag when the data
+                is secrets, passwords, or PII.
+            12. Command injection in shell scripts: only when there is a
+                concrete attack path through untrusted input.
+
+            For each surviving finding, score confidence 1–10:
+            - 1–3: low / likely noise — drop
+            - 4–6: medium — drop unless obvious and concrete
+            - 7–10: high — keep
+
+            # PROCESS
+
+            Run this in three steps, exactly:
+
+            1. Spawn a Task sub-agent to identify candidate vulnerabilities.
+               Pass the full instructions above (objective, categories,
+               methodology, hard exclusions, precedents). Have it return a
+               structured list of candidates with file/line/category/
+               description/exploit/fix.
+
+            2. For EACH candidate from step 1, spawn an independent Task
+               sub-agent IN PARALLEL to adversarially verify it. Each
+               verifier gets the full FALSE-POSITIVE FILTER above and is
+               told to default to "drop" if uncertain. Each returns a
+               confidence score 1–10.
+
+            3. Drop any finding with confidence < 8. For every finding that
+               survives, call:
+
+                   mcp__github_inline_comment__create_inline_comment
+
+               with `{ path, line, body }` pointing at the exact file and
+               line in the diff. The body should follow:
+
+                   **<Severity>: <Category>**
+                   <One-paragraph description of the issue and concrete
+                   exploit scenario.>
+                   **Recommendation:** <One-sentence fix.>
+
+               Do NOT post a single summary comment listing all findings —
+               the workflow handles a top-level summary after this run
+               completes. If zero findings survive Phase 3, exit without
+               calling any tool.
+
+            Begin.
           show_full_output: "true"
           # Read/Grep/Glob let the model explore the repo for context
           # (existing sanitization patterns, threat model, callers of a

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -1,15 +1,26 @@
 name: Claude Security Review
 
+# This workflow inlines the security-review prompt rather than calling the
+# bundled /security-review slash command. The bundled skill silently bombs
+# whenever the runner's clone gets shallowed mid-run (claude-code-action's
+# restoreConfigFromBase does this on every PR by design — see
+# https://github.com/anthropics/claude-code-action/blob/v1/src/github/operations/restore-config.ts),
+# because its first action is `git diff origin/HEAD...` and a shallow clone
+# has no merge base. Computing the diff ourselves before the action starts
+# eliminates that whole class of failure.
+
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
+    # Only review PRs targeting our long-lived release branch. PRs into
+    # short-lived feature branches don't need a security gate — they get
+    # reviewed when those features are merged into main.
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       pr_number:
-        description:
-          'PR number to review (note: workflow_dispatch will NOT post inline comments — the action only attaches the
-          inline-comment MCP server on PR-context events. Use this only for end-to-end smoke-testing the prompt
-          plumbing.)'
+        description: PR number to review (workflow_dispatch will NOT post inline comments — use only for prompt smoke tests)
         required: true
         type: string
 
@@ -45,10 +56,6 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            // pull_request_target opened/reopened/synchronize: gate on the PR author
-            //   (auto-runs on maintainer-authored PRs; community PRs need the label path below).
-            // pull_request_target labeled (safe-to-review): gate on the labeler (sender)
-            //   so a maintainer applying the label authorizes the run on a community PR.
             const isLabel = context.payload.action === 'labeled';
             const user = isLabel
               ? context.payload.sender.login
@@ -60,35 +67,25 @@ jobs:
                 team_slug: 'agentcore-cli-devs',
                 username: user,
               });
-              console.log(`${reason} is a member of agentcore-cli-devs`);
               core.setOutput('authorized', 'true');
-            } catch (teamError) {
+            } catch {
               try {
                 const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   username: user,
                 });
-                const hasWriteAccess = ['write', 'admin'].includes(data.permission);
-                if (hasWriteAccess) {
-                  console.log(`${reason} has write access (${data.permission})`);
-                  core.setOutput('authorized', 'true');
-                } else {
-                  console.log(`${reason} does not have write access (${data.permission}) — skipping review`);
-                  core.setOutput('authorized', 'false');
-                }
-              } catch (collabError) {
-                console.log(`${reason} authorization check failed (${collabError.status}) — skipping review`);
+                core.setOutput('authorized', ['write', 'admin'].includes(data.permission) ? 'true' : 'false');
+              } catch {
                 core.setOutput('authorized', 'false');
               }
             }
-
       - name: Auto-authorize workflow_dispatch
         id: dispatch-auth
         if: github.event_name == 'workflow_dispatch'
         run: echo "authorized=true" >> "$GITHUB_OUTPUT"
 
-  security-review:
+  review:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
     runs-on: ubuntu-latest
@@ -96,9 +93,6 @@ jobs:
     env:
       AWS_REGION: us-west-2
     steps:
-      # Generate the GitHub App token first so every subsequent github-script step can
-      # use it. The default GITHUB_TOKEN is read-only on pull_request_target /
-      # pull_request_review events from forks, which makes label/comment writes 403.
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v1
@@ -106,7 +100,7 @@ jobs:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Resolve PR number
+      - name: Resolve PR
         id: pr
         uses: actions/github-script@v9
         env:
@@ -114,10 +108,9 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            const num =
-              context.eventName === 'workflow_dispatch'
-                ? parseInt(process.env.PR_NUMBER_INPUT, 10)
-                : context.payload.pull_request.number;
+            const num = context.eventName === 'workflow_dispatch'
+              ? parseInt(process.env.PR_NUMBER_INPUT, 10)
+              : context.payload.pull_request.number;
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -127,7 +120,7 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('base_ref', pr.base.ref);
 
-      - name: Add claude-security-reviewing label
+      - name: Add reviewing label
         uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -148,7 +141,7 @@ jobs:
                   repo: context.repo.repo,
                   name: 'claude-security-reviewing',
                   color: 'D73A4A',
-                  description: 'Claude Code /security-review in progress',
+                  description: 'Claude Code security review in progress',
                 });
               }
             }
@@ -163,104 +156,248 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
-          # The bundled /security-review skill runs `git diff origin/HEAD...` so we need
-          # the base branch locally too. fetch-depth: 0 grabs the full history.
           fetch-depth: 0
 
-      - name: Prepare base ref for /security-review skill
+      - name: Compute diff
+        id: diff
         env:
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
         run: |
           set -euo pipefail
-          # The bundled /security-review skill's SessionStart hook runs
-          # `git diff --name-only origin/HEAD...` as its first command. Two
-          # things have to be true for that to succeed:
-          #   1. origin/HEAD has to be a valid ref. actions/checkout doesn't
-          #      set up the remote's symbolic HEAD, so we point it at the PR's
-          #      base branch.
-          #   2. The PR head and origin/<base> have to share a merge base in
-          #      the local clone. actions/checkout@v6 with `ref: <head_sha>`
-          #      fetches the head's history but on fork PRs may NOT fetch
-          #      origin/<base> into the clone — leaving `git diff origin/HEAD...`
-          #      to fail with "no merge base", which silently bombs the skill
-          #      (num_turns=0, model never invoked) and would otherwise look
-          #      like a clean review with zero findings.
-          # Fetching origin/<base> explicitly closes that gap.
+          # Compute the diff *before* claude-code-action shallows the repo.
+          # The action's restoreConfigFromBase() runs `git fetch --depth=1`
+          # against the base branch on startup, which strips history and
+          # would break any base-vs-head diff after that point. Doing it
+          # here means the model gets a frozen artifact that can't be
+          # invalidated by anything the action does later.
           git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
-          git remote set-head origin "$BASE_REF"
-          git symbolic-ref refs/remotes/origin/HEAD
+          git diff "origin/$BASE_REF...HEAD" > /tmp/pr.diff
+          BYTES=$(wc -c < /tmp/pr.diff)
+          FILES=$(git diff --name-only "origin/$BASE_REF...HEAD" | wc -l | tr -d ' ')
+          echo "bytes=$BYTES" >> "$GITHUB_OUTPUT"
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "Diff: $BYTES bytes across $FILES files"
 
-          # Sanity: ensure the merge base actually resolves before we hand off
-          # to the skill. If it doesn't, fail loudly here rather than letting
-          # the skill silently bail.
-          if ! git merge-base "origin/$BASE_REF" HEAD >/dev/null; then
-            echo "::error::No merge base between HEAD and origin/$BASE_REF — /security-review cannot compute a diff."
-            exit 1
-          fi
-          echo "Merge base: $(git merge-base "origin/$BASE_REF" HEAD)"
-          echo "Files changed: $(git diff --name-only "origin/$BASE_REF...HEAD" | wc -l)"
+      - name: Build prompt
+        if: steps.diff.outputs.bytes != '0'
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/prompt"
+          cat > "$RUNNER_TEMP/prompt/prompt.md" <<'PROMPT_EOF'
+          You are performing a HIGH-CONFIDENCE security code review of a pull
+          request. The complete diff is at `/tmp/pr.diff` — read it first
+          using the Read tool. That file is the ground truth for what the
+          PR changes; do not run `git diff` or any other git commands. To
+          understand context — callers of a changed function, existing
+          sanitization patterns, the project's threat model — use Grep,
+          Glob, and Read against the repository working tree. Do not use
+          Bash.
 
-      - name: Configure AWS credentials (OIDC)
+          # OBJECTIVE
+
+          Identify HIGH-CONFIDENCE security vulnerabilities newly introduced
+          by this PR that have real exploitation potential. This is NOT a
+          general code review. Focus ONLY on security implications added by
+          the PR. Do not comment on pre-existing issues.
+
+          # CRITICAL INSTRUCTIONS
+
+          1. MINIMIZE FALSE POSITIVES: Only flag issues where you are >80%
+             confident of actual exploitability.
+          2. AVOID NOISE: Skip theoretical issues, style concerns, or
+             low-impact findings.
+          3. FOCUS ON IMPACT: Prioritize vulnerabilities that lead to
+             unauthorized access, data breach, or system compromise.
+          4. DO NOT report any of:
+             - Denial of service / resource exhaustion / rate limiting
+             - Secrets at rest on disk (handled by other tooling)
+             - Memory consumption or CPU exhaustion
+
+          # CATEGORIES TO EXAMINE
+
+          **Input validation**: SQL injection, command injection, XXE,
+          template injection, NoSQL injection, path traversal.
+          **AuthN/AuthZ**: authentication bypass, privilege escalation,
+          session/JWT flaws, authorization-logic bypasses.
+          **Crypto & secrets**: hardcoded keys/passwords/tokens, weak
+          algorithms, improper key storage, weak randomness, certificate
+          validation bypass.
+          **Code execution**: deserialization RCE (pickle, YAML, etc.),
+          eval injection, XSS (reflected/stored/DOM) — only in unsafe paths
+          (see precedents).
+          **Data exposure**: sensitive logging, PII handling violations,
+          API leakage, debug-info exposure.
+
+          A finding can still be HIGH severity if only exploitable from the
+          local network.
+
+          # METHODOLOGY
+
+          Phase 1 — Repository context: identify existing security
+          libraries/frameworks, sanitization patterns, the project's threat
+          model. Use search tools.
+
+          Phase 2 — Comparative analysis: compare new changes against
+          established patterns; flag deviations and net-new attack surface.
+
+          Phase 3 — Vulnerability assessment: for each modified file,
+          trace user input → sensitive operations, look for unsafe privilege
+          boundary crossings, identify injection points.
+
+          # FALSE-POSITIVE FILTER (apply hard)
+
+          Read the code (Read/Grep/Glob); do not run commands to reproduce
+          or write files.
+
+          HARD EXCLUSIONS — drop any finding matching:
+          1. DoS / resource exhaustion.
+          2. Secrets/credentials on disk if otherwise secured.
+          3. Rate limiting or service overload.
+          4. Memory/CPU exhaustion.
+          5. Missing input validation on non-security-critical fields.
+          6. Input sanitization in GitHub Actions workflows unless clearly
+             triggerable via untrusted input.
+          7. Lack of hardening; only flag concrete vulns.
+          8. Theoretical race conditions or timing attacks.
+          9. Outdated third-party libraries (handled separately).
+          10. Memory-safety issues in memory-safe languages (Rust, Go,
+              JS/TS, Python).
+          11. Files that are unit tests or test-only.
+          12. Log spoofing — un-sanitized user input to logs is not a vuln.
+          13. SSRF that only controls the path (host/protocol control is
+              required).
+          14. User-controlled content in AI system prompts is not a vuln.
+          15. Regex injection.
+          16. Regex DoS.
+          17. Insecure documentation (.md and similar).
+          18. Lack of audit logs.
+
+          PRECEDENTS:
+          1. Plaintext-logging high-value secrets IS a vuln; logging URLs
+             is assumed safe.
+          2. UUIDs are unguessable and need no validation.
+          3. Env vars and CLI flags are trusted inputs.
+          4. Resource leaks (memory, fd) are not vulns.
+          5. Tabnabbing, XS-Leaks, prototype pollution, open redirects:
+             only with extremely high confidence.
+          6. React / Angular: do not report XSS in components or .tsx files
+             unless using `dangerouslySetInnerHTML`,
+             `bypassSecurityTrustHtml`, or equivalents.
+          7. GitHub Actions workflow vulns: only when a concrete attack
+             path through untrusted input exists.
+          8. Missing AuthN/AuthZ in client-side code is not a vuln —
+             validation is the server's job.
+          9. MEDIUM findings only when obvious and concrete.
+          10. .ipynb notebook vulns: only with a concrete attack path
+              through untrusted input.
+          11. Logging non-PII data is not a vuln. Only flag when the data
+              is secrets, passwords, or PII.
+          12. Command injection in shell scripts: only when there is a
+              concrete attack path through untrusted input.
+
+          For each surviving finding, score confidence 1–10:
+          - 1–3: low / likely noise — drop
+          - 4–6: medium — drop unless obvious and concrete
+          - 7–10: high — keep
+
+          # PROCESS
+
+          Run this in three steps, exactly:
+
+          1. Spawn a Task sub-agent to identify candidate vulnerabilities.
+             Pass the full instructions above (objective, categories,
+             methodology, hard exclusions, precedents). Have it return a
+             structured list of candidates with file/line/category/
+             description/exploit/fix.
+
+          2. For EACH candidate from step 1, spawn an independent Task
+             sub-agent IN PARALLEL to adversarially verify it. Each
+             verifier gets the full FALSE-POSITIVE FILTER above and is
+             told to default to "drop" if uncertain. Each returns a
+             confidence score 1–10.
+
+          3. Drop any finding with confidence < 8. For every finding that
+             survives, call:
+
+                 mcp__github_inline_comment__create_inline_comment
+
+             with `{ path, line, body }` pointing at the exact file and
+             line in the diff. The body should follow:
+
+                 **<Severity>: <Category>**
+                 <One-paragraph description of the issue and concrete
+                 exploit scenario.>
+                 **Recommendation:** <One-sentence fix.>
+
+             Do NOT post a single summary comment listing all findings —
+             the workflow handles a top-level summary after this run
+             completes. If zero findings survive Phase 3, exit without
+             calling any tool.
+
+          Begin.
+          PROMPT_EOF
+
+      - name: Configure AWS credentials
+        if: steps.diff.outputs.bytes != '0'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
           aws-region: us-west-2
 
-      - name: Run Claude Code security review
+      - name: Load prompt into env
+        id: load-prompt
+        if: steps.diff.outputs.bytes != '0'
+        # The action only accepts `prompt:` (a string), not a file path —
+        # passing prompt_file silently no-ops, leaves the action with no
+        # trigger, and skips the run with "No trigger found". Read the
+        # built prompt into an environment variable so we can pass it
+        # inline below. Using GITHUB_ENV with a randomized heredoc
+        # sentinel is the standard Actions idiom for multi-line values.
+        env:
+          PROMPT_FILE: ${{ runner.temp }}/prompt/prompt.md
+        run: |
+          set -euo pipefail
+          DELIM="EOF_$(uuidgen)"
+          {
+            echo "PROMPT_BODY<<$DELIM"
+            cat "$PROMPT_FILE"
+            echo "$DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Run Claude Code
         id: review
+        if: steps.diff.outputs.bytes != '0'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          use_bedrock: 'true'
-          # The Claude Code SDK that ships with the action has /security-review bundled
-          # as a slash command. Invoking it directly lets the skill drive its own
-          # `git diff origin/HEAD...`, sub-task fan-out, and false-positive filtering
-          # without us re-implementing any of that. We append a short tail telling the
-          # action to use the inline-comment MCP tool for findings.
-          prompt: |
-            /security-review
-
-            For each finding, call mcp__github_inline_comment__create_inline_comment with
-            { path, line, body } pointing at the exact file and line in the diff. Do NOT
-            post a single summary comment listing all findings — the workflow handles a
-            top-level summary after this run completes. If there are no findings, exit
-            without calling any tool.
-          show_full_output: 'true'
-          # Allow-listing this MCP tool name is what tells the action to register the
-          # github_inline_comment MCP server. See anthropics/claude-code-action
-          # src/mcp/install-mcp-server.ts.
+          use_bedrock: "true"
+          prompt: ${{ env.PROMPT_BODY }}
+          show_full_output: "true"
+          # Read/Grep/Glob let the model explore the repo for context
+          # (existing sanitization patterns, threat model, callers of a
+          # changed function). Task is needed for the parallel verifier
+          # sub-agents in Phase 2. The github_inline_comment MCP tool is
+          # the output channel; allow-listing it is also what tells the
+          # action to attach the inline-comment MCP server. Bash is
+          # intentionally NOT allowed: the prompt forbids running
+          # commands, and keeping Bash off the list makes the diff at
+          # /tmp/pr.diff the only ground truth (no `git diff` re-runs
+          # against a possibly-shallow clone).
           claude_args: >-
-            --model us.anthropic.claude-opus-4-7 --max-turns 30 --allowedTools
-            mcp__github_inline_comment__create_inline_comment
+            --model us.anthropic.claude-opus-4-7 --max-turns 60 --allowedTools "Read Grep Glob Task
+            mcp__github_inline_comment__create_inline_comment"
 
-      - name: Verify model actually ran
+      - name: Verify model ran productively
         id: model-ran
-        # The action exits 0 even when the model was never invoked (e.g. a
-        # SessionStart hook errored before the first turn). Treating that as
-        # success would let the workflow falsely report "no high-confidence
-        # findings" — that's exactly what happened on PR #1474, where the
-        # `/security-review` skill's first `git diff origin/HEAD...` hit a
-        # "no merge base" error, the SDK still returned `subtype: success`
-        # with `num_turns: 0` and zero tokens, and the buffer was empty.
-        #
-        # The action writes its full SDK transcript to
-        # ${RUNNER_TEMP}/claude-execution-output.json. We pull the final
-        # result envelope and require that the model actually took turns and
-        # spent tokens. If it didn't, mark the run as not-actually-completed
-        # so the summary comment uses the failure branch instead of pretending
-        # there were no findings.
-        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        if:
+          steps.diff.outputs.bytes != '0' && (steps.review.conclusion == 'success' || steps.review.conclusion ==
+          'failure')
         env:
-          # The action exposes its full SDK transcript path as the
-          # `execution_file` step output (a JSON array of stream events; the
-          # final element is the result envelope). We fall back to the known
-          # path under RUNNER_TEMP if for some reason the output is missing.
-          OUTPUT_JSON:
-            ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+          OUTPUT_JSON: ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
         run: |
           set -euo pipefail
           if [ ! -s "$OUTPUT_JSON" ]; then
-            echo "::warning::No claude-execution-output.json found at $OUTPUT_JSON; cannot verify the model ran."
+            echo "::warning::No execution transcript at $OUTPUT_JSON — cannot verify"
             echo "ran=unknown" >> "$GITHUB_OUTPUT"
             echo "num_turns=0" >> "$GITHUB_OUTPUT"
             exit 0
@@ -271,18 +408,20 @@ jobs:
           echo "num_turns=$NUM_TURNS, is_error=$IS_ERROR, output_tokens=$OUTPUT_TOKENS"
           echo "num_turns=$NUM_TURNS" >> "$GITHUB_OUTPUT"
           if [ "$IS_ERROR" = "true" ] || [ "$NUM_TURNS" = "0" ] || [ "$OUTPUT_TOKENS" = "0" ]; then
-            echo "::error::Claude Code SDK reported success but the model never ran productively (num_turns=$NUM_TURNS, output_tokens=$OUTPUT_TOKENS, is_error=$IS_ERROR). The /security-review skill likely bailed before analysis (e.g. SessionStart hook error). Refusing to report 'no findings'."
+            echo "::group::Last messages from SDK transcript"
+            jq -r '.[] | select(.type == "user" or .type == "system") | .message.content // .subtype' "$OUTPUT_JSON" | tail -40
+            echo "::endgroup::"
+            echo "::error::Model did not run productively (turns=$NUM_TURNS, output_tokens=$OUTPUT_TOKENS, is_error=$IS_ERROR)"
             echo "ran=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           echo "ran=true" >> "$GITHUB_OUTPUT"
 
-      - name: Count buffered findings
+      - name: Count findings
         id: findings
-        # Only count if the review step actually ran (success or failure - both produce
-        # a meaningful buffer state). Skip on cancellation/skip so we don't lie about
-        # "no findings" when Bedrock was never invoked.
-        if: steps.review.conclusion == 'success' || steps.review.conclusion == 'failure'
+        if:
+          steps.diff.outputs.bytes != '0' && (steps.review.conclusion == 'success' || steps.review.conclusion ==
+          'failure')
         run: |
           set -euo pipefail
           BUFFER=/tmp/inline-comments-buffer.jsonl
@@ -294,10 +433,7 @@ jobs:
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Buffered findings: $COUNT"
 
-      - name: Post security review summary comment
-        # Always post some kind of summary so the PR shows the run happened, but branch on
-        # the review step's conclusion so a cancelled/skipped run doesn't get reported as
-        # "no findings".
+      - name: Post summary
         if: always()
         uses: actions/github-script@v9
         env:
@@ -306,6 +442,8 @@ jobs:
           REVIEW_CONCLUSION: ${{ steps.review.conclusion }}
           MODEL_RAN: ${{ steps.model-ran.outputs.ran }}
           NUM_TURNS: ${{ steps.model-ran.outputs.num_turns }}
+          DIFF_BYTES: ${{ steps.diff.outputs.bytes }}
+          DIFF_FILES: ${{ steps.diff.outputs.files }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -316,25 +454,21 @@ jobs:
             const modelRan = process.env.MODEL_RAN || 'unknown';
             const numTurns = process.env.NUM_TURNS || '0';
             const runUrl = process.env.RUN_URL;
+            const diffBytes = parseInt(process.env.DIFF_BYTES || '0', 10);
 
             let body;
-            if (modelRan !== 'true') {
-              // Two cases land here, both unsafe to report as "no findings":
-              //   - 'false': SDK exited 0 but transcript shows the model never ran productively
-              //     (e.g. /security-review's SessionStart hook errored before the first turn).
-              //   - 'unknown': claude-execution-output.json was missing, so we couldn't verify
-              //     the model ran at all. Treat as not-verified rather than silently green.
-              body = `**Claude Security Review:** the review did not actually analyze this PR (model took ${numTurns} turn${numTurns === '1' ? '' : 's'} — the skill likely failed during setup). See the [run](${runUrl}) for details; a later push or re-run is needed for a real review.`;
+            if (diffBytes === 0) {
+              body = `**Claude Security Review:** PR has an empty diff against base — nothing to review. ([run](${runUrl}))`;
+            } else if (modelRan !== 'true') {
+              body = `**Claude Security Review:** the review did not analyze this PR (model took ${numTurns} turn${numTurns === '1' ? '' : 's'}). See the [run](${runUrl}) for details; a later push or re-run is needed.`;
             } else if (conclusion === 'success') {
-              body =
-                count > 0
-                  ? `**Claude Security Review:** posted ${count} inline finding${count === 1 ? '' : 's'} on this PR. ([run](${runUrl}))`
-                  : `**Claude Security Review:** no high-confidence findings. ([run](${runUrl}))`;
+              body = count > 0
+                ? `**Claude Security Review:** posted ${count} inline finding${count === 1 ? '' : 's'} on this PR. ([run](${runUrl}))`
+                : `**Claude Security Review:** no high-confidence findings. ([run](${runUrl}))`;
             } else if (conclusion === 'failure') {
               body = `**Claude Security Review:** the review run failed before completing. See the [run](${runUrl}) for details.`;
             } else {
-              // cancelled / skipped — analysis didn't run, do NOT claim "no findings"
-              body = `**Claude Security Review:** the review run was ${conclusion} before the analysis could complete (likely superseded or interrupted). See the [run](${runUrl}); a later run on this PR will replace this status.`;
+              body = `**Claude Security Review:** the review run was ${conclusion} before analysis could complete. See the [run](${runUrl}); a later run on this PR will replace this status.`;
             }
 
             await github.rest.issues.createComment({
@@ -344,7 +478,7 @@ jobs:
               body,
             });
 
-      - name: Remove claude-security-reviewing label
+      - name: Remove reviewing label
         if: always()
         uses: actions/github-script@v9
         env:


### PR DESCRIPTION
Follow-up to #516. Two bugs were discovered in the rolled-out workflow that make it silently fail with num_turns=0:

1. The bundled `/security-review` skill's first command is `git diff origin/HEAD...`, which fails after `claude-code-action`'s `restoreConfigFromBase()` shallows the runner's clone.
2. The `prompt_file:` input we passed doesn't exist on `anthropics/claude-code-action@v1` — only `prompt:` (a string) does. The action silently ignored it and skipped with 'No trigger found'.

Same fix as aws/private-agentcore-cli-staging PRs #291, #296, #298, #299. Verified end-to-end on smoke-test PR #297 with Trigger result: true, num_turns: 2, output_tokens: 386.