### PR TITLE
fix(memory): strip injected user context from restored messages to prevent O(turns) accumulation

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -787,6 +787,8 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             messages = self.converter.events_to_messages(events)
             if self.config.filter_restored_tool_context:
                 messages = self._filter_restored_tool_context(messages)
+            if self.config.retrieval_config:
+                messages = self._filter_restored_user_context(messages)
             if limit is not None:
                 return messages[offset : offset + limit]
             else:
@@ -821,6 +823,40 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
                 )
             )
 
+        return filtered_messages
+
+    def _filter_restored_user_context(self, messages: list[SessionMessage]) -> list[SessionMessage]:
+        """Strip previously-injected <context_tag> blocks from restored user messages.
+
+        Without this, the context block that was prepended to each user message during
+        a prior turn is reloaded from storage on every subsequent turn, causing the
+        injected context to accumulate O(turns × records) across the conversation.
+        Fresh context is re-injected by retrieve_customer_context on each new turn.
+        """
+        open_tag = f"<{self.config.context_tag}>"
+        filtered_messages: list[SessionMessage] = []
+        for session_message in messages:
+            message = session_message.to_message()
+            if message.get("role") != "user":
+                filtered_messages.append(session_message)
+                continue
+            filtered_content = [
+                block
+                for block in message.get("content", [])
+                if not (isinstance(block, dict) and block.get("text", "").startswith(open_tag))
+            ]
+            if not filtered_content:
+                filtered_messages.append(session_message)
+                continue
+            filtered_messages.append(
+                SessionMessage(
+                    message={"role": message["role"], "content": filtered_content},
+                    message_id=session_message.message_id,
+                    redact_message=session_message.redact_message,
+                    created_at=session_message.created_at,
+                    updated_at=session_message.updated_at,
+                )
+            )
         return filtered_messages
 
     # endregion SessionRepository interface implementation


### PR DESCRIPTION
## Summary

When `retrieval_config` is configured, `retrieve_customer_context()` prepends a `<context_tag>` XML block to each user message, and the message is persisted to AgentCore Memory with that block embedded. On every subsequent turn, `list_messages()` reloads all historical messages verbatim — so every restored user message re-appears with its injected context block intact. The result is O(turns × records) token accumulation:

```
Turn 1: [user+XML, assistant]
Turn 2: [user+XML, assistant, user+XML, assistant]
Turn 3: [user+XML, assistant, user+XML, assistant, user+XML, assistant]
```

Observed with 5 turns and 3 preference records: **3,655 chars of repeated context (83% of total message content)**.

## Fix

Added `_filter_restored_user_context()` — mirroring the existing `_filter_restored_tool_context()` pattern — which strips any content block whose text starts with the opening `<context_tag>` before the messages are handed to the Strands runtime. The filter is applied in `list_messages()` whenever `retrieval_config` is configured. Fresh context is re-injected on each new turn by `retrieve_customer_context()`, so no context is lost.

Fixes #420

## Changes

- `src/bedrock_agentcore/memory/integrations/strands/session_manager.py`:
  - Added `_filter_restored_user_context()` method (36 lines, analogous to `_filter_restored_tool_context()`)
  - Called in `list_messages()` when `self.config.retrieval_config` is set