### PR TITLE
fix: remove monotonic_timestamp

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -5,7 +5,7 @@ import json
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, NamedTuple, Optional
 
@@ -97,38 +97,6 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
     - Support for custom retrieval configurations per namespace
     - Consistent with existing Strands Session managers (such as: FileSessionManager, S3SessionManager)
     """
-
-    # Class-level timestamp tracking for monotonic ordering
-    _timestamp_lock = threading.Lock()
-    _last_timestamp: Optional[datetime] = None
-
-    @classmethod
-    def _get_monotonic_timestamp(cls, desired_timestamp: Optional[datetime] = None) -> datetime:
-        """Get a monotonically increasing timestamp.
-
-        Args:
-            desired_timestamp (Optional[datetime]): The desired timestamp. If None, uses current time.
-
-        Returns:
-            datetime: A timestamp guaranteed to be greater than any previously returned timestamp.
-        """
-        if desired_timestamp is None:
-            desired_timestamp = datetime.now(timezone.utc)
-
-        with cls._timestamp_lock:
-            if cls._last_timestamp is None:
-                cls._last_timestamp = desired_timestamp
-                return desired_timestamp
-
-            # Why the 1 second check? Because Boto3 does NOT support sub 1 second resolution.
-            if desired_timestamp <= cls._last_timestamp + timedelta(seconds=1):
-                # Increment by 1 second to ensure ordering
-                new_timestamp = cls._last_timestamp + timedelta(seconds=1)
-            else:
-                new_timestamp = desired_timestamp
-
-            cls._last_timestamp = new_timestamp
-            return new_timestamp
 
     def __init__(
         self,
@@ -282,7 +250,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                 payload=[
                     {"blob": json.dumps(session.to_dict())},
                 ],
-                eventTimestamp=self._get_monotonic_timestamp(),
+                eventTimestamp=datetime.now(timezone.utc),
                 metadata={STATE_TYPE_KEY: {"stringValue": StateType.SESSION.value}},
             )
             logger.info("Created session: %s with event: %s", session.session_id, event.get("event", {}).get("eventId"))
@@ -414,7 +382,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                 payload=[
                     {"blob": json.dumps(session_agent.to_dict())},
                 ],
-                eventTimestamp=self._get_monotonic_timestamp(),
+                eventTimestamp=datetime.now(timezone.utc),
                 metadata={
                     STATE_TYPE_KEY: {"stringValue": StateType.AGENT.value},
                     AGENT_ID_KEY: {"stringValue": session_agent.agent_id},
@@ -582,7 +550,6 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
 
         # Parse the original timestamp and use it as desired timestamp
         original_timestamp = datetime.fromisoformat(session_message.created_at.replace("Z", "+00:00"))
-        monotonic_timestamp = self._get_monotonic_timestamp(original_timestamp)
 
         if self.config.batch_size > 1:
             # Buffer the pre-processed message
@@ -593,7 +560,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                         session_id=session_id,
                         messages=messages,
                         is_blob=is_blob,
-                        timestamp=monotonic_timestamp,
+                        timestamp=original_timestamp,
                         metadata=merged_metadata,
                     )
                 )
@@ -613,7 +580,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                     actor_id=self.config.actor_id,
                     session_id=session_id,
                     messages=messages,
-                    event_timestamp=monotonic_timestamp,
+                    event_timestamp=original_timestamp,
                     metadata=merged_metadata,
                 )
             else:
@@ -622,7 +589,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                     "actorId": self.config.actor_id,
                     "sessionId": session_id,
                     "payload": [{"blob": json.dumps(messages[0])}],
-                    "eventTimestamp": monotonic_timestamp,
+                    "eventTimestamp": original_timestamp,
                 }
                 if merged_metadata:
                     create_event_kwargs["metadata"] = merged_metadata
@@ -1174,7 +1141,7 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                     actorId=self.config.actor_id,
                     sessionId=self.config.session_id,
                     payload=payloads,
-                    eventTimestamp=self._get_monotonic_timestamp(),
+                    eventTimestamp=datetime.now(timezone.utc),
                     metadata={
                         STATE_TYPE_KEY: {"stringValue": StateType.AGENT.value},
                         AGENT_ID_KEY: {"stringValue": agent_id},


### PR DESCRIPTION
*Description of changes:*
A previous [pull request](https://github.com/aws/bedrock-agentcore-sdk-python/pull/83) introduced the `_get_monotonic_timestamp` function in order to address the issue of out of order tool calls which can lead to a ValidationException with the Converse API. However this change did not address the issue as users are still able to encounter the ValidationException under certain circumstances.

By using a 1 second resolution with an Agent that can run many tool calls, it will result in timestamps generated many seconds into the future. If the same Agent is being used then this is not an issue as that Agent will still have the proper `_last_timestamp` preserved so it will continue to increment on that but if an Agent is hosted behind a cluster such as EKS where requests that come in with a session_id do not route to the same pod/container. The initial timestamp generated in a new pod (where a new instance of the `AgentCoreMemorySessionManager` class will happen) is going to be the current timestamp which can be less than the last timestamp of the last record in AgentCore Memory if the API calls happen within a very short period of time.

The solution here is to revert back to the previous method of recording timestamps (which is to use `datetime.now(timezone.utc)`). Since timestamps are generated down to the microsecond level (this may have not been the case when the prior pull request was created but from testing directly with the boto3 sdk timestamps are at a microsecond granularity) the likelihood that 2 messages will share the exact same time at this resolution is effectively zero for a given session.

## Testing
The easiest way to replicate the issue is to run the below `test.py` file multiple times in quick succession with a model that has very low latency. The below bash script does not create a Memory if it does not exist so you will have to manually create this.

### Bash Script
```bash
#!/usr/bin/env bash

# Set ENV Variables
export ACTOR_ID="ACTOR_ID_TEST99"
export SESSION_ID="SESSION_ID_TEST99"
export MEM_NAME="EventsAndSessions_Test"
export MEM_ID=$(aws bedrock-agentcore-control list-memories | jq -r --arg s "$MEM_NAME" '.memories[] | select(.id | contains($s)) | .id' | head -1)

# Run 1st User Prompting session
python test.py

# Run 2nd User Prompting session
python test.py

# Run final User Promptin session (should fail with monotonic_timestamp if previous sessions were fast enough)
sleep 5
python test.py
```

### Python Script
```python
import json
import time
import os
from datetime import datetime
from strands import Agent, tool
from botocore.exceptions import ClientError
from bedrock_agentcore.memory import MemoryClient
from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig
from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
from strands.models.bedrock import BedrockModel

# Create new session manager (simulating fresh container)
from botocore.config import Config
retry_config = Config(
    retries={
        'max_attempts': 12,  # Increase from default 4 to 10
        'mode': 'adaptive'
    }
)

@tool
def get_weather(location: str) -> str:
    """Get the current weather for a location."""
    # Mock weather data
    weather_data = {
        "seattle": "Rainy, 55°F",
        "san francisco": "Foggy, 62°F", 
        "new york": "Sunny, 68°F",
        "london": "Cloudy, 52°F"
    }
    return weather_data.get(location.lower(), f"Weather data not available for {location}")

@tool
def calculate_tip(bill_amount: float, tip_percentage: float = 18.0) -> dict:
    """Calculate tip and total amount for a restaurant bill."""
    tip_amount = bill_amount * (tip_percentage / 100)
    total_amount = bill_amount + tip_amount

    return {
        "bill_amount": bill_amount,
        "tip_percentage": tip_percentage,
        "tip_amount": round(tip_amount, 2),
        "total_amount": round(total_amount, 2)
    }


def main():
    MEM_ID = os.environ["MEM_ID"]
    ACTOR_ID = os.environ["ACTOR_ID"]
    SESSION_ID  = os.environ["SESSION_ID"]

    agentcore_memory_config = AgentCoreMemoryConfig(
        memory_id=MEM_ID,
        session_id=SESSION_ID,
        actor_id=ACTOR_ID
    )

    print("\n🔄 Testing restart scenario (simulating container restart)...")

    # Step 5: Simulate agent restart by creating new session manager and agent
    print("🔄 Simulating agent restart - creating new session manager and agent...")

    new_session_manager = AgentCoreMemorySessionManager(
        agentcore_memory_config=agentcore_memory_config,
        region_name="us-east-1",
        boto_client_config=retry_config
    )

    # Create new agent (simulating agent restart)
    model = BedrockModel(model_id="qwen.qwen3-32b-v1:0")
    agent = Agent(
        model=model,
        system_prompt="You are a helpful assistant with access to weather and tip calculation tools. Remember user preferences and use tools when appropriate.",
        session_manager=new_session_manager,
        tools=[get_weather, calculate_tip]
    )

    # Test weather tool
    try:
        response1 = agent("What's the weather like in Seattle?")
        print(f"User: What's the weather like in Seattle?")
        print(f"Agent: {response1}")
    except Exception as e:
        if 'Throttl' in str(e) or 'Rate exceeded' in str(e):
            print("⏳ Throttling detected, sleeping for 4 seconds...")
            time.sleep(4)
            response1 = agent("What's the weather like in Seattle?")
            print(f"User: What's the weather like in Seattle?")
            print(f"Agent: {response1}")
        else:
            print(f"User: What's the weather like in Seattle?")
            raise
    
    # Test tip calculator tool
    try:
        response2 = agent("I had dinner and the bill was $85.50. Can you calculate a 20% tip?")
        print(f"\nUser: I had dinner and the bill was $85.50. Can you calculate a 20% tip?")
        print(f"Agent: {response2}")
    except Exception as e:
        if 'Throttl' in str(e) or 'Rate exceeded' in str(e):
            print("⏳ Throttling detected, sleeping for 4 seconds...")
            time.sleep(4)
            response2 = agent("I had dinner and the bill was $85.50. Can you calculate a 20% tip?")
            print(f"\nUser: I had dinner and the bill was $85.50. Can you calculate a 20% tip?")
            print(f"Agent: {response2}")
        else:
            raise
    
    # Test memory - agent should remember previous interactions
    try:
        response3 = agent("What was the weather I asked about earlier?")
        print(f"\nUser: What was the weather I asked about earlier?")
        print(f"Agent: {response3}")
    except Exception as e:
        if 'Throttl' in str(e) or 'Rate exceeded' in str(e):
            print("⏳ Throttling detected, sleeping for 4 seconds...")
            time.sleep(4)
            response3 = agent("What was the weather I asked about earlier?")
            print(f"\nUser: What was the weather I asked about earlier?")
            print(f"Agent: {response3}")
        else:
            raise
    
    # Test another tool usage
    try:
        response4 = agent("Check the weather in New York and calculate a 15% tip on a $42.75 bill")
        print(f"\nUser: Check the weather in New York and calculate a 15% tip on a $42.75 bill")
        print(f"Agent: {response4}")
    except Exception as e:
        if 'Throttl' in str(e) or 'Rate exceeded' in str(e):
            print("⏳ Throttling detected, sleeping for 4 seconds...")
            time.sleep(4)
            response4 = agent("Check the weather in New York and calculate a 15% tip on a $42.75 bill")
            print(f"\nUser: Check the weather in New York and calculate a 15% tip on a $42.75 bill")
            print(f"Agent: {response4}")
        else:
            raise

    # Test that the new agent can load conversation history without ValidationException
    try:
        response5 = agent("I had dinner and the bill was $102.50. Can you calculate a 15% tip?")
        print(f"\nUser: I had dinner and the bill was $102.50. Can you calculate a 15% tip?")
        print(f"Agent: {response5}")
    except Exception as e:
        if 'Throttl' in str(e) or 'Rate exceeded' in str(e):
            print("⏳ Throttling detected, sleeping for 4 seconds...")
            time.sleep(4)
            response5 = agent("I had dinner and the bill was $102.50. Can you calculate a 15% tip?")
            print(f"\nUser: I had dinner and the bill was $102.50. Can you calculate a 15% tip?")
            print(f"Agent: {response5}")
        else:
            raise

main()
```