### PR TITLE
fix(memory-integ): address capacity cap and update failures in tests

### DIFF
--- a/src/bedrock_agentcore/memory/controlplane.py
+++ b/src/bedrock_agentcore/memory/controlplane.py
@@ -379,9 +379,13 @@ class MemoryControlPlaneClient:
                     break
 
             if strategy_id:
-                return self._wait_for_strategy_active(memory_id, strategy_id, max_wait, poll_interval)
+                memory = self._wait_for_strategy_active(memory_id, strategy_id, max_wait, poll_interval)
             else:
                 logger.warning("Could not identify newly added strategy %s to wait for activation", strategy_name)
+
+            # Also ensure the memory itself has returned to ACTIVE
+            if memory.get("status") != MemoryStatus.ACTIVE.value:
+                memory = self._wait_for_memory_active(memory_id, max_wait, poll_interval)
 
         return memory
 

--- a/tests_integ/memory/test_controlplane.py
+++ b/tests_integ/memory/test_controlplane.py
@@ -18,6 +18,32 @@ class TestMemoryControlPlaneClient:
         cls.client = MemoryControlPlaneClient(region_name=cls.region)
         cls.test_prefix = f"test_cp_{int(time.time())}"
         cls.memory_ids = []
+        cls._cleanup_stale_memories()
+
+    @classmethod
+    def _cleanup_stale_memories(cls):
+        """Delete test memories older than 3 hours. Best-effort; failures won't block tests."""
+        try:
+            from datetime import datetime, timedelta, timezone
+
+            memories = cls.client.list_memories()
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=3)
+            stale = [
+                m
+                for m in memories
+                if m.get("id", "").startswith("test_cp_") and m.get("createdAt") and m["createdAt"] < cutoff
+            ]
+            print(f"[cleanup] Found {len(memories)} total memories, {len(stale)} stale test_cp_ memories (>3h old)")
+            deleted = 0
+            for m in stale:
+                try:
+                    cls.client.delete_memory(memory_id=m["id"])
+                    deleted += 1
+                except Exception as e:
+                    print(f"[cleanup] Failed to delete {m['id']}: {e}")
+            print(f"[cleanup] Deleted {deleted}/{len(stale)} stale memories")
+        except Exception as e:
+            print(f"[cleanup] Could not list memories for cleanup: {e}")
 
     @classmethod
     def teardown_class(cls):


### PR DESCRIPTION
Failing integ tests on main: https://github.com/aws/bedrock-agentcore-sdk-python/actions/runs/30303039785/job/90288106089. 

### Problem

Failing integ tests on main: https://github.com/aws/bedrock-agentcore-sdk-python/actions/runs/30303039785/job/90288106089 with two root causes:

- `add_strategy(wait_for_active=True)` only waited for the strategy to reach ACTIVE, but the memory itself could still be in `UPDATING` state. Consecutive `add_strategy` calls (as in `test_add_strategy_immediately_after_another`) would hit `ValidationException: Memory is in transitional state UPDATING`.
- CI account hit memory limit with 150. 

## Solution

  After the strategy is confirmed `ACTIVE`, `add_strategy` now also checks the memory status and waits for it to return to `ACTIVE` using the existing `_wait_for_memory_active` utility.

## Testing
  - All 6 integ tests pass against dev account (previously test 4 failed consistently)

### Notes
there appears to be an issue with PRs from forks: https://github.com/aws/bedrock-agentcore-sdk-python/pull/603 so make this from origin branch. 