### PR TITLE
fix(test): pin autoevals judge to the OpenAI API

### DIFF
--- a/tests_integ/evaluation/test_third_party_adapters.py
+++ b/tests_integ/evaluation/test_third_party_adapters.py
@@ -17,6 +17,7 @@ RUN:
 """
 
 import json
+import os
 
 import pytest
 
@@ -138,12 +139,25 @@ class TestAutoEvalsAdapterIntegration:
         """Verify autoevals is installed."""
         import autoevals  # noqa: F401
 
-    def test_factuality_scorer(self):
+    @pytest.fixture
+    def openai_client(self):
+        """An OpenAI client pinned to the OpenAI API.
+
+        Left to its own defaults, autoevals sends requests to the Braintrust AI
+        gateway authenticated with BRAINTRUST_API_KEY, which rejects an OpenAI
+        key with 401. Passing an explicit client is the documented way to choose
+        the provider (the api_key/base_url arguments are deprecated).
+        """
+        from openai import OpenAI
+
+        return OpenAI(api_key=os.environ["OPENAI_API_KEY"], base_url="https://api.openai.com/v1")
+
+    def test_factuality_scorer(self, openai_client):
         from autoevals import Factuality
 
         from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
 
-        scorer = Factuality()
+        scorer = Factuality(client=openai_client)
         adapter = AutoEvalsAdapter(metric=scorer)
 
         # Assistant-only output (no tool messages), which is what the helper
@@ -156,12 +170,12 @@ class TestAutoEvalsAdapterIntegration:
         assert result.value is not None
         assert result.label in ("Pass", "Fail")
 
-    def test_custom_threshold(self):
+    def test_custom_threshold(self, openai_client):
         from autoevals import Factuality
 
         from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
 
-        scorer = Factuality()
+        scorer = Factuality(client=openai_client)
         adapter = AutoEvalsAdapter(metric=scorer, threshold=0.9)
 
         result = adapter(_make_agent_evaluator_input())
@@ -169,12 +183,12 @@ class TestAutoEvalsAdapterIntegration:
         assert isinstance(result, EvaluatorOutput)
         assert result.value is not None
 
-    def test_with_custom_mapper(self):
+    def test_with_custom_mapper(self, openai_client):
         from autoevals import Factuality
 
         from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
 
-        scorer = Factuality()
+        scorer = Factuality(client=openai_client)
         adapter = AutoEvalsAdapter(
             metric=scorer,
             custom_mapper=lambda ev: {


### PR DESCRIPTION
## Summary

Follow-up to #614, which took the `evaluation` group from **6 failures to 3**. The three DeepEval tests now pass — confirming both the span-fixture fix and the `OPENAI_API_KEY` wiring work. The three remaining `AutoEvalsAdapter` tests fail with:

```
openai.AuthenticationError: Braintrust gateway error: auth failed
  [401 Unauthorized]: Invalid API Key ... org: None
```

**The key is valid — it was being sent to the wrong service.** `autoevals` does not call OpenAI directly by default (`autoevals/oai.py`):

```python
if base_url is None:
    base_url = os.environ.get("OPENAI_BASE_URL") or _gateway_url()   # https://gateway.braintrust.dev
    if _is_gateway_url(base_url):
        api_key = os.environ.get("BRAINTRUST_API_KEY") or os.environ.get("OPENAI_API_KEY")
```

With `OPENAI_BASE_URL` unset it routes to the Braintrust AI gateway, which rejects an OpenAI key. This is documented behaviour, not a bug — `init()`'s own docstring example pairs the gateway `base_url` with `BRAINTRUST_API_KEY`.

## Fix

Pass an explicit client, which is the provider-selection path `autoevals` documents. Its `api_key` / `base_url` arguments are marked *"Deprecated: Use the `client` argument"*, so this is the forward-compatible option rather than setting `OPENAI_BASE_URL` in CI.

The client is built once in a fixture; each test passes it to the scorer, keeping the provider choice visible at the call site.

Scoped to the Autoevals tests only — DeepEval is untouched and already passing.

## Testing

```
# an injected client bypasses the gateway: probe with a deliberately invalid key
Error code: 401 - Incorrect API key provided: sk-fake-*robe ...
#   ^ OpenAI's own error, no Braintrust in the message (previously: "Braintrust gateway error")

ruff format --check  -> 1 file already formatted
ruff check           -> All checks passed!
```

I could not run these tests against the real key locally: the value lives only in the central DevX Secrets Manager account, and `secretsmanager:GetSecretValue` on it is granted solely to `DevXWorkflowSecretsReader-SDKPython` for the CI OIDC subjects — my `ReadOnly` role is denied by design. So the routing fix is verified structurally, and the first true green run for these three tests will be in CI.

## Reviewer note

`safety-gate` does not apply here — this touches no workflow files, so the integration tests should run automatically on this PR.

The `autoevals` default judge model is `gpt-5-mini`. If the provisioned key's account lacks access to it, expect a model `404` rather than a `401`; that would be a key-provisioning follow-up, not a code issue.
