### PR TITLE
fix(memory): guard retrieve_customer_context against empty message content

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -848,7 +848,10 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             event (MessageAddedEvent): The message added event containing the agent and message data.
         """
         messages = event.agent.messages
-        if not messages or messages[-1].get("role") != "user" or "text" not in messages[-1].get("content")[0]:
+        if not messages or messages[-1].get("role") != "user":
+            return None
+        content = messages[-1].get("content")
+        if not content or "text" not in content[0]:
             return None
         if not self.config.retrieval_config:
             # Only retrieve LTM

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
@@ -1169,6 +1169,31 @@ class TestAgentCoreMemorySessionManager:
                     result = manager.retrieve_customer_context(event)
                     assert result is None
 
+    def test_retrieve_customer_context_empty_content(self, agentcore_config_with_retrieval, mock_memory_client):
+        """Empty content list on the last message must not raise IndexError."""
+        with patch(
+            "bedrock_agentcore.memory.integrations.strands.session_manager.MemoryClient",
+            return_value=mock_memory_client,
+        ):
+            with patch("boto3.Session") as mock_boto_session:
+                mock_session = Mock()
+                mock_session.region_name = "us-west-2"
+                mock_session.client.return_value = Mock()
+                mock_boto_session.return_value = mock_session
+
+                with patch(
+                    "strands.session.repository_session_manager.RepositorySessionManager.__init__", return_value=None
+                ):
+                    manager = AgentCoreMemorySessionManager(agentcore_config_with_retrieval)
+
+                    mock_agent = Mock()
+                    mock_agent.messages = [{"role": "user", "content": []}]
+
+                    event = MessageAddedEvent(agent=mock_agent, message={"role": "user", "content": []})
+                    result = manager.retrieve_customer_context(event)
+                    assert result is None
+                    mock_memory_client.retrieve_memories.assert_not_called()
+
     def test_retrieve_customer_context_no_config(self, agentcore_config, mock_memory_client):
         """Test retrieve_customer_context with no retrieval config."""
         with patch(


### PR DESCRIPTION
Thanks for maintaining this project! Would appreciate a review when you get a chance.

Fixes #543

## Problem

`AgentCoreMemorySessionManager.retrieve_customer_context` (registered as a `MessageAddedEvent` callback) indexes the first content block of the last message without checking that the content list is non-empty:

```python
if not messages or messages[-1].get("role") != "user" or "text" not in messages[-1].get("content")[0]:
    return None
```

When the last message has an empty `content` list (`[]`), `messages[-1].get("content")[0]` raises `IndexError`. Because this runs inside a `MessageAddedEvent` hook, the exception propagates out of the event loop and aborts the whole agent invocation (surfacing as a `500` on AgentCore Runtime). The existing guard handles `not messages` but not an empty `content` list. (See #543 for a runnable end-to-end reproduction.)

## Solution

Check that `content` is non-empty before indexing the first block, returning early otherwise. Added a regression test (`test_retrieve_customer_context_empty_content`) that fails without the guard and passes with it. All existing tests in the session manager suite still pass, and `ruff check` / `ruff format` are clean.
