### PR TITLE
fix(memory): normalize restored history to a Converse-valid sequence

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -797,7 +797,11 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             return []
 
     def _filter_restored_tool_context(self, messages: list[SessionMessage]) -> list[SessionMessage]:
-        """Strip historical toolUse/toolResult context from restored messages."""
+        """Strip toolUse/toolResult context, merging same-role turns into a Converse-valid sequence.
+
+        The trailing turn is left as-is: the runtime appends the next user turn before the model
+        call, so forcing a user tail here would create two adjacent user turns.
+        """
         filtered_messages: list[SessionMessage] = []
         for session_message in messages:
             message = session_message.to_message()
@@ -810,6 +814,9 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             if not filtered_content:
                 continue
 
+            if filtered_messages and filtered_messages[-1].to_message()["role"] == message["role"]:
+                filtered_content = filtered_messages.pop().to_message()["content"] + filtered_content
+
             filtered_message: Message = {"role": message["role"], "content": filtered_content}
             filtered_messages.append(
                 SessionMessage(
@@ -820,6 +827,9 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                     updated_at=session_message.updated_at,
                 )
             )
+
+        while filtered_messages and filtered_messages[0].to_message()["role"] != "user":
+            filtered_messages.pop(0)
 
         return filtered_messages
 

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
@@ -394,6 +394,72 @@ class TestAgentCoreMemorySessionManager:
         assert messages[1].message["role"] == "user"
         assert messages[0].message["role"] == "assistant"
 
+    def test_filter_restored_drops_tool_only_turn_and_merges_assistants(self, session_manager):
+        """A toolResult-only user turn is dropped, so the surrounding assistant turns merge."""
+        messages = [
+            SessionMessage(message={"role": "user", "content": [{"text": "hi"}]}, message_id=0),
+            SessionMessage(
+                message={
+                    "role": "assistant",
+                    "content": [{"text": "calling"}, {"toolUse": {"toolUseId": "t1", "name": "f", "input": {}}}],
+                },
+                message_id=1,
+            ),
+            SessionMessage(
+                message={
+                    "role": "user",
+                    "content": [{"toolResult": {"toolUseId": "t1", "status": "success", "content": [{"text": "ok"}]}}],
+                },
+                message_id=2,
+            ),
+            SessionMessage(message={"role": "assistant", "content": [{"text": "done"}]}, message_id=3),
+        ]
+
+        result = session_manager._filter_restored_tool_context(messages)
+
+        assert [m.message for m in result] == [
+            {"role": "user", "content": [{"text": "hi"}]},
+            {"role": "assistant", "content": [{"text": "calling"}, {"text": "done"}]},
+        ]
+
+    def test_filter_restored_drops_leading_non_user_turns(self, session_manager):
+        """Restored history must start on a user turn."""
+        messages = [
+            SessionMessage(message={"role": "assistant", "content": [{"text": "orphan"}]}, message_id=0),
+            SessionMessage(message={"role": "user", "content": [{"text": "hi"}]}, message_id=1),
+            SessionMessage(message={"role": "assistant", "content": [{"text": "answer"}]}, message_id=2),
+        ]
+
+        result = session_manager._filter_restored_tool_context(messages)
+
+        assert [m.message for m in result] == [
+            {"role": "user", "content": [{"text": "hi"}]},
+            {"role": "assistant", "content": [{"text": "answer"}]},
+        ]
+
+    def test_filter_restored_preserves_trailing_assistant_turn(self, session_manager):
+        """The trailing assistant turn is kept; the runtime appends the next user turn."""
+        messages = [
+            SessionMessage(message={"role": "user", "content": [{"text": "hi"}]}, message_id=0),
+            SessionMessage(message={"role": "assistant", "content": [{"text": "answer"}]}, message_id=1),
+        ]
+
+        result = session_manager._filter_restored_tool_context(messages)
+
+        assert [m.message for m in result] == [
+            {"role": "user", "content": [{"text": "hi"}]},
+            {"role": "assistant", "content": [{"text": "answer"}]},
+        ]
+
+    def test_filter_restored_all_assistant_history_becomes_empty(self, session_manager):
+        """History with no user turn is dropped entirely."""
+        messages = [
+            SessionMessage(message={"role": "assistant", "content": [{"text": "a"}]}, message_id=0),
+            SessionMessage(message={"role": "assistant", "content": [{"text": "b"}]}, message_id=1),
+        ]
+
+        assert session_manager._filter_restored_tool_context(messages) == []
+
     def test_events_to_messages_empty_payload(self, session_manager):
         """Test converting Bedrock events with empty payload."""
         events = [

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager_openai_converter.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager_openai_converter.py
@@ -121,6 +121,5 @@ def test_list_messages_filters_restored_tool_context():
 
         assert [m.message for m in messages] == [
             {"role": "user", "content": [{"text": "hello"}]},
-            {"role": "assistant", "content": [{"text": "calling tool"}]},
-            {"role": "assistant", "content": [{"text": "done"}]},
+            {"role": "assistant", "content": [{"text": "calling tool"}, {"text": "done"}]},
         ]


### PR DESCRIPTION
Thanks for maintaining this integration! Would appreciate your review of the fix below.

Fixes #547.

## Problem

With `filter_restored_tool_context=True`, stripping tool blocks drops a `toolResult`-only user turn, which leaves the surrounding assistant turns adjacent and breaks Converse's role alternation. The next invocation then fails with an assistant-prefill `ValidationException` (full details in #547).

## Solution

After stripping tool blocks, `_filter_restored_tool_context` now merges adjacent same-role turns and drops leading non-user turns, so the restored history alternates strictly and starts on a user turn:

```
restored (after strip):  user(q) → assistant(text) → assistant(answer)
normalized:              user(q) → assistant([text, answer])
+ runtime appends user:  user(q) → assistant([text, answer]) → user(next)   ✅ Converse-valid
```

The trailing turn is left as-is, since the runtime appends the next user turn before the model call (forcing a user tail here would create two adjacent user turns). Scoped to the existing `filter_restored_tool_context` opt-in, so behavior is unchanged unless enabled.

### Note on merging

Merging is lossy: collapsing two assistant turns into one drops the turn boundary, and the merged message keeps a single event id (the earlier turn's id is not retained). This is consistent with what the flag already does — it discards the tool round-trip from restored history — and merging preserves all text content (concatenated as separate content blocks) rather than dropping a turn. Happy to take a different approach if you'd prefer the lost context handled another way.
