### PR TITLE
fix(runtime): drop time_of_last_update from A2A and AG-UI ping responses

### DIFF
--- a/src/bedrock_agentcore/runtime/a2a.py
+++ b/src/bedrock_agentcore/runtime/a2a.py
@@ -5,7 +5,6 @@ extraction, health checks, and Docker host detection.
 """
 
 import logging
-import time
 import uuid
 from typing import Any, Callable, Optional
 
@@ -238,20 +237,16 @@ def build_a2a_app(
         context_builder=context_builder,
     )
 
-    last_status_update_time = time.time()
-
     def _handle_ping(request: Any) -> JSONResponse:
-        nonlocal last_status_update_time
         try:
             if ping_handler is not None:
                 status = ping_handler()
             else:
                 status = PingStatus.HEALTHY
-            last_status_update_time = time.time()
         except Exception:
             logger.exception("Custom ping handler failed, falling back to Healthy")
             status = PingStatus.HEALTHY
-        return JSONResponse({"status": status.value, "time_of_last_update": int(last_status_update_time)})
+        return JSONResponse({"status": status.value})
 
     # Build the Starlette app with /ping included upfront, then add A2A routes,
     # so we don't depend on mutating app.routes after build().

--- a/src/bedrock_agentcore/runtime/ag_ui.py
+++ b/src/bedrock_agentcore/runtime/ag_ui.py
@@ -11,7 +11,6 @@ to both endpoints automatically.
 
 import inspect
 import logging
-import time
 import uuid
 from typing import Any, Callable, Optional
 
@@ -79,7 +78,6 @@ class AGUIApp(Starlette):
 
         self._handler: Optional[Callable] = None
         self._ping_handler: Optional[Callable] = None
-        self._last_status_update_time: float = time.time()
 
         routes = [
             Route("/invocations", self._handle_invocation, methods=["POST"]),
@@ -324,11 +322,10 @@ class AGUIApp(Starlette):
                 status = self._ping_handler()
             else:
                 status = PingStatus.HEALTHY
-            self._last_status_update_time = time.time()
         except Exception:
             logger.exception("Custom ping handler failed, falling back to Healthy")
             status = PingStatus.HEALTHY
-        return JSONResponse({"status": status.value, "time_of_last_update": int(self._last_status_update_time)})
+        return JSONResponse({"status": status.value})
 
 
 def build_ag_ui_app(

--- a/tests/bedrock_agentcore/runtime/test_a2a.py
+++ b/tests/bedrock_agentcore/runtime/test_a2a.py
@@ -70,15 +70,14 @@ def _send_message_params(text: str = "hello") -> dict:
 
 
 class TestBuildA2AApp:
-    def test_ping_returns_healthy_with_timestamp(self):
+    def test_ping_returns_healthy_without_timestamp(self):
         app = build_a2a_app(_EchoExecutor(), _make_agent_card())
         client = TestClient(app)
         resp = client.get("/ping")
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "Healthy"
-        assert isinstance(body["time_of_last_update"], int)
-        assert body["time_of_last_update"] > 0
+        assert "time_of_last_update" not in body
 
     def test_custom_ping_handler(self):
         app = build_a2a_app(

--- a/tests/bedrock_agentcore/runtime/test_ag_ui.py
+++ b/tests/bedrock_agentcore/runtime/test_ag_ui.py
@@ -56,8 +56,7 @@ class TestBuildAGUIApp:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "Healthy"
-        assert isinstance(body["time_of_last_update"], int)
-        assert body["time_of_last_update"] > 0
+        assert "time_of_last_update" not in body
 
     def test_custom_ping_handler(self):
         app = AGUIApp()

--- a/tests/integration/runtime/test_a2a_integration.py
+++ b/tests/integration/runtime/test_a2a_integration.py
@@ -206,7 +206,7 @@ class TestA2AServerIntegration:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "Healthy"
-        assert isinstance(body["time_of_last_update"], int)
+        assert "time_of_last_update" not in body
 
     def test_bedrock_headers_propagated_to_executor(self, echo_executor):
         builder = BedrockCallContextBuilder()

--- a/tests/integration/runtime/test_ag_ui_integration.py
+++ b/tests/integration/runtime/test_ag_ui_integration.py
@@ -108,7 +108,7 @@ class TestAGUIServerIntegration:
         assert resp.status_code == 200
         body = resp.json()
         assert body["status"] == "Healthy"
-        assert isinstance(body["time_of_last_update"], int)
+        assert "time_of_last_update" not in body
 
     def test_bedrock_headers_propagated_via_sse(self):
         def _test():


### PR DESCRIPTION
## Summary

The A2A (`a2a.py`) and AG-UI (`ag_ui.py`) `/ping` handlers set `time_of_last_update` to the current time on **every** ping, instead of reporting when the status last changed. This PR **drops `time_of_last_update` from the A2A and AG-UI ping responses**, which now return `{"status": ...}`. `app.py` is intentionally left unchanged.

## Why this is the fix

The Runtime platform consumes `time_of_last_update` to detect session idleness — it expects the timestamp to reflect **when the status last changed**. Because the A2A and AG-UI handlers re-stamped it to "now" on every ping (every poll interval), the platform saw a continuous status change and never treated the session as idle. As a result:

- The idle session timeout (`IdleRuntimeSessionTimeout`) never fired.
- Sessions persisted until `MaxLifetime` instead of being released when idle.
- Under load, session count grew unbounded and could exhaust the session/VM quota (`ServiceQuotaExceededException`).

Overriding the ping handler did **not** help, because the SDK set `time_of_last_update` regardless of the handler's return value — so there was no customer workaround.

Dropping the field is the correct fix: with `time_of_last_update` absent, the platform tracks status changes using its own clock, and the idle timeout works as configured. `app.py` is unaffected — it already stamps the timestamp only on an actual status change, so its idle behavior was already correct.

## Changes

- `src/bedrock_agentcore/runtime/a2a.py` — `_handle_ping` returns `{"status": status.value}`; removed the per-ping `last_status_update_time` tracking (and its `nonlocal`) and the now-unused `import time`.
- `src/bedrock_agentcore/runtime/ag_ui.py` — same change; removed the `self._last_status_update_time` attribute and now-unused `import time`.
- Tests — updated the A2A/AG-UI unit and integration ping tests to assert `time_of_last_update` is **absent** from the response. `test_app.py` is unchanged (the HTTP app still emits the field, correctly, on status transition).

## Backward compatibility

Removing the field is non-breaking: the platform treats `time_of_last_update` as optional, so omitting it is accepted. Agents on older SDK versions (still sending the field) and agents on this version (omitting it) both pass the health check.

## Testing

- `uv run pytest tests/bedrock_agentcore/runtime/test_a2a.py tests/bedrock_agentcore/runtime/test_ag_ui.py tests/bedrock_agentcore/runtime/test_app.py` → **191 passed**
- `ruff check` clean on all changed files

## Note

A companion internal docs change updates the AgentCore Runtime protocol-contract pages to document `time_of_last_update` correctly — as an optional field that must reflect the last status change, with a warning against re-stamping it on every ping.