### PR TITLE
ci: add API reference docs generation workflow

### DIFF
--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,68 @@
+# =============================================================================
+# publish-api-docs.yml  —  bedrock-agentcore-sdk-python
+# =============================================================================
+# Auto-generates the Python SDK API reference as AsciiDoc (.adoc) on every
+# release and uploads it as a build artifact for the docs team to publish.
+#
+# Pipeline: install released SDK -> extract doc-model JSON (inspect + docstrings)
+#           -> render .adoc -> upload artifact.
+#
+# NOTE: this generates and publishes the docs as an artifact only; landing them
+# in the docs site is a separate step for now and may be automated later.
+# =============================================================================
+
+name: Publish API docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  ADOC_PREFIX: python-sdk
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the published SDK
+        # Install the EXACT released version, not the newest on PyPI.
+        # `release: [published]` can fire for pre-releases too, so pin to the
+        # release tag when present; fall back to newest for manual runs.
+        run: |
+          pip install --upgrade pip
+          if [ -n "$RELEASE_TAG" ]; then
+            pip install "bedrock-agentcore==${RELEASE_TAG#v}"
+          else
+            pip install bedrock-agentcore
+          fi
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+
+      - name: Extract doc-model JSON
+        run: python scripts/extract_api_model.py --out doc-model.json
+
+      - name: Render .adoc
+        run: |
+          python scripts/render_adoc.py \
+            --model doc-model.json \
+            --out-dir out/adoc \
+            --prefix "${ADOC_PREFIX}"
+
+      - name: Upload API-docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-adoc
+          path: out/adoc
+          if-no-files-found: error

--- a/scripts/extract_api_model.py
+++ b/scripts/extract_api_model.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# =============================================================================
+# extract_api_model.py  —  Python SDK -> doc-model JSON
+# =============================================================================
+# Introspects the installed `bedrock-agentcore` package and emits the shared
+# doc-model JSON (schema v1, see _shared/render_adoc.py) that the shared
+# renderer turns into .adoc.
+#
+# Runs on a GitHub-hosted runner AFTER `pip install bedrock-agentcore`, so the
+# import below resolves against the real published wheel.
+#
+# NOTE: if these workflows are later consolidated into a single shared reusable
+# workflow, this script is vendored there and selected via a `language: python`
+# input. It lives here now only so the draft is self-contained and runnable in
+# isolation.
+#
+# Docstring style: the SDK uses Google-style docstrings. We do a light parse
+# (Args/Returns/Raises/Example sections). We intentionally keep the parser
+# small; anything we can't classify falls through into `description` verbatim.
+# =============================================================================
+
+import argparse
+import importlib
+import inspect
+import json
+import re
+import sys
+
+PACKAGE = "bedrock_agentcore"
+
+# All public modules to document (decision: include ALL of them).
+# Each maps to one group == one .adoc file.
+GROUPS = [
+    ("runtime", "Runtime", "bedrock_agentcore.runtime"),
+    ("memory", "Memory", "bedrock_agentcore.memory"),
+    ("identity", "Identity", "bedrock_agentcore.identity"),
+    ("tools", "Built-in Tools", "bedrock_agentcore.tools"),
+    ("gateway", "Gateway", "bedrock_agentcore.gateway"),
+    ("policy", "Policy", "bedrock_agentcore.policy"),
+    ("evaluation", "Evaluation", "bedrock_agentcore.evaluation"),
+    ("config-bundle", "Configuration Bundles", "bedrock_agentcore.config_bundle"),
+    ("payments", "Payments", "bedrock_agentcore.payments"),
+    ("knowledge-base", "Knowledge Base", "bedrock_agentcore.knowledge_base"),
+]
+
+_SECTION_RE = re.compile(r"^\s*(Args|Arguments|Returns|Raises|Example|Examples):\s*$")
+_ARG_RE = re.compile(r"^\s+(\w+)\s*(?:\(([^)]+)\))?:\s*(.*)$")
+
+# The SDK mixes Google-style ("Args:") and reST-style (":param x:") docstrings,
+# so we also recognize the reST field forms and pull them out of the prose.
+_REST_PARAM_RE = re.compile(r"^\s*:param\s+(\w+):\s*(.*)$")
+_REST_RETURNS_RE = re.compile(r"^\s*:returns?:\s*(.*)$")
+_REST_RAISES_RE = re.compile(r"^\s*:raises?\s+([\w.]+):\s*(.*)$")
+
+
+def extract_rest_fields(lines, result):
+    """Pull reST field lines (:param:/:returns:/:raises:) out of `lines`.
+
+    Returns the remaining (non-field) lines so they can form the description.
+    Mutates `result` in place, matching the Google parser's output shape.
+    """
+    kept = []
+    for line in lines:
+        m = _REST_PARAM_RE.match(line)
+        if m:
+            result["params"].append(
+                {
+                    "name": m.group(1),
+                    "type": None,
+                    "required": True,
+                    "description": m.group(2).strip(),
+                }
+            )
+            continue
+        m = _REST_RETURNS_RE.match(line)
+        if m:
+            result["returns"] = {"type": None, "description": m.group(1).strip()}
+            continue
+        m = _REST_RAISES_RE.match(line)
+        if m:
+            result["raises"].append({"type": m.group(1), "description": m.group(2).strip()})
+            continue
+        kept.append(line)
+    return kept
+
+
+def parse_google_docstring(doc):
+    """Very small Google-style docstring parser -> structured dict."""
+    result = {"summary": "", "description": "", "params": [], "returns": None, "raises": [], "examples": []}
+    if not doc:
+        return result
+    lines = inspect.cleandoc(doc).splitlines()
+
+    # summary = first paragraph
+    i = 0
+    summary = []
+    while i < len(lines) and lines[i].strip():
+        summary.append(lines[i].strip())
+        i += 1
+    result["summary"] = " ".join(summary)
+
+    section = "description"
+    desc, example_buf = [], []
+    while i < len(lines):
+        line = lines[i]
+        m = _SECTION_RE.match(line)
+        if m:
+            name = m.group(1).lower()
+            section = {
+                "args": "args",
+                "arguments": "args",
+                "returns": "returns",
+                "raises": "raises",
+                "example": "example",
+                "examples": "example",
+            }[name]
+            i += 1
+            continue
+        if section == "description":
+            desc.append(line)
+        elif section == "args":
+            am = _ARG_RE.match(line)
+            if am:
+                result["params"].append(
+                    {
+                        "name": am.group(1),
+                        "type": (am.group(2) or "").strip() or None,
+                        "required": "optional" not in (am.group(2) or "").lower(),
+                        "description": am.group(3).strip(),
+                    }
+                )
+            elif result["params"] and line.strip():
+                result["params"][-1]["description"] += " " + line.strip()
+        elif section == "returns":
+            if line.strip():
+                if result["returns"] is None:
+                    result["returns"] = {"type": None, "description": line.strip()}
+                else:
+                    result["returns"]["description"] += " " + line.strip()
+        elif section == "raises":
+            am = _ARG_RE.match(line)
+            if am:
+                result["raises"].append({"type": am.group(1), "description": am.group(3).strip()})
+        elif section == "example":
+            example_buf.append(line)
+        i += 1  # always advance — non-header branches above don't, else infinite loop
+
+    # Second pass: some docstrings use reST fields (:param:/:returns:/:raises:)
+    # instead of, or mixed with, Google sections. Pull those out of the prose.
+    desc = extract_rest_fields(desc, result)
+    result["description"] = "\n".join(desc).strip()
+    if example_buf:
+        code = "\n".join(example_buf).strip()
+        # strip a leading ```python fence if the docstring used one
+        code = re.sub(r"^```\w*\n?|\n?```$", "", code).strip()
+        if code:
+            result["examples"].append({"lang": "python", "code": code})
+    return result
+
+
+def _own_docstring(obj):
+    """Return obj's docstring, but suppress ones merely inherited from `object`.
+
+    Classes/methods that don't define their own docstring inherit boilerplate
+    like "Initialize self. See help(type(self))..." from object.__init__ /
+    object.__new__ — noise we don't want in the reference.
+    """
+    doc = inspect.getdoc(obj)
+    if not doc:
+        return None
+    for base in (object.__init__, object.__new__, object):
+        if doc == inspect.getdoc(base):
+            return None
+    return doc
+
+
+def entry_from_object(name, obj):
+    """Build a doc-model entry for a class or function."""
+    doc = parse_google_docstring(_own_docstring(obj))
+    try:
+        signature = inspect.signature(obj)
+        # Drop the implicit `self`/`cls` receiver from method signatures.
+        params = [p for p in signature.parameters.values() if p.name not in ("self", "cls")]
+        signature = signature.replace(parameters=params)
+        sig = f"{name}{signature}"
+    except (ValueError, TypeError):
+        sig = name
+
+    kind = "class" if inspect.isclass(obj) else "function"
+    entry = {
+        "kind": kind,
+        "name": name,
+        "signature": sig,
+        "summary": doc["summary"],
+        "description": doc["description"],
+        "params": doc["params"],
+        "returns": doc["returns"],
+        "raises": doc["raises"],
+        "examples": doc["examples"],
+        "members": [],
+    }
+
+    if kind == "class":
+        for mname, mobj in inspect.getmembers(obj, predicate=inspect.isfunction):
+            if mname.startswith("_") and mname != "__init__":
+                continue
+            if mobj.__qualname__.split(".")[0] != obj.__name__:
+                continue  # skip inherited members
+            entry["members"].append(entry_from_object(mname, mobj))
+    return entry
+
+
+def collect_public_names(module):
+    """Public API of a module = its __all__, else non-underscore attrs."""
+    names = getattr(module, "__all__", None)
+    if names:
+        return list(names)
+    return [n for n in dir(module) if not n.startswith("_")]
+
+
+def build_group(gid, title, modname):
+    try:
+        module = importlib.import_module(modname)
+    except Exception as e:  # noqa: BLE001 — module may not exist in a given version
+        print(f"  skip {modname}: {e}", file=sys.stderr)
+        return None
+
+    summary = (inspect.getdoc(module) or "").split("\n\n")[0]
+    entries = []
+    for name in collect_public_names(module):
+        # Some modules (e.g. evaluation) expose symbols via a lazy __getattr__
+        # that RAISES ImportError for optional extras rather than returning a
+        # default — so we can't rely on getattr's default and must catch.
+        try:
+            obj = getattr(module, name, None)
+        except Exception as e:  # noqa: BLE001
+            print(f"  skip {modname}.{name}: {type(e).__name__}", file=sys.stderr)
+            continue
+        if inspect.isclass(obj) or inspect.isfunction(obj):
+            # only document objects actually defined in this package
+            if getattr(obj, "__module__", "").startswith(PACKAGE):
+                entries.append(entry_from_object(name, obj))
+    if not entries:
+        return None
+    return {"id": gid, "title": title, "summary": summary, "entries": entries}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True, help="output doc-model JSON path")
+    args = ap.parse_args()
+
+    importlib.import_module(PACKAGE)
+    # The package exposes its version via distribution metadata, not a
+    # __version__ attribute, so read it from there (fall back gracefully).
+    try:
+        from importlib.metadata import version as _dist_version
+
+        version = _dist_version("bedrock-agentcore")
+    except Exception:  # noqa: BLE001
+        version = "unknown"
+
+    groups = []
+    for gid, title, modname in GROUPS:
+        g = build_group(gid, title, modname)
+        if g:
+            groups.append(g)
+
+    model = {
+        "source": "python-sdk",
+        "package": "bedrock-agentcore",
+        "version": version,
+        "language": "python",
+        "groups": groups,
+    }
+    with open(args.out, "w") as f:
+        json.dump(model, f, indent=2)
+    print(f"Wrote doc-model: {len(groups)} groups, version {version}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# =============================================================================
+# render_adoc.py  —  shared doc-model -> AsciiDoc renderer
+# =============================================================================
+# Renders a normalized "doc-model" JSON (produced by any of the three
+# extractors) into .adoc files for the documentation repository.
+#
+# It is deliberately source-agnostic: the Python extractor, the TypeScript
+# TypeDoc extractor, and the CLI --help extractor all emit the SAME doc-model
+# schema, so this one renderer produces consistent output for all three.
+#
+# NOTE: if these workflows are later consolidated into a single shared reusable
+# workflow, this file is vendored there ONCE and every source repo's caller
+# invokes it. Keep it dependency-free (stdlib only) so it drops cleanly into any
+# runner.
+#
+# -----------------------------------------------------------------------------
+# doc-model schema (v1) — the contract every extractor must emit:
+#   {
+#     "source":   "python-sdk" | "ts-sdk" | "cli",
+#     "package":  "bedrock-agentcore",
+#     "version":  "1.16.0",
+#     "language": "python" | "typescript" | "cli",
+#     "groups": [                      # a group -> one .adoc file
+#       {
+#         "id":       "runtime",       # -> <prefix>-runtime.adoc, and anchor id
+#         "title":    "Runtime",
+#         "summary":  "Runtime management and application context.",
+#         "entries": [                 # classes / functions / commands
+#           {
+#             "kind":      "class" | "function" | "command",
+#             "name":      "BedrockAgentCoreApp",
+#             "signature": "BedrockAgentCoreApp(params)",
+#             "summary":   "one-line summary",
+#             "description": "longer prose (optional)",
+#             "params": [ {"name","type","required","description"} ],
+#             "returns":  {"type","description"} | null,
+#             "raises":   [ {"type","description"} ],
+#             "examples": [ {"lang","code"} ],
+#             "members":  [ <entry>, ... ]   # methods on a class (recursive)
+#           }
+#         ]
+#       }
+#     ]
+#   }
+# -----------------------------------------------------------------------------
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+
+SCHEMA_VERSION = 1
+
+
+def esc(text):
+    """Escape AsciiDoc-significant characters in inline text."""
+    if not text:
+        return ""
+    # Guard the couple of chars that start AsciiDoc markup in running prose.
+    return text.replace("|", "\\|").replace("{", "\\{")
+
+
+# Match markdown code fences that may be indented (reST/Google docstrings often
+# indent example blocks). `re.MULTILINE` lets ^ match each line start; the
+# leading-whitespace groups are stripped from the captured code.
+_FENCE_RE = re.compile(r"^[ \t]*```(\w*)[ \t]*\n(.*?)\n[ \t]*```[ \t]*$", re.DOTALL | re.MULTILINE)
+
+
+def render_prose(text):
+    """Render description prose that may contain markdown ``` code fences.
+
+    Docstrings/TSDoc frequently embed fenced code blocks in the description
+    (not just in @example). Left alone they leak literal backticks into the
+    AsciiDoc. Split the prose on fences: escape the prose spans, and convert
+    each fenced block into an AsciiDoc [source] block (verbatim, not escaped).
+    """
+    if not text:
+        return []
+    out = []
+    pos = 0
+    for m in _FENCE_RE.finditer(text):
+        before = text[pos : m.start()].strip()
+        if before:
+            out.append(esc(before))
+            out.append("")
+        lang = m.group(1) or ""
+        out.append(f"[source,{lang}]" if lang else "[source]")
+        out.append("----")
+        # Dedent the captured code (fences are often indented in docstrings).
+        out.append(textwrap.dedent(m.group(2)).rstrip())
+        out.append("----")
+        out.append("")
+        pos = m.end()
+    tail = text[pos:].strip()
+    if tail:
+        out.append(esc(tail))
+    return out
+
+
+def block(lines):
+    return "\n".join(lines)
+
+
+def render_params(params, out):
+    if not params:
+        return
+    out.append("*Parameters*")
+    out.append("")
+    for p in params:
+        req = "" if p.get("required") else " _(optional)_"
+        typ = f"`{p['type']}`" if p.get("type") else ""
+        out.append(f"`{p['name']}`{req} {typ}::")
+        out.append(esc(p.get("description", "")) or "_No description._")
+    out.append("")
+
+
+def render_returns(returns, out):
+    if not returns:
+        return
+    typ = f"`{returns['type']}` — " if returns.get("type") else ""
+    out.append("*Returns*")
+    out.append("")
+    out.append(f"{typ}{esc(returns.get('description', ''))}".strip())
+    out.append("")
+
+
+def render_raises(raises, out):
+    if not raises:
+        return
+    out.append("*Raises*")
+    out.append("")
+    for r in raises:
+        out.append(f"`{r.get('type', 'Error')}`:: {esc(r.get('description', ''))}")
+    out.append("")
+
+
+def clean_example_code(code):
+    """Strip stray markdown fence lines from example code.
+
+    Extractors try to remove ``` fences, but real docstrings put them mid-buffer
+    (e.g. a fence followed by extra "Notes:"/"Thread Safety:" prose swept into
+    the example). Since this text is already going inside an AsciiDoc [source]
+    block, any line that is just a fence is spurious — drop it, and drop trailing
+    non-code prose that follows a closing fence.
+    """
+    lines = code.split("\n")
+    kept = []
+    closed = False
+    for line in lines:
+        if re.match(r"^[ \t]*```", line):
+            # A closing fence marks the end of the real code; ignore the fence
+            # line itself and stop taking subsequent prose.
+            if kept:
+                closed = True
+            continue
+        if closed and line.strip() == "":
+            continue
+        if closed and line.strip():
+            break  # prose after the closing fence — not part of the example
+        kept.append(line)
+    return textwrap.dedent("\n".join(kept)).strip()
+
+
+def render_examples(examples, out):
+    for ex in examples or []:
+        lang = ex.get("lang", "text")
+        code = clean_example_code(ex.get("code", ""))
+        if not code:
+            continue
+        out.append(f"[source,{lang}]")
+        out.append("----")
+        out.append(code)
+        out.append("----")
+        out.append("")
+
+
+def render_entry(entry, level, out):
+    """Render a single class/function/command as an AsciiDoc section."""
+    heading = "=" * level
+    name = entry.get("name", "")
+    out.append(f"{heading} {name}")
+    out.append("")
+
+    sig = entry.get("signature")
+    if sig:
+        out.append("[source]")
+        out.append("----")
+        out.append(sig)
+        out.append("----")
+        out.append("")
+
+    if entry.get("summary"):
+        out.extend(render_prose(entry["summary"]))
+        out.append("")
+    if entry.get("description"):
+        out.extend(render_prose(entry["description"]))
+        out.append("")
+
+    render_params(entry.get("params"), out)
+    render_returns(entry.get("returns"), out)
+    render_raises(entry.get("raises"), out)
+    render_examples(entry.get("examples"), out)
+
+    # methods / subcommands nest one heading level deeper
+    for member in entry.get("members", []):
+        render_entry(member, level + 1, out)
+
+
+def render_group(group, model, prefix):
+    """Render one group -> one .adoc file body (string)."""
+    out = []
+    gid = group["id"]
+    # AsciiDoc anchor so the TOC / other pages can xref into it.
+    out.append(f"[[{prefix}-{gid}]]")
+    out.append(f"= {group['title']}")
+    out.append("")
+    out.append(f"_Auto-generated from `{model['package']}` v{model['version']} — do not edit by hand._")
+    out.append("")
+    if group.get("summary"):
+        out.extend(render_prose(group["summary"]))
+        out.append("")
+
+    for entry in group.get("entries", []):
+        render_entry(entry, level=2, out=out)
+
+    return block(out).rstrip() + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Render doc-model JSON to .adoc")
+    ap.add_argument("--model", required=True, help="path to doc-model JSON")
+    ap.add_argument("--out-dir", required=True, help="output dir for .adoc files")
+    ap.add_argument(
+        "--prefix",
+        required=True,
+        help="filename + anchor prefix, e.g. 'python-sdk', 'ts-sdk', 'cli'",
+    )
+    args = ap.parse_args()
+
+    with open(args.model) as f:
+        model = json.load(f)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    written = []
+    for group in model.get("groups", []):
+        body = render_group(group, model, args.prefix)
+        fname = f"{args.prefix}-{group['id']}.adoc"
+        path = os.path.join(args.out_dir, fname)
+        with open(path, "w") as f:
+            f.write(body)
+        written.append(fname)
+
+    # Emit the list of includes the caller can splice into the docs TOC file.
+    manifest = os.path.join(args.out_dir, f"{args.prefix}-includes.txt")
+    with open(manifest, "w") as f:
+        for fname in written:
+            f.write(f"include::{args.prefix}/{fname}[leveloffset=+1]\n")
+
+    print(f"Rendered {len(written)} .adoc files to {args.out_dir}", file=sys.stderr)
+    for fname in written:
+        print(f"  - {fname}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/scripts/test_render_adoc.py
+++ b/tests/unit/scripts/test_render_adoc.py
@@ -1,0 +1,99 @@
+"""Tests for the shared AsciiDoc renderer (scripts/render_adoc.py).
+
+These lock in the rendering properties that were hard-won during validation:
+no leftover markdown code fences, balanced ``----`` source-block delimiters, no
+``self``/``cls`` noise, and no duplicated summary/description text.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# scripts/ is not a package; load render_adoc.py directly by path.
+_RENDER_PATH = Path(__file__).resolve().parents[3] / "scripts" / "render_adoc.py"
+_spec = importlib.util.spec_from_file_location("render_adoc", _RENDER_PATH)
+render_adoc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(render_adoc)
+
+
+def _render(entry, level=2):
+    out = []
+    render_adoc.render_entry(entry, level, out)
+    return "\n".join(out)
+
+
+def _entry(**overrides):
+    base = {
+        "kind": "class",
+        "name": "Widget",
+        "signature": "Widget(name: str)",
+        "summary": "A widget.",
+        "description": "",
+        "params": [],
+        "returns": None,
+        "raises": [],
+        "examples": [],
+        "members": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestRenderProse:
+    def test_fenced_block_becomes_source_block(self):
+        text = "Intro line.\n\n```python\nx = 1\n```"
+        out = "\n".join(render_adoc.render_prose(text))
+        assert "```" not in out
+        assert "[source,python]" in out
+        assert "x = 1" in out
+
+    def test_indented_fence_is_handled(self):
+        text = "Example:\n\n    ```python\n    y = 2\n    ```"
+        out = "\n".join(render_adoc.render_prose(text))
+        assert "```" not in out
+        # dedented inside the source block
+        assert "\ny = 2" in "\n" + out
+
+    def test_plain_prose_passthrough(self):
+        assert render_adoc.render_prose("just text") == ["just text"]
+
+
+class TestRenderEntry:
+    def test_no_fence_leaks_in_description(self):
+        adoc = _render(_entry(description="See:\n\n```python\nfoo()\n```"))
+        assert "```" not in adoc
+        assert "[source,python]" in adoc
+
+    def test_balanced_source_delimiters(self):
+        adoc = _render(_entry(examples=[{"lang": "python", "code": "a = 1"}]))
+        assert adoc.count("----") % 2 == 0
+
+    def test_summary_and_description_not_duplicated(self):
+        adoc = _render(_entry(summary="A widget.", description="More detail."))
+        assert adoc.count("A widget.") == 1
+        assert adoc.count("More detail.") == 1
+
+    def test_params_render_as_definition_list(self):
+        adoc = _render(_entry(params=[{"name": "name", "type": "str", "required": True, "description": "The name."}]))
+        assert "`name`" in adoc
+        assert "The name." in adoc
+
+    def test_example_stray_fence_stripped(self):
+        # A closing fence plus trailing prose swept into the example must not leak.
+        code = "a = 1\n```\nNotes: not code."
+        adoc = _render(_entry(examples=[{"lang": "python", "code": code}]))
+        assert "```" not in adoc
+        assert "Notes: not code." not in adoc
+
+
+class TestCleanExampleCode:
+    def test_strips_fences_and_trailing_prose(self):
+        cleaned = render_adoc.clean_example_code("x = 1\n```\nTrailing prose.")
+        assert "```" not in cleaned
+        assert "Trailing prose." not in cleaned
+        assert "x = 1" in cleaned
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Adds a workflow that auto-generates the Python SDK API reference as AsciiDoc on each release (via `inspect` + docstrings) and uploads it as a build artifact for the docs team to publish.

Files: workflow + extractor (`scripts/extract_api_model.py`) + renderer (`scripts/render_adoc.py`). Runs on `release` and `workflow_dispatch`.