### PR TITLE
fix(evaluation): make EvaluatorOutput.label optional for error responses

### DIFF
--- a/src/bedrock_agentcore/evaluation/custom_code_based_evaluators/models.py
+++ b/src/bedrock_agentcore/evaluation/custom_code_based_evaluators/models.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class ReferenceInput(BaseModel):
@@ -60,14 +60,28 @@ class EvaluatorInput(BaseModel):
 class EvaluatorOutput(BaseModel):
     """Result returned by a code-based evaluator function.
 
+    For **success** responses, ``label`` is required and ``errorCode`` / ``errorMessage``
+    should be omitted.  For **error** responses, set ``errorCode`` (and optionally
+    ``errorMessage``); ``label`` may be omitted.
+
     Attributes:
-        value: Numerical score for the evaluation.
-        label: Categorical label (e.g. "Pass", "Fail"). Required.
+        value: Numerical score for the evaluation (success responses).
+        label: Categorical label (e.g. "Pass", "Fail"). Required unless errorCode is set.
         explanation: Optional explanation of the evaluation result.
+        errorCode: Error code for error responses (e.g. "VALIDATION_FAILED").
+        errorMessage: Human-readable error description for error responses.
     """
 
     value: Optional[float] = None
-    label: str
+    label: Optional[str] = None
     explanation: Optional[str] = None
     errorCode: Optional[str] = None
     errorMessage: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_label_or_error_code(self) -> "EvaluatorOutput":
+        if not self.errorCode and self.label is None:
+            raise ValueError(
+                "label is required for success responses; set errorCode to return an error response without a label"
+            )
+        return self

--- a/tests/bedrock_agentcore/evaluation/custom_code_based_evaluators/test_models.py
+++ b/tests/bedrock_agentcore/evaluation/custom_code_based_evaluators/test_models.py
@@ -74,17 +74,31 @@ class TestEvaluatorOutput:
         assert out.label == "Pass"
         assert out.explanation == "Looks good"
 
-    def test_label_required(self):
+    def test_label_required_without_error_code(self):
         import pytest
         from pydantic import ValidationError
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError, match="label is required for success responses"):
             EvaluatorOutput(value=1.0)
 
     def test_label_only(self):
         out = EvaluatorOutput(label="Fail")
         assert out.label == "Fail"
         assert out.value is None
+
+    def test_error_response_without_label(self):
+        out = EvaluatorOutput(
+            errorCode="VALIDATION_FAILED",
+            errorMessage="Input spans missing required attributes.",
+        )
+        assert out.label is None
+        assert out.errorCode == "VALIDATION_FAILED"
+        assert out.errorMessage == "Input spans missing required attributes."
+
+    def test_error_response_with_label(self):
+        out = EvaluatorOutput(label="Fail", errorCode="PARTIAL_ERROR", errorMessage="Some fields missing")
+        assert out.label == "Fail"
+        assert out.errorCode == "PARTIAL_ERROR"
 
 
 class TestReferenceInput:


### PR DESCRIPTION
## Summary

The documented Lambda contract for code-based evaluators allows error-only responses that omit `label`:

```json
{ errorCode: VALIDATION_FAILED, errorMessage: ... }
```

However, constructing such a response with the SDK helper model raised a Pydantic `ValidationError` because `label` was unconditionally required (`label: str`).

This PR makes `label` optional **only when `errorCode` is set**, preserving the existing validation for success responses:

- **Success response** (no `errorCode`): `label` is still required — a `ValidationError` is raised if omitted.
- **Error response** (`errorCode` set): `label` may be omitted.

Fixes #541

## Changes

- `src/bedrock_agentcore/evaluation/custom_code_based_evaluators/models.py`:
  - `label: str` → `label: Optional[str] = None`
  - Added `@model_validator(mode=after)` that raises `ValueError` when both `label` and `errorCode` are absent
  - Updated docstring to document the two response shapes

- `tests/bedrock_agentcore/evaluation/custom_code_based_evaluators/test_models.py`:
  - Updated `test_label_required` → `test_label_required_without_error_code` with match string
  - Added `test_error_response_without_label` and `test_error_response_with_label`