### PR TITLE
ci(gateway): pass KB_ROLE_ARN secret to integration tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -200,6 +200,7 @@ jobs:
           RESOURCE_POLICY_TEST_PRINCIPAL: ${{ secrets.RESOURCE_POLICY_TEST_PRINCIPAL }}
           GATEWAY_ROLE_ARN: ${{ secrets.GATEWAY_ROLE_ARN }}
           GATEWAY_LAMBDA_ARN: ${{ secrets.GATEWAY_LAMBDA_ARN }}
+          KB_ROLE_ARN: ${{ secrets.KB_ROLE_ARN }}
           EVAL_ROLE_ARN: ${{ secrets.EVAL_ROLE_ARN }}
           EVAL_LOG_GROUP: ${{ secrets.EVAL_LOG_GROUP }}
           RUNTIME_ROLE_ARN: ${{ secrets.RUNTIME_ROLE_ARN }}


### PR DESCRIPTION
## What

Adds `KB_ROLE_ARN: ${{ secrets.KB_ROLE_ARN }}` to the env block of the gateway integration-test job in `.github/workflows/integration-testing.yml`.

## Why

The gateway KB-target integration tests (`tests_integ/gateway/test_gateway_kb_targets.py`) require **both** `GATEWAY_ROLE_ARN` and `KB_ROLE_ARN`:

```python
if not cls.gateway_role_arn or not cls.kb_role_arn:
    pytest.fail("GATEWAY_ROLE_ARN and KB_ROLE_ARN must be set")
```

The `KB_ROLE_ARN` repo secret has been created, but it was not yet passed into the test environment, so the gateway job fails at `setup_class`. This wires the secret through.

## Verification

Ran the KB-target test locally with the new role set: `setup_class` succeeds end-to-end — it creates the S3 Vectors bucket/index, a Bedrock Knowledge Base (via `KB_ROLE_ARN`), and a Gateway, then tears them all down (no leftover resources). The role has `bedrock:InvokeModel`, `s3:*`, and `s3vectors:*` as the test docstring requires.

> Note: the `create_knowledge_base_target` assertions currently fail later on a separate, role-independent issue — public botocore (1.43.31) does not yet include the `connector` shape that `gateway/client.py` sends in `targetConfiguration.mcp`. That is tracked separately and is out of scope for this CI wiring change.