### PR TITLE
fix(memory): guard against integer message_id in update_message

### DIFF
--- a/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
+++ b/src/bedrock_agentcore/memory/integrations/strands/session_manager.py
@@ -686,6 +686,19 @@ class AgentCoreMemorySessionManager(RepositorySessionManager, SessionRepository)
             logger.debug("Message has no event ID and was not found in buffer - skipping update")
             return
 
+        # Strands' RepositorySessionManager.initialize_agent passes SessionMessage objects
+        # whose message_id is a sequential integer index (0, 1, 2 …), not an AWS eventId
+        # string (e.g. "4#abc123f").  Passing an integer to delete_event causes a
+        # ParamValidationError at the botocore layer.  Skip the update — the event
+        # cannot be located by a positional index alone.
+        if isinstance(old_message_id, int):
+            logger.warning(
+                "update_message: message_id %r is a Strands positional integer index, not an "
+                "AWS eventId string — skipping delete of old event (see issue #556)",
+                old_message_id,
+            )
+            return
+
         # Create a new event with the updated message content
         try:
             updated_message = SessionMessage(


### PR DESCRIPTION
## Summary

`update_message` crashes with a `ParamValidationError` when `session_message.message_id` is a Strands positional integer index (e.g. `4`) rather than an AWS eventId string (e.g. `"4#abc123f"`).

This happens because `RepositorySessionManager.initialize_agent` populates `_latest_agent_message` with `SessionMessage` objects that carry a sequential integer `message_id`. When `redact_latest_message` is subsequently called it reads `_latest_agent_message[agent_id]` and passes that message to `update_message`, which then calls `delete_event(eventId=4)`. botocore rejects the integer:

```
Parameter validation failed: Invalid type for parameter eventId,
value: 4, type: <class 'int'>, valid types: <class 'str'>
```

Fixes #556

## Changes

- `src/bedrock_agentcore/memory/integrations/strands/session_manager.py`: add an `isinstance(old_message_id, int)` guard immediately after the existing `None` check in `update_message`. Integer positional indices cannot be mapped to AWS eventId strings without an extra API call, so the method logs a warning and returns early, preventing the `ParamValidationError`.