### PR TITLE
fix(memory): wrap boto3 clients in context-isolating proxy to silence OTel detach errors

### DIFF
--- a/src/bedrock_agentcore/memory/client.py
+++ b/src/bedrock_agentcore/memory/client.py
@@ -8,6 +8,7 @@ The SDK automatically normalizes responses to provide both field names for
 backward compatibility.
 """
 
+import contextvars
 import copy
 import logging
 import time
@@ -40,6 +41,40 @@ from .constants import (
 from .models.filters import EventMetadataFilter, IndexedKey, MemoryMetadataFilter, MetadataValue
 
 logger = logging.getLogger(__name__)
+
+
+class _ContextIsolatingProxy:
+    """Wraps a boto3 client so that each method call runs inside a context copy.
+
+    When the SDK is used from an asyncio task or a ThreadPoolExecutor thread that
+    already has an OpenTelemetry context attached, the OTel boto3 auto-instrumentation
+    (e.g. ``aws-opentelemetry-distro``) calls ``opentelemetry.context.attach()`` and
+    then ``opentelemetry.context.detach()`` around each API call.  Python's
+    ``ContextVar.reset()`` raises ``ValueError`` if the token was created in a
+    different execution context than the one calling ``reset()`` — which can happen
+    when an asyncio task inherits OTel context from a parent task or when a thread
+    pool worker is used across ``await`` boundaries.
+
+    Running each call inside ``contextvars.copy_context().run()`` creates an
+    isolated snapshot so the OTel attach/detach pair is always contained within the
+    same context, preventing the ``ValueError``.
+    """
+
+    __slots__ = ("_client", "meta")
+
+    def __init__(self, client: Any) -> None:
+        object.__setattr__(self, "_client", client)
+        object.__setattr__(self, "meta", client.meta)
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(object.__getattribute__(self, "_client"), name)
+        if callable(attr):
+
+            def _wrapper(*args: Any, **kwargs: Any) -> Any:
+                return contextvars.copy_context().run(attr, *args, **kwargs)
+
+            return _wrapper
+        return attr
 
 
 class MemoryClient:
@@ -95,10 +130,12 @@ class MemoryClient:
         user_agent_extra = build_user_agent_suffix(integration_source)
         client_config = Config(user_agent_extra=user_agent_extra)
 
-        self.gmcp_client = session.client(
-            "bedrock-agentcore-control", region_name=self.region_name, config=client_config
+        self.gmcp_client = _ContextIsolatingProxy(
+            session.client("bedrock-agentcore-control", region_name=self.region_name, config=client_config)
         )
-        self.gmdp_client = session.client("bedrock-agentcore", region_name=self.region_name, config=client_config)
+        self.gmdp_client = _ContextIsolatingProxy(
+            session.client("bedrock-agentcore", region_name=self.region_name, config=client_config)
+        )
 
         logger.info(
             "Initialized MemoryClient for control plane: %s, data plane: %s",


### PR DESCRIPTION
## Problem

When `MemoryClient` is used inside an asyncio application with `aws-opentelemetry-distro` (or any OTel boto3 auto-instrumentation), every data-plane or control-plane call emits an ERROR-level log:

```
ERROR [opentelemetry.context] Failed to detach context
ValueError: Token was created in a different Context
```

This happens because the OTel boto3 instrumentation calls `context.attach()` before the API call and `context.detach()` after. Python's `ContextVar.reset()` raises `ValueError` when the token was created in a different execution context -- which occurs when the SDK is used from an asyncio task that inherited OTel context from a parent task, or when a `ThreadPoolExecutor` worker crosses `await` boundaries.

At scale (many concurrent agents, `AgentCoreMemorySessionManager` with `asyncio.to_thread()`), this fills CloudWatch with spurious ERROR entries that obscure real failures.

## Fix

Added `_ContextIsolatingProxy` -- a thin wrapper around a boto3 client that runs each method call inside `contextvars.copy_context().run()`. This creates an isolated context snapshot so the OTel attach/detach pair is always contained within the same context, making `ContextVar.reset()` succeed.

Both `gmdp_client` (data plane) and `gmcp_client` (control plane) are wrapped at construction time in `MemoryClient.__init__`. This fixes every call site -- including direct `self.gmdp_client.create_event(...)` calls in `session_manager.py` -- without per-call changes.

The proxy exposes `meta` directly (for `meta.region_name` logging) and wraps all callable attributes; non-callable attributes are returned as-is.

## Changes

- `src/bedrock_agentcore/memory/client.py`:
  - Added `import contextvars`
  - Added `_ContextIsolatingProxy` class (27 lines, before `MemoryClient`)
  - Wrapped `gmdp_client` and `gmcp_client` with the proxy in `__init__`

Fixes #456