### PR TITLE
fix(ci): prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -47,7 +47,9 @@ jobs:
 
       # Fetch the base branch so the ref is available for griffe's worktree.
       - name: Fetch base branch
-        run: git fetch origin "${{ github.base_ref }}" --depth=1
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF" --depth=1
 
       # Run griffe using its Python API for stable, structured output.
       # The Python API is used instead of the CLI to:
@@ -150,6 +152,8 @@ jobs:
       # rather than creating a new one per commit.
       - name: Post or update PR comment
         uses: actions/github-script@v8
+        env:
+          GRIFFE_EXIT_CODE: ${{ steps.griffe.outputs.exit_code }}
         with:
           script: |
             const fs = require('fs');
@@ -186,7 +190,7 @@ jobs:
             }
 
             // Log summary to the Actions step output for visibility.
-            const exitCode = '${{ steps.griffe.outputs.exit_code }}';
+            const exitCode = process.env.GRIFFE_EXIT_CODE;
             if (exitCode === '1') {
               core.warning('Breaking changes detected — see PR comment for details.');
             }

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -56,20 +56,28 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREV_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
         run: |
           gh pr merge --auto --squash "$PR_URL"
-          echo "✓ Auto-merge enabled: ${{ steps.metadata.outputs.dependency-names }} \
-          (${{ steps.metadata.outputs.previous-version }} → \
-          ${{ steps.metadata.outputs.new-version }}, \
-          ${{ steps.metadata.outputs.update-type }})"
+          echo "✓ Auto-merge enabled: $DEP_NAMES \
+          ($PREV_VERSION → \
+          $NEW_VERSION, \
+          $UPDATE_TYPE)"
 
       # major bumps: log clearly and do nothing.
       # The PR stays open and is assigned to aws/bedrock-agentcore-maintainers
       # via dependabot.yml for human review.
       - name: Skip major bumps — human review required
         if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          DEP_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          PREV_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
         run: |
-          echo "⏭ Skipped: ${{ steps.metadata.outputs.dependency-names }} \
-          is a major bump (${{ steps.metadata.outputs.previous-version }} → \
-          ${{ steps.metadata.outputs.new-version }}). \
+          echo "⏭ Skipped: $DEP_NAMES \
+          is a major bump ($PREV_VERSION → \
+          $NEW_VERSION). \
           Requires review from aws/bedrock-agentcore-maintainers."

--- a/.github/workflows/integration-testing-regression.yml
+++ b/.github/workflows/integration-testing-regression.yml
@@ -216,11 +216,13 @@ jobs:
 
       # Install test dependencies only — NOT the library (already installed above).
       - name: Install test dependencies
+        env:
+          EXTRA_DEPS: ${{ matrix.extra-deps }}
         run: |
           pip install --no-cache-dir \
             pytest pytest-xdist pytest-order pytest-rerunfailures \
             requests strands-agents uvicorn httpx starlette websockets \
-            ${{ matrix.extra-deps }}
+            $EXTRA_DEPS
 
       # Run the old test suite against the new library.
       # A failure here means a test that passed in the previous release
@@ -235,14 +237,18 @@ jobs:
           RESOURCE_POLICY_TEST_ARN: ${{ secrets.RESOURCE_POLICY_TEST_ARN }}
           RESOURCE_POLICY_TEST_PRINCIPAL: ${{ secrets.RESOURCE_POLICY_TEST_PRINCIPAL }}
           BASELINE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+          TEST_GROUP: ${{ matrix.group }}
+          PYTEST_PATH: ${{ matrix.path }}
         timeout-minutes: ${{ matrix.timeout }}
         working-directory: /tmp/baseline-tests
+        # PYTEST_PATH comes from the job matrix and holds space-separated pytest
+        # path args; left unquoted intentionally so it word-splits.
         run: |
           echo "================================================"
           echo "Library:    bedrock-agentcore (PR branch source)"
-          echo "Test suite: $BASELINE_TAG tests_integ/${{ matrix.group }}"
+          echo "Test suite: $BASELINE_TAG tests_integ/$TEST_GROUP"
           echo "================================================"
-          pytest ${{ matrix.path }} \
+          pytest $PYTEST_PATH \
             -n auto --dist=loadscope \
             -s --log-cli-level=INFO
 

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -185,9 +185,11 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
+        env:
+          EXTRA_DEPS: ${{ matrix.extra-deps }}
         run: |
           pip install -e .
-          pip install --no-cache-dir pytest pytest-xdist pytest-order pytest-rerunfailures requests strands-agents uvicorn httpx starlette websockets ${{ matrix.extra-deps }}
+          pip install --no-cache-dir pytest pytest-xdist pytest-order pytest-rerunfailures requests strands-agents uvicorn httpx starlette websockets $EXTRA_DEPS
 
       - name: Run integration tests
         env:
@@ -208,10 +210,14 @@ jobs:
           COGNITO_POOL_ID: ${{ secrets.COGNITO_POOL_ID }}
           COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
           COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
+          PYTEST_PATH: ${{ matrix.path }}
+          PYTEST_IGNORE: ${{ matrix.ignore }}
         id: tests
         timeout-minutes: ${{ matrix.timeout }}
+        # PYTEST_PATH/PYTEST_IGNORE come from the job matrix and hold space-separated
+        # pytest path/ignore args; left unquoted intentionally so they word-split.
         run: |
-          pytest ${{ matrix.path }} ${{ matrix.ignore }} -n auto --dist=loadscope -s --log-cli-level=INFO
+          pytest $PYTEST_PATH $PYTEST_IGNORE -n auto --dist=loadscope -s --log-cli-level=INFO
 
   safety-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -31,8 +31,10 @@ jobs:
     steps:
       - name: Validate running from main
         if: github.ref != 'refs/heads/main'
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          echo "❌ ERROR: Must run from main branch, got ${{ github.ref }}"
+          echo "❌ ERROR: Must run from main branch, got $GITHUB_REF"
           exit 1
 
       - name: Checkout code


### PR DESCRIPTION
## Description

Hardens our GitHub Actions workflows against **script injection** (the AppSec/ACAT "Script Injection in GitHub Actions workflows" finding class).

Several `run:` and `actions/github-script` steps interpolated GitHub context values directly into the script body via `${{ … }}`. The Actions runner substitutes those *before* the shell/JS parses the line, so context data can execute as code. The fix follows GitHub's recommended pattern: bind each expression to an `env:` variable and reference the **shell/JS** variable instead (`env:` assignments are not an injection vector). No behavior changes.

> Note: the release workflow that the AppSec scan originally flagged (`release.yml`) was already split into `release-prepare.yml` / `release-publish.yml` using the safe pattern; the remaining flagged instance on `main` lived on stale post-merge branches. This PR closes out the *same vulnerability class* everywhere else it still appears on `main`.

### Files & what changed
- **breaking-change-check.yml** — `github.base_ref` (a fork PR's source branch name) flowed into `git fetch`; now via `env:`. The `github-script` step reads `steps.griffe.outputs.exit_code` from `process.env`.
- **dependabot-auto-merge.yml** — `steps.metadata.outputs.*` (dependency names/versions/update-type) routed through `env:` in both echo steps.
- **integration-testing.yml** / **integration-testing-regression.yml** — `matrix.extra-deps`, `matrix.path`, `matrix.ignore`, `matrix.group` routed through `env:`. The pytest path/deps vars are intentionally left unquoted so they word-split into args exactly as before.
- **release-prepare.yml** — `github.ref` in the "must run from main" error message routed through `env:`.

## Testing

Workflow-only changes. Validated by:
- [x] YAML parses cleanly for all five workflows
- [x] Verified no `${{ }}` expressions remain inside any `run:`/`script:` body across the entire `.github/workflows/` tree
- [x] Behavior preserved (matrix word-splitting retained where intended)
