### PR TITLE
Add LLM issue auto-triage: type and high-severity labelers

### DIFF
--- a/.github/labelers/severity.yml
+++ b/.github/labelers/severity.yml
@@ -15,6 +15,18 @@ instructions: |
   - A regression: behavior that worked in a previous released version of
     bedrock-agentcore and is broken in a newer release.
 
+  In addition to matching a category above, the failure must affect users in
+  production or block adoption of a release. Judge blast radius: would a
+  typical production user of the SDK hit this in a core path (importing the
+  package, running an agent, storing/retrieving memory)? A failure that only
+  occurs in a specific optional integration, edge-case code path, or unusual
+  combination of features does not qualify, even with a crash and a solid
+  reproduction — those are ordinary bugs. In particular: a crash or
+  validation error inside a third-party framework integration (e.g. the
+  Strands session manager) that requires a specific feature combination to
+  trigger is an ordinary bug, regardless of how detailed the report is.
+  Report quality is not severity.
+
   Does NOT qualify, even if the author says it is urgent or critical:
   - Feature requests and enhancements of any kind.
   - Usage questions, configuration mistakes, or environment problems.

--- a/.github/labelers/severity.yml
+++ b/.github/labelers/severity.yml
@@ -1,0 +1,30 @@
+instructions: |
+  This labeler decides one thing: whether the issue is high severity. Almost
+  all issues are NOT high severity — return an empty list unless the issue
+  clearly and credibly describes one of the qualifying situations below.
+  A noisy severity label trains maintainers to ignore it, so precision
+  matters far more than recall.
+
+  Qualifies as high-severity ONLY when the issue describes, with concrete
+  evidence (error output, versions, reproduction, or a specific code path):
+  - A production outage or agents failing to run at all because of the SDK.
+  - Data loss or data corruption caused by the SDK (e.g. memory records
+    lost or silently dropped).
+  - A security vulnerability or credential/secret exposure in the SDK.
+  - A crash or hard failure in a core code path with no workaround.
+  - A regression: behavior that worked in a previous released version of
+    bedrock-agentcore and is broken in a newer release.
+
+  Does NOT qualify, even if the author says it is urgent or critical:
+  - Feature requests and enhancements of any kind.
+  - Usage questions, configuration mistakes, or environment problems.
+  - Bugs with a documented or obvious workaround.
+  - Vague reports with no reproduction, versions, or error output.
+  - Issues in other AgentCore components (CLI, service, console) rather
+    than this Python SDK.
+  - Performance complaints without evidence of a regression or outage.
+
+  When in doubt, return an empty list.
+
+labels:
+  high-severity: "Production outage, data loss, security vulnerability, crash with no workaround, or regression in a released version — with concrete evidence."

--- a/.github/labelers/type.yml
+++ b/.github/labelers/type.yml
@@ -1,0 +1,13 @@
+instructions: |
+  Classify the issue by what the author is asking for, not by tone.
+  - "bug" requires a claim that existing SDK behavior is broken or incorrect.
+  - "enhancement" covers new features, API additions, and improvements to
+    existing behavior that is working as documented.
+  - "question" covers usage help, clarification requests, and "how do I"
+    issues, even when phrased as a problem report.
+  If the issue is a bug report that also proposes a fix, label it "bug".
+
+labels:
+  bug: "Existing SDK behavior is broken, incorrect, or crashes."
+  enhancement: "Request for a new feature, API addition, or improvement to working behavior."
+  question: "Usage question, clarification request, or how-do-I issue."

--- a/.github/workflows/issue-auto-triage.yml
+++ b/.github/workflows/issue-auto-triage.yml
@@ -1,0 +1,55 @@
+name: Issue Auto Triage
+
+# Classifies new issues with an LLM (Bedrock via strands-agents/devtools
+# issue-labeler) and applies labels from a hardcoded allowlist. The model has
+# no tools, no shell, and no GitHub access — it returns a structured object
+# whose label field is an enum built from the config allowlist, so the worst
+# a prompt injection in an issue body can achieve is a mislabel.
+#
+# Labeler configs live in .github/labelers/. Each job is an independent
+# classification concern and they run in parallel.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  id-token: write
+  contents: read
+
+jobs:
+  label-type:
+    name: "Label: Type"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      # strands-agents/devtools/issue-labeler pinned to a reviewed commit
+      # (main as of 2026-07-17). Bump deliberately, not automatically.
+      - uses: strands-agents/devtools/issue-labeler@5e50593798905abfbb31cc709f5ac58a2992b03a
+        with:
+          aws_role_arn: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
+          config_path: '.github/labelers/type.yml'
+          max_labels: '1'
+
+  label-severity:
+    name: "Label: Severity"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/labelers
+          sparse-checkout-cone-mode: false
+      - uses: strands-agents/devtools/issue-labeler@5e50593798905abfbb31cc709f5ac58a2992b03a
+        with:
+          aws_role_arn: ${{ secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN }}
+          config_path: '.github/labelers/severity.yml'
+          max_labels: '1'
+          # Severity calls for concrete evidence (stack traces, repro steps),
+          # which the default 1000-char truncation would often cut off.
+          max_body_length: '4000'


### PR DESCRIPTION
## What

Adds automatic issue triage on `issues: opened` using [strands-agents/devtools/issue-labeler](https://github.com/strands-agents/devtools/tree/main/issue-labeler) (the same setup strands-agents runs on their SDK repos), pinned by commit SHA.

Two parallel jobs:
- **Type** (`.github/labelers/type.yml`): applies exactly one of `bug` / `enhancement` / `question`.
- **Severity** (`.github/labelers/severity.yml`): applies `high-severity` or nothing. Criteria are deliberately conservative — production outage, data loss, security vulnerability, crash with no workaround, or regression in a released version, and only with concrete evidence. Feature requests, usage questions, and vague reports never qualify. Body truncation is raised to 4000 chars for this job so stack traces/repro steps are visible to the classifier.

The `high-severity` label has been created on the repo.

## Security model

The classifier LLM has **no tools, no shell, and no GitHub access**. It returns a structured object whose label field is an enum built from the config allowlist, so out-of-allowlist labels are rejected by the schema. Issue content is sanitized and truncated before reaching Bedrock. IAM is scoped to `bedrock:InvokeModel*` via an inline session policy; the workflow needs only `issues: write`. Worst case from prompt injection in an issue body is a mislabel.

## Notes for reviewers

- Reuses `secrets.BEDROCK_SECURITY_REVIEW_ROLE_ARN` (same OIDC role as the PR security review). **If that role's trust policy pins the `sub` claim to pull-request refs, it will reject `issues`-triggered runs** — needs a check before merge, or a dedicated minimal role.
- The action is pinned to `5e50593` (strands devtools main as of 2026-07-17); bump deliberately.
- Possible follow-up: Slack notification when `high-severity` lands, via the existing `github-slack-notifications.yml` webhook.