### PR TITLE
ci: install deepeval and autoevals for evaluation integ tests

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -120,7 +120,7 @@ jobs:
           - group: evaluation
             path: tests_integ/evaluation
             timeout: 15
-            extra-deps: "strands-agents-evals"
+            extra-deps: "strands-agents-evals deepeval autoevals"
             ignore: ""
           - group: services
             path: tests_integ/services


### PR DESCRIPTION
## Problem

`Test (evaluation)` in the Secure Integration test workflow is failing on `main` ([run 30494098538](https://github.com/aws/bedrock-agentcore-sdk-python/actions/runs/30494098538/job/90718798678)):

```
ERROR tests_integ/evaluation/test_third_party_adapters.py::TestDeepEvalAdapterIntegration::test_bias_metric_passes - ModuleNotFoundError: No module named 'deepeval'
ERROR tests_integ/evaluation/test_third_party_adapters.py::TestAutoEvalsAdapterIntegration::test_factuality_scorer - ModuleNotFoundError: No module named 'autoevals'
======= 36 passed, 1 skipped, 41 warnings, 6 errors in 78.52s (0:01:18) ========
```

`test_third_party_adapters.py` (added in #568) imports `deepeval` and `autoevals`, but the `evaluation` matrix group only installed `strands-agents-evals`. The bare `import` calls in the autouse fixtures raise `ModuleNotFoundError`, which pytest reports as **errors** rather than skips, so the job exits 1.

Both packages are already declared as optional extras in `pyproject.toml` (`[deepeval]`, `[autoevals]`) — they were simply never installed in that job.

## Change

One line — add both packages to the evaluation group's `extra-deps`.

## Testing

- `python3 -c "yaml.safe_load(...)"` — workflow YAML parses, matrix entry correct
- Installed the full evaluation dep set on Python 3.10 (CI's version); `deepeval==4.1.4` and `autoevals` both resolve and import cleanly, no conflicts with `strands-agents-evals==1.0.3`
- Confirmed the two `ModuleNotFoundError`s are gone, and confirmed the residual OpenAI-credential failures documented above