### PR TITLE
fix(test): repair four unit tests drifting behind source and upstream APIs

### DIFF
--- a/src/bedrock_agentcore/evaluation/custom_code_based_evaluators/models.py
+++ b/src/bedrock_agentcore/evaluation/custom_code_based_evaluators/models.py
@@ -82,7 +82,6 @@ class EvaluatorOutput(BaseModel):
     def _require_label_or_error_code(self) -> "EvaluatorOutput":
         if not self.errorCode and self.label is None:
             raise ValueError(
-                "Either label, value, or errorCode must be set; "
-                "set errorCode to return an error response without a label"
+                "label is required for success responses; set errorCode to return an error response without a label"
             )
         return self

--- a/src/bedrock_agentcore/evaluation/integrations/strands_agents_evals/README.md
+++ b/src/bedrock_agentcore/evaluation/integrations/strands_agents_evals/README.md
@@ -83,8 +83,7 @@ evaluator = create_strands_evaluator("Builtin.Helpfulness")
 
 # Run evaluations
 experiment = Experiment(cases=cases, evaluators=[evaluator])
-reports = experiment.run_evaluations(task_fn)
-report = reports[0]
+report = experiment.run_evaluations(task_fn)
 
 # View results
 print(f"Overall score: {report.overall_score:.2f}")
@@ -175,8 +174,7 @@ def task_fn(case):
 
 evaluator = create_strands_evaluator("Builtin.Helpfulness")
 experiment = Experiment(cases=cases, evaluators=[evaluator])
-reports = experiment.run_evaluations(task_fn)
-report = reports[0]
+report = experiment.run_evaluations(task_fn)
 
 print(f"Overall score: {report.overall_score:.2f}")
 ```

--- a/tests/bedrock_agentcore/evaluation/integrations/strands_agents_evals/test_end_to_end.py
+++ b/tests/bedrock_agentcore/evaluation/integrations/strands_agents_evals/test_end_to_end.py
@@ -65,8 +65,7 @@ class TestEndToEndIntegration:
         with patch("boto3.client", return_value=mock_boto_client):
             evaluator = create_strands_evaluator("Builtin.Helpfulness")
             experiment = Experiment(cases=cases, evaluators=[evaluator])
-            reports = experiment.run_evaluations(task_fn)
-            report = reports[0]
+            report = experiment.run_evaluations(task_fn)
 
             # Should return 0 score for empty trajectory
             assert report.overall_score == 0.0

--- a/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
+++ b/tests/bedrock_agentcore/memory/integrations/strands/test_agentcore_memory_session_manager.py
@@ -3722,9 +3722,13 @@ class TestAsyncMode:
         registry = HookRegistry()
         manager.register_hooks(registry)
 
-        for event_type in (MultiAgentInitializedEvent, AfterNodeCallEvent, AfterMultiAgentInvocationEvent):
-            callbacks = registry._registered_callbacks.get(event_type, [])
-            assert callbacks, f"No callbacks registered for {event_type.__name__}"
+        for event in (
+            MultiAgentInitializedEvent(source=Mock()),
+            AfterNodeCallEvent(source=Mock(), node_id="n1"),
+            AfterMultiAgentInvocationEvent(source=Mock()),
+        ):
+            callbacks = list(registry.get_callbacks_for(event))
+            assert callbacks, f"No callbacks registered for {type(event).__name__}"
             assert all(asyncio.iscoroutinefunction(cb) for cb in callbacks)
 
     def test_async_mode_logs_sync_invocation_warning(self, mock_memory_client, caplog):
@@ -3746,15 +3750,18 @@ class TestAsyncMode:
         manager.register_hooks(registry)
 
         # BidiAgentInitializedEvent dispatches via the sync hook path, so its callback must NOT be a coroutine.
-        init_callbacks = registry._registered_callbacks.get(BidiAgentInitializedEvent, [])
+        init_callbacks = list(registry.get_callbacks_for(BidiAgentInitializedEvent(agent=Mock())))
         assert init_callbacks, "No callbacks registered for BidiAgentInitializedEvent"
         assert not any(asyncio.iscoroutinefunction(cb) for cb in init_callbacks)
 
         # BidiMessageAddedEvent and BidiAfterInvocationEvent dispatch via invoke_callbacks_async,
         # so their callbacks should be async to keep the event loop unblocked.
-        for event_type in (BidiMessageAddedEvent, BidiAfterInvocationEvent):
-            callbacks = registry._registered_callbacks.get(event_type, [])
-            assert callbacks, f"No callbacks registered for {event_type.__name__}"
+        for event in (
+            BidiMessageAddedEvent(agent=Mock(), message={"role": "user", "content": [{"text": "x"}]}),
+            BidiAfterInvocationEvent(agent=Mock()),
+        ):
+            callbacks = list(registry.get_callbacks_for(event))
+            assert callbacks, f"No callbacks registered for {type(event).__name__}"
             assert all(asyncio.iscoroutinefunction(cb) for cb in callbacks)
 
 


### PR DESCRIPTION
> **Draft.** Depends on #609 — see *Ordering* below.

Fixes the 4 pre-existing unit-test failures on `main` that #609 does not cover. All four are tests (or a message/doc) that fell behind source and upstream changes; none are product bugs.

## 1 + 2. `TestAsyncMode` multi-agent and bidi callbacks

`test_agentcore_memory_session_manager.py:3726` and `:3756` reached into the **private** registry dict:

```python
callbacks = registry._registered_callbacks.get(event_type, [])
assert all(asyncio.iscoroutinefunction(cb) for cb in callbacks)   # always False
```

Upstream Strands now stores callbacks wrapped in a `_CallbackEntry`:

```
type= <class 'strands.hooks.registry._CallbackEntry'>
repr= _CallbackEntry(callback=<function ...register_hooks.<locals>._offload.<locals>._callback ...>)
```

`iscoroutinefunction()` on the wrapper is always `False`, so the assertion could never hold. The source is correct — `session_manager.py:989-991` does register async `_offload` callbacks.

The fix is the accessor the *passing* sibling tests already use (lines 3636–3714): public `registry.get_callbacks_for(event)`, which unwraps.

**Side benefit:** the bidi-init assertion at `:3751` is `not any(iscoroutinefunction(...))`. It was passing for the wrong reason — the wrapper is never a coroutine function, so it would have passed even if the callback were wrongly async. Against unwrapped callbacks it now actually tests what it claims.

## 3. `EvaluatorOutput` validator message — source fix

The message advertised a `value` escape hatch that does not exist:

```python
if not self.errorCode and self.label is None:      # value is never inspected
    raise ValueError("Either label, value, or errorCode must be set; ...")
```

The class docstring (`models.py:63-65`) and every caller in `src/` agree that `label` is required unless `errorCode` is set, so the **message** was the defect, not the logic. Corrected to `"label is required for success responses; ..."`, which is also what the test expected.

## 4. `test_evaluation_with_empty_trajectory`

```
TypeError: 'EvaluationReport' object is not subscriptable
```

`run_evaluations()` returns a single report now, verified against the installed library:

```
run_evaluations -> <class 'strands_evals.types.evaluation_report.EvaluationReport'>
model_fields: ['overall_score', 'scores', 'cases', 'test_passes', ...]
```

Dropped the `[0]`. **Also fixed the same stale pattern in `README.md`** (2 occurrences) — the documented `reports = ...; report = reports[0]` snippet would hand users the identical `TypeError`.

## Testing

- `uv run pytest tests/` on Python 3.10 → **2934 passed**, 10 skipped, 4 xpassed, **0 failed**
- `TestAsyncMode` in isolation → 8 passed
- `ruff check src/ tests/` → all checks passed; `ruff format` applied (the shortened message now fits one line — verified `main` was format-clean beforehand, so that reflow is mine)

## Ordering

This branch is cut from `main`, so on its own CI still hits the 2 `deepeval` collection errors that #609 fixes — verified with a clean `uv sync --dev`:

```
ERROR tests/.../third_party/deepeval/test_adapter.py
ERROR tests/.../third_party/deepeval/test_error_handling.py
Interrupted: 2 errors during collection
```

Kept as a draft for that reason. **#609 then this** turns `ci.yml` green; merge order the other way leaves 4 failures. Happy to rebase on #609 if you'd prefer to see this one green before review.

Related: #608 (integration workflow), #609 (dev-group pin).