### PR TITLE
fix(memory): type EventMetadataFilter.operator as str

### DIFF
--- a/src/bedrock_agentcore/memory/models/filters.py
+++ b/src/bedrock_agentcore/memory/models/filters.py
@@ -86,7 +86,9 @@ class EventMetadataFilter(TypedDict):
     """
 
     left: LeftExpression
-    operator: OperatorType
+    # Stored as the operator's string value (e.g. "EQUALS_TO"), not the enum itself,
+    # since this dict is serialized directly to the AgentCore service.
+    operator: str
     right: Optional[RightExpression]
 
     def build_expression(

--- a/tests/bedrock_agentcore/memory/models/test_filters.py
+++ b/tests/bedrock_agentcore/memory/models/test_filters.py
@@ -1,17 +1,62 @@
 """Unit tests for memory record metadata filter models."""
 
 from datetime import datetime
+from typing import get_type_hints
 
 import pytest
 
 from bedrock_agentcore.memory.models import (
+    EventMetadataFilter,
     IndexedKey,
+    LeftExpression,
     MemoryMetadataFilter,
     MemoryRecordLeftExpression,
     MemoryRecordOperatorType,
     MemoryRecordRightExpression,
     MetadataValueType,
+    OperatorType,
+    RightExpression,
 )
+
+
+class TestEventMetadataFilter:
+    """Test cases for EventMetadataFilter."""
+
+    def test_operator_is_annotated_as_str(self):
+        """The stored `operator` is the enum's string value, so the field is typed `str`.
+
+        Regression for #240: `build_expression` stores `operator.value` (a string),
+        but the field was annotated `OperatorType` (the enum), which mis-typed every
+        constructed filter. This mirrors the already-correct `MemoryMetadataFilter`.
+        """
+        assert get_type_hints(EventMetadataFilter)["operator"] is str
+
+    def test_build_expression_equals_string(self):
+        """build_expression stores the operator's string value, not the enum."""
+        result = EventMetadataFilter.build_expression(
+            LeftExpression.build("location"),
+            OperatorType.EQUALS_TO,
+            RightExpression.build("NYC"),
+        )
+
+        assert result == {
+            "left": {"metadataKey": "location"},
+            "operator": "EQUALS_TO",
+            "right": {"metadataValue": {"stringValue": "NYC"}},
+        }
+
+    def test_build_expression_exists_no_right_operand(self):
+        """An EXISTS filter omits the right operand."""
+        result = EventMetadataFilter.build_expression(
+            LeftExpression.build("location"),
+            OperatorType.EXISTS,
+        )
+
+        assert result == {
+            "left": {"metadataKey": "location"},
+            "operator": "EXISTS",
+        }
+        assert "right" not in result
 
 
 class TestMemoryRecordLeftExpression:


### PR DESCRIPTION
## Summary

`EventMetadataFilter.build_expression` stores `operator.value` (the operator's string, e.g. `"EQUALS_TO"`) in the returned dict, but the `EventMetadataFilter` TypedDict annotated `operator` as the `OperatorType` enum. Every constructed filter therefore mis-typed the field relative to the value that is actually serialized to the AgentCore service.

This annotates `operator` as `str`, matching the sibling `MemoryMetadataFilter`, which already documents and types the field this way.

Fixes #240

## Changes

- `src/bedrock_agentcore/memory/models/filters.py`: type `EventMetadataFilter.operator` as `str` (was `OperatorType`), with a clarifying comment mirroring `MemoryMetadataFilter`.
- `tests/.../models/test_filters.py`: add the first unit tests for `EventMetadataFilter` — the field annotation plus `build_expression` for a value operator and an existence operator.

## Testing

`uv run pytest tests/bedrock_agentcore/memory/models/test_filters.py` — all pass. No runtime behavior changes; `build_expression` already produced string operators.
