### PR TITLE
feat(payments): add MPP (Machine Payments Protocol) support

### DIFF
--- a/src/bedrock_agentcore/payments/README.md
+++ b/src/bedrock_agentcore/payments/README.md
@@ -1,13 +1,16 @@
 # Bedrock AgentCore payments SDK
 
 High-level Python SDK for AWS Bedrock AgentCore payments service with support for payment instrument management,
-session-based payment limits, and x402 payment processing for AI agent microtransactions.
+session-based payment limits, and internet native payment protocols support such as x402 and MPP for AI agent microtransactions.
 
 ## Overview
 
 The Bedrock AgentCore Payments SDK enables AI agents to process microtransaction payments to access paid APIs,
-MCP servers, and premium content. The SDK supports the [x402 Payment Required](https://www.x402.org/) protocol,
-allowing agents to automatically handle HTTP 402 responses and complete cryptocurrency transactions on behalf of users.
+MCP servers, and premium content. The SDK supports two payment protocols — [x402 Payment
+Required](https://www.x402.org/) and [MPP (Machine Payments Protocol)](https://mpp.dev) — allowing agents to
+automatically handle HTTP 402 responses and complete transactions on behalf of users. The protocol is detected
+from the 402 response, so a single `generate_payment_header` call covers both
+(see [Payment Header Generation](#payment-header-generation) and [MPP](#mpp-machine-payments-protocol)).
 
 ### Architecture
 
@@ -33,7 +36,7 @@ PaymentClient (Control Plane)
 |-----------|-------|---------|
 | `PaymentClient` | Control plane | Create and manage payment infrastructure (managers, connectors, credential providers) |
 | `PaymentManager` | Data plane | Payment operations (instruments, sessions, payment processing, header generation) |
-| `AgentCorePaymentsPlugin` | Framework integration | Strands Agents plugin for automatic x402 payment handling ([see Strands README](integrations/strands/README.md)) |
+| `AgentCorePaymentsPlugin` | Framework integration | Strands Agents plugin for automatic x402 and MPP payment handling ([see Strands README](integrations/strands/README.md)) |
 
 ## Installation
 
@@ -349,12 +352,48 @@ payment = manager.process_payment(
 )
 ```
 
+For MPP, pass `payment_type="MPP"` and forward the raw challenge header verbatim:
+
+```python
+payment = manager.process_payment(
+    payment_session_id=payment_session_id,
+    payment_instrument_id=payment_instrument_id,
+    payment_type="MPP",
+    payment_input={
+        "mpp": {
+            "version": "1",
+            # Exactly one challenge per call, passed exactly as the server sent it.
+            "wwwAuthenticateHeaders": [
+                'Payment id="aB3cDeF4", realm="api.example.com", method="evm", '
+                'intent="charge", request="eyJhbW91bnQ..."'
+            ],
+            # Optional. Authorizes charging network (gas) fees to the buyer's wallet.
+            "buyerPaysGasFees": True,
+        }
+    },
+    user_id="test-user-123",
+)
+# payment["paymentOutput"]["mpp"] -> {"version", "selectedPaymentId", "paymentCredential"}
+```
+
+Most callers should prefer `generate_payment_header` below, which selects the challenge and
+builds the `Authorization` header for you.
+
 ---
 
 ### Payment Header Generation
 
-Generate x402 payment headers for HTTP 402 Payment Required responses. This is the core method
-used by the Strands plugin under the hood:
+Generate payment headers for HTTP 402 Payment Required responses. This is the core method
+used by the Strands plugin under the hood.
+
+Two protocols are supported and the protocol is **detected automatically** from the 402
+response, so callers use the same method for both:
+
+| 402 response contains | Protocol | Returned header |
+|---|---|---|
+| `WWW-Authenticate: Payment ...` | MPP | `{"Authorization": "Payment <token>"}` |
+| `x402Version` + `accepts` in the body | x402 v1 | `{"X-PAYMENT": "base64..."}` |
+| `Payment-Required` header | x402 v2 | `{"PAYMENT-SIGNATURE": "base64..."}` |
 
 ```python
 header = manager.generate_payment_header(
@@ -383,12 +422,130 @@ header = manager.generate_payment_header(
 # Returns: {"X-PAYMENT": "base64..."} (v1) or {"PAYMENT-SIGNATURE": "base64..."} (v2)
 ```
 
-**Network selection process:**
+**Network selection process (x402):**
 1. Filter accepts to those matching the instrument's blockchain type (Ethereum or Solana)
 2. Use provided `network_preferences` or fall back to the default `NETWORK_PREFERENCES`
 3. Pick the first network from preferences that matches a filtered accept
 4. If no match found, return the first filtered accept
 
+---
+
+### MPP (Machine Payments Protocol)
+
+[MPP](https://mpp.dev) servers answer with `402 Payment Required` and advertise their payment
+options as `WWW-Authenticate: Payment` challenges. The same `generate_payment_header` call
+handles them — pass the 402 response through and attach the returned header on retry:
+
+```python
+header = manager.generate_payment_header(
+    payment_instrument_id=payment_instrument_id,
+    payment_session_id=payment_session_id,
+    payment_required_request={
+        "statusCode": 402,
+        "headers": {
+            # One challenge per payment option. Repeated headers may also be
+            # passed as a list of strings.
+            "WWW-Authenticate": (
+                'Payment id="aB3cDeF4", realm="api.example.com", method="evm", '
+                'intent="charge", request="eyJhbW91bnQ...", expires="2026-04-01T12:05:00Z", '
+                'Payment id="sol-1", realm="api.example.com", method="solana", '
+                'intent="charge", request="eyJhbW91bnQ..."'
+            ),
+        },
+        "body": {},
+    },
+    user_id="test-user-123",
+)
+# Returns: {"Authorization": "Payment <base64url-token>"}
+
+# Retry the original request with the header attached.
+response = httpx.get("https://api.example.com/resource", headers=header)
+```
+
+**Supported methods and intents**
+
+| Payment method | Satisfied by instrument network |
+|---|---|
+| `evm` | `ETHEREUM` |
+| `tempo` | `ETHEREUM` (Tempo is an EVM chain) |
+| `solana` | `SOLANA` |
+
+Only the `charge` intent is implemented. Challenges advertising `session` or `subscription`
+are filtered out. A challenge with no `intent` param is treated as `charge`.
+
+**Challenge selection process**
+
+`ProcessPayment` fulfills exactly one challenge per call, so the SDK reduces the advertised
+options to the single one your instrument can pay:
+
+1. Drop challenges whose `intent` is not `charge`
+2. Drop challenges whose `expires` is in the past
+3. Keep only challenges whose `method` the instrument's blockchain can satisfy
+4. Order the survivors by `network_preferences` (default `NETWORK_PREFERENCES`), deriving each
+   challenge's network from its decoded `request` — `methodDetails.chainId` becomes
+   `eip155:<chainId>`, and Solana's `methodDetails.network` becomes `solana-mainnet` /
+   `solana-devnet` / `solana-testnet` (defaults to mainnet when absent)
+5. Break ties on the soonest expiry, then on the order the server advertised them
+
+Selection failures raise `PaymentError` **before** any service call, so an unsatisfiable 402
+never consumes session budget.
+
+The selected challenge's raw header value is forwarded to the service **verbatim**. This is
+deliberate: the challenge HMAC binds to the exact base64url `request`/`opaque` bytes, so the
+SDK never re-encodes them. Unknown auth-params are preserved rather than rejected, per the
+specification's "unknown parameters must be ignored by clients" rule.
+
+**Network (gas) fees**
+
+An MPP challenge advertises who sponsors blockchain network fees via its
+`methodDetails.feePayer` flag: `true` means the seller sponsors them, `false` or absent (the
+protocol default) means the buyer pays them from the paying wallet, on top of the challenge
+`amount`.
+
+Because that extra cost is **not visible in the challenge `amount`**, the service does not
+assume the buyer accepts it. When a challenge does not offer seller-sponsored fees, the payment
+is signed only if you pass `buyer_pays_gas_fees=True`; otherwise it fails with a validation
+error so you can decide — or obtain a challenge whose seller sponsors fees.
+
+```python
+header = manager.generate_payment_header(
+    payment_instrument_id=payment_instrument_id,
+    payment_session_id=payment_session_id,
+    payment_required_request=payment_required_request,
+    user_id="test-user-123",
+    # Explicitly accept paying network fees from the buyer's wallet.
+    buyer_pays_gas_fees=True,
+)
+```
+
+The parameter is optional and tri-state:
+
+| Value | Meaning |
+|---|---|
+| omitted / `None` | Field is not sent; the protocol default applies (buyer declines) |
+| `False` | Buyer explicitly declines to pay network fees |
+| `True` | Buyer authorizes network fees charged to their own wallet |
+
+It has no effect on challenges where the seller already sponsors fees
+(`methodDetails.feePayer=true`), and is ignored on the x402 path. Both framework integrations
+expose it as `buyer_pays_gas_fees` on their config.
+
+**Working with challenges directly**
+
+The parsing and selection helpers are exported for callers who need them:
+
+```python
+from bedrock_agentcore.payments import (
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
+if is_mpp_payment_required(payment_required_request):
+    challenges = extract_challenges(payment_required_request)
+    selected = select_challenge(challenges, instrument_network="ETHEREUM")
+    print(selected["id"], selected["method"], selected["raw"])
+```
 ---
 
 ### Deleting Resources
@@ -663,7 +820,7 @@ except PaymentError as e:
 | `list_payment_sessions()` | List payment sessions for a user |
 | `delete_payment_session()` | Delete a payment session (hard delete) |
 | `process_payment()` | Process a payment transaction |
-| `generate_payment_header()` | Generate x402 payment headers for 402 responses |
+| `generate_payment_header()` | Generate payment headers for 402 responses (x402 or MPP, auto-detected) |
 
 ### PaymentManager Constructor Parameters
 

--- a/src/bedrock_agentcore/payments/README.md
+++ b/src/bedrock_agentcore/payments/README.md
@@ -526,9 +526,29 @@ The parameter is optional and tri-state:
 | `False` | Buyer explicitly declines to pay network fees |
 | `True` | Buyer authorizes network fees charged to their own wallet |
 
+Only `True`, `False`, or `None` are accepted — other values raise `PaymentError` rather than
+being coerced. This is deliberate: `bool("false")` is `True` in Python, so coercion would let the
+string `"false"` authorize wallet charges. Authorizing network fees must be unambiguous.
+
 It has no effect on challenges where the seller already sponsors fees
 (`methodDetails.feePayer=true`), and is ignored on the x402 path. Both framework integrations
 expose it as `buyer_pays_gas_fees` on their config.
+
+**Responses advertising both MPP and x402**
+
+Some endpoints advertise both protocols in the same 402. MPP is preferred, but if no advertised
+MPP challenge is satisfiable by the payment instrument and the response also carries a usable
+x402 requirement, the SDK falls back to x402 rather than failing the payment:
+
+| 402 contents | Outcome |
+|---|---|
+| Satisfiable MPP challenge (± x402) | Paid via MPP → `Authorization` |
+| MPP challenge the instrument cannot satisfy **+** usable x402 `accepts` | Falls back to x402 → `X-PAYMENT` |
+| MPP challenge the instrument cannot satisfy, no usable x402 | `PaymentError` |
+
+The fallback applies **only** to challenge-selection failures, which happen before anything is
+submitted. A failure after the payment has been sent to the service always propagates — retrying
+under x402 at that point could charge the buyer twice.
 
 **Working with challenges directly**
 

--- a/src/bedrock_agentcore/payments/__init__.py
+++ b/src/bedrock_agentcore/payments/__init__.py
@@ -7,6 +7,7 @@ from .constants import (
     PaymentConnectorType,
     PaymentManagerStatus,
     PaymentsAuthorizerType,
+    PaymentType,
 )
 from .manager import (
     InsufficientBudget,
@@ -18,6 +19,13 @@ from .manager import (
     PaymentSessionConfigurationRequired,
     PaymentSessionExpired,
     PaymentSessionNotFound,
+)
+from .mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    parse_www_authenticate,
+    select_challenge,
 )
 
 __all__ = [
@@ -35,5 +43,12 @@ __all__ = [
     "PaymentConnectorStatus",
     "PaymentConnectorType",
     "PaymentsAuthorizerType",
+    "PaymentType",
     "DEFAULT_MAX_RESULTS",
+    # MPP (Machine Payments Protocol)
+    "MppChallengeSelectionError",
+    "extract_challenges",
+    "is_mpp_payment_required",
+    "parse_www_authenticate",
+    "select_challenge",
 ]

--- a/src/bedrock_agentcore/payments/_model_patch.py
+++ b/src/bedrock_agentcore/payments/_model_patch.py
@@ -1,0 +1,190 @@
+"""Runtime injection of MPP shapes into the bedrock-agentcore service model.
+
+The MPP additions to ``ProcessPayment`` (the ``mpp`` members of the ``PaymentInput`` /
+``PaymentOutput`` unions and the ``MPP`` value on the ``PaymentType`` enum) reached the
+service before they reached a public botocore release. Without them, botocore rejects an
+MPP payment **client-side**, before the request is ever signed::
+
+    Unknown parameter in paymentInput: "mpp", must be one of: cryptoX402
+
+This module adds those shapes to the in-memory service model of a single boto3 client.
+It is idempotent and self-limiting: once a botocore release ships the shapes natively,
+:func:`patch_process_payment_model` detects them and does nothing. It never writes to
+the installed botocore package, and it only ever adds shapes — no existing member,
+enum value, or constraint is modified, so the x402 path is unaffected.
+
+The shape definitions mirror the service's Smithy model.
+"""
+
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Shape names as they appear in the bedrock-agentcore service-2.json model.
+_PAYMENT_TYPE = "PaymentType"
+_PAYMENT_INPUT = "PaymentInput"
+_PAYMENT_OUTPUT = "PaymentOutput"
+_MPP_INPUT = "MppPaymentInput"
+_MPP_OUTPUT = "MppPaymentOutput"
+_MPP_CREDENTIAL = "MppPaymentCredential"
+_MPP_VERSION = "MppVersion"
+_MPP_HEADER = "WwwAuthenticateHeader"
+_MPP_HEADER_LIST = "WwwAuthenticateHeaderList"
+_MPP_SELECTED_ID = "MppSelectedPaymentId"
+
+_MPP_ENUM_VALUE = "MPP"
+
+
+def _mpp_shapes() -> Dict[str, Dict[str, Any]]:
+    """Build the MPP shape definitions to merge into the service model.
+
+    Mirrors AmazonBedrockAgentCorePaymentsDataPlaneModel's processPayment.smithy.
+
+    Returns:
+        Mapping of shape name to its JSON model definition.
+    """
+    return {
+        _MPP_VERSION: {
+            "type": "string",
+            "min": 1,
+            "max": 10,
+            "pattern": "^[0-9]+$",
+            "documentation": "<p>Protocol version identifier — bare numeric string.</p>",
+        },
+        _MPP_HEADER: {
+            "type": "string",
+            "min": 1,
+            "max": 16384,
+            "documentation": "<p>A raw WWW-Authenticate: Payment header value from a 402 response.</p>",
+        },
+        _MPP_HEADER_LIST: {
+            "type": "list",
+            "member": {"shape": _MPP_HEADER},
+            "min": 1,
+            "max": 1,
+            "documentation": "<p>The raw WWW-Authenticate header value to fulfill.</p>",
+        },
+        _MPP_SELECTED_ID: {
+            "type": "string",
+            "min": 1,
+            "max": 512,
+            "documentation": "<p>The id of the challenge that was paid.</p>",
+        },
+        _MPP_CREDENTIAL: {
+            "type": "string",
+            "min": 1,
+            "max": 32768,
+            "sensitive": True,
+            "documentation": "<p>Ready-to-send Authorization: Payment header value.</p>",
+        },
+        _MPP_INPUT: {
+            "type": "structure",
+            "required": ["version", "wwwAuthenticateHeaders"],
+            "members": {
+                "version": {
+                    "shape": _MPP_VERSION,
+                    "documentation": "<p>The MPP protocol version.</p>",
+                },
+                "wwwAuthenticateHeaders": {
+                    "shape": _MPP_HEADER_LIST,
+                    "documentation": "<p>The raw WWW-Authenticate: Payment header value(s), verbatim.</p>",
+                },
+                "buyerPaysGasFees": {
+                    "shape": "Boolean",
+                    "documentation": (
+                        "<p>Authorizes ACP to sign a payment whose blockchain network (gas) fees are "
+                        "charged to the buyer's own wallet, on top of the payment amount.</p>"
+                    ),
+                },
+            },
+            "documentation": "<p>The input for an MPP payment.</p>",
+        },
+        _MPP_OUTPUT: {
+            "type": "structure",
+            "required": ["version", "selectedPaymentId", "paymentCredential"],
+            "members": {
+                "version": {
+                    "shape": _MPP_VERSION,
+                    "documentation": "<p>The MPP protocol version.</p>",
+                },
+                "selectedPaymentId": {
+                    "shape": _MPP_SELECTED_ID,
+                    "documentation": "<p>The id of the challenge that was paid.</p>",
+                },
+                "paymentCredential": {
+                    "shape": _MPP_CREDENTIAL,
+                    "documentation": "<p>Ready-to-send Authorization header value.</p>",
+                },
+            },
+            "documentation": "<p>The output from an MPP payment.</p>",
+        },
+    }
+
+
+def _model_supports_mpp(shapes: Dict[str, Any]) -> bool:
+    """Check whether the model already exposes the MPP union members natively."""
+    payment_input = shapes.get(_PAYMENT_INPUT) or {}
+    return "mpp" in (payment_input.get("members") or {})
+
+
+def patch_process_payment_model(client: Any) -> bool:
+    """Add the MPP shapes to *client*'s service model if botocore lacks them.
+
+    Mutates the ``service-2.json`` dict backing this client's service model, then
+    clears the cached shape objects so botocore rebuilds them on next use. Only this
+    client's model object is affected; the on-disk botocore data files are untouched.
+
+    Args:
+        client: A boto3 ``bedrock-agentcore`` client.
+
+    Returns:
+        True if shapes were injected, False if the model already supported MPP or the
+        model could not be patched.
+    """
+    try:
+        service_model = client.meta.service_model
+        shapes = service_model._shape_resolver._shape_map
+    except AttributeError:
+        # botocore internals moved. MPP will fail loudly at call time with a clear
+        # ParamValidationError rather than being silently mis-sent, so degrade quietly.
+        logger.debug("MPP: could not access the service model shape map; skipping model patch")
+        return False
+
+    if _model_supports_mpp(shapes):
+        logger.debug("MPP: botocore model already supports MPP; no patch needed")
+        return False
+
+    for name, definition in _mpp_shapes().items():
+        shapes.setdefault(name, definition)
+
+    # Add the union members that reference the new shapes.
+    payment_input = shapes.get(_PAYMENT_INPUT)
+    if isinstance(payment_input, dict) and isinstance(payment_input.get("members"), dict):
+        payment_input["members"].setdefault(
+            "mpp",
+            {"shape": _MPP_INPUT, "documentation": "<p>Input for an MPP payment.</p>"},
+        )
+
+    payment_output = shapes.get(_PAYMENT_OUTPUT)
+    if isinstance(payment_output, dict) and isinstance(payment_output.get("members"), dict):
+        payment_output["members"].setdefault(
+            "mpp",
+            {"shape": _MPP_OUTPUT, "documentation": "<p>Output from an MPP payment.</p>"},
+        )
+
+    # Extend the paymentType enum. botocore does not validate enum values on
+    # serialization, but keeping the model accurate avoids surprising introspection.
+    payment_type = shapes.get(_PAYMENT_TYPE)
+    if isinstance(payment_type, dict) and isinstance(payment_type.get("enum"), list):
+        if _MPP_ENUM_VALUE not in payment_type["enum"]:
+            payment_type["enum"].append(_MPP_ENUM_VALUE)
+
+    # Drop cached Shape instances so the resolver rebuilds them from the updated map.
+    try:
+        client.meta.service_model._shape_resolver._shape_cache.clear()
+    except AttributeError:
+        logger.debug("MPP: no shape cache to clear")
+
+    logger.debug("MPP: injected MPP shapes into the bedrock-agentcore service model")
+    return True

--- a/src/bedrock_agentcore/payments/constants.py
+++ b/src/bedrock_agentcore/payments/constants.py
@@ -34,6 +34,14 @@ class PaymentConnectorType(Enum):
     STRIPE_PRIVY = "StripePrivy"
 
 
+class PaymentType(Enum):
+    """Payment protocols supported by ProcessPayment."""
+
+    CRYPTO_X402 = "CRYPTO_X402"
+    # MPP does not differentiate between crypto and fiat — one value covers both.
+    MPP = "MPP"
+
+
 class PaymentsAuthorizerType(Enum):
     """Payment manager authorizer types."""
 
@@ -70,3 +78,37 @@ NETWORK_PREFERENCES = [
     "eip155:84532",  # Base Sepolia (testnet)
     "eip155:11155111",  # Ethereum Sepolia (Test)
 ]
+
+# ─────────────────────────────────────────────────────────────
+# MPP (Machine Payments Protocol) — https://mpp.dev
+# ─────────────────────────────────────────────────────────────
+
+# Default MPP protocol version sent to ProcessPayment. The service model constrains
+# this to a bare numeric string (^[0-9]+$).
+MPP_DEFAULT_VERSION = "1"
+
+# The `Payment` auth-scheme name used in `WWW-Authenticate` / `Authorization` headers.
+MPP_AUTH_SCHEME = "Payment"
+
+# Only the `charge` intent is implemented. Challenges advertising `session` or
+# `subscription` are filtered out during selection.
+MPP_SUPPORTED_INTENT = "charge"
+
+# Payment method identifiers, mapped to the blockchain family of the payment
+# instrument that can satisfy them. Tempo is an EVM chain, so it maps to ETHEREUM.
+MPP_METHOD_BLOCKCHAIN = {
+    "evm": "ETHEREUM",
+    "tempo": "ETHEREUM",
+    "solana": "SOLANA",
+}
+
+# Maps a Solana `methodDetails.network` value to the network identifier used in
+# NETWORK_PREFERENCES. Per draft-solana-charge-00 the field is optional and
+# defaults to mainnet.
+MPP_SOLANA_NETWORK_ALIASES = {
+    "mainnet": "solana-mainnet",
+    "devnet": "solana-devnet",
+    "localnet": "solana-testnet",
+    "testnet": "solana-testnet",
+}
+MPP_SOLANA_DEFAULT_NETWORK = "mainnet"

--- a/src/bedrock_agentcore/payments/constants.py
+++ b/src/bedrock_agentcore/payments/constants.py
@@ -105,10 +105,15 @@ MPP_METHOD_BLOCKCHAIN = {
 # Maps a Solana `methodDetails.network` value to the network identifier used in
 # NETWORK_PREFERENCES. Per draft-solana-charge-00 the field is optional and
 # defaults to mainnet.
+#
+# `localnet` is deliberately absent. It denotes a distinct local RPC/Surfpool
+# environment, not Solana testnet; aliasing it would let a local-only challenge
+# satisfy a solana-testnet preference and outrank a genuinely payable devnet
+# challenge. Unmapped values are left unranked rather than misranked — they remain
+# selectable when they are the only option, but never win on preference order.
 MPP_SOLANA_NETWORK_ALIASES = {
     "mainnet": "solana-mainnet",
     "devnet": "solana-devnet",
-    "localnet": "solana-testnet",
     "testnet": "solana-testnet",
 }
 MPP_SOLANA_DEFAULT_NETWORK = "mainnet"

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -50,6 +50,11 @@ class AgentCorePaymentsPluginConfig:
             When None (default), errors produce deterministic ToolMessages directly.
         max_error_retries: Maximum times the error callback can return RETRY per tool call.
             Default 3. Set to 0 to disable the callback entirely.
+        buyer_pays_gas_fees: MPP only. Authorizes charging blockchain network (gas) fees to
+            the buyer's wallet, on top of the payment amount. MPP challenges advertise who
+            sponsors fees via methodDetails.feePayer; when the seller does not, the service
+            signs only if this is True and otherwise fails validation. None (default) leaves
+            the protocol default in place and the field unsent. Ignored for x402.
     """
 
     payment_manager_arn: str
@@ -73,6 +78,7 @@ class AgentCorePaymentsPluginConfig:
     auto_session_expiry_minutes: int = 60
     on_payment_error: Optional[Callable] = None
     max_error_retries: int = 3
+    buyer_pays_gas_fees: Optional[bool] = None
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
@@ -133,6 +139,11 @@ class AgentCorePaymentsPluginConfig:
             raise ValueError(f"max_error_retries must be an int, got {type(self.max_error_retries).__name__}")
         if self.max_error_retries < 0:
             raise ValueError(f"max_error_retries must be >= 0, got {self.max_error_retries}")
+
+        if self.buyer_pays_gas_fees is not None and not isinstance(self.buyer_pays_gas_fees, bool):
+            raise ValueError(
+                f"buyer_pays_gas_fees must be a boolean or None, got {type(self.buyer_pays_gas_fees).__name__}"
+            )
 
     def update_payment_session_id(self, payment_session_id: str) -> None:
         """Update the payment session ID.

--- a/src/bedrock_agentcore/payments/integrations/handlers.py
+++ b/src/bedrock_agentcore/payments/integrations/handlers.py
@@ -1,8 +1,13 @@
-"""Tool-specific handlers for X.402 payment processing.
+"""Tool-specific handlers for payment processing.
 
 This module provides handlers for extracting payment information from different tool responses.
 Each handler is responsible for parsing tool-specific response formats and extracting
-HTTP status codes and X.402 payment requirements.
+HTTP status codes and payment requirements.
+
+Both supported protocols are handled: x402 (payment requirements in the response body or
+the ``Payment-Required`` header) and MPP (payment options advertised as
+``WWW-Authenticate: Payment`` challenges). Because handlers surface the full header
+dictionary, MPP challenges reach ``PaymentManager.generate_payment_header`` unmodified.
 """
 
 import ast
@@ -12,6 +17,33 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# Header carrying MPP payment challenges on a 402 response.
+_WWW_AUTHENTICATE = "www-authenticate"
+
+# The MPP auth-scheme name, lowercased for case-insensitive comparison.
+_MPP_SCHEME = "payment"
+
+
+def has_mpp_challenge(headers: Any) -> bool:
+    """Check whether a header mapping advertises a usable MPP ``Payment`` challenge.
+
+    Delegates to the MPP parser so detection and parsing can never disagree. A
+    hand-rolled prefix check here would drift: it would miss a ``Payment`` challenge
+    that follows another scheme (``Bearer ..., Payment ...``) and would falsely match
+    a hypothetical ``PaymentXYZ`` scheme.
+
+    Args:
+        headers: A header dictionary (case-insensitive keys) or any other value.
+
+    Returns:
+        True if a parseable ``WWW-Authenticate: Payment`` challenge is present.
+    """
+    from bedrock_agentcore.payments.mpp import is_mpp_payment_required
+
+    if not isinstance(headers, dict):
+        return False
+    return is_mpp_payment_required({"headers": headers})
 
 
 class PaymentResponseHandler(ABC):
@@ -336,21 +368,46 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
         """
         return isinstance(data, dict) and "x402Version" in data and "accepts" in data
 
+    @staticmethod
+    def _response_headers(result: Any) -> Dict[str, Any]:
+        """Extract the upstream response headers from an MCP Gateway result.
+
+        Returns:
+            The ``responseHeaders`` dict, or an empty dict if absent.
+        """
+        if not isinstance(result, dict):
+            return {}
+        headers = result.get("responseHeaders")
+        return headers if isinstance(headers, dict) else {}
+
+    def _is_payment_required(self, result: Any) -> bool:
+        """Check whether the MCP result represents a payment-required response.
+
+        Covers x402 (payment data in structuredContent) and MPP (a
+        ``WWW-Authenticate: Payment`` challenge in the upstream response headers).
+        """
+        if not isinstance(result, dict):
+            return False
+        if self._is_x402_payment_data(result.get("structuredContent")):
+            return True
+        return has_mpp_challenge(self._response_headers(result))
+
     def extract_status_code(self, result: Any) -> Optional[int]:
         """Extract status code from MCP Gateway tool result.
 
-        MCP Gateway returns HTTP 200 with x402 payment data embedded in
-        structuredContent, so there is no explicit 402 status code. We infer
-        402 from the presence of x402Version + accepts fields.
+        MCP Gateway returns HTTP 200 with the payment requirement embedded in the
+        response, so there is no explicit 402 status code. We infer 402 from the
+        presence of x402Version + accepts fields, or an MPP ``Payment`` challenge
+        in the upstream response headers.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            402 if x402 payment data found, None otherwise
+            402 if payment required data found, None otherwise
         """
         try:
-            if isinstance(result, dict) and self._is_x402_payment_data(result.get("structuredContent")):
+            if self._is_payment_required(result):
                 return 402
             return None
         except Exception as e:
@@ -360,18 +417,23 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
     def extract_headers(self, result: Any) -> Optional[Dict[str, Any]]:
         """Extract headers from MCP Gateway tool result.
 
-        Returns content-type header when structuredContent contains x402 data.
+        Returns the upstream ``responseHeaders`` when present — MPP challenges live
+        there and must be forwarded intact. Falls back to a synthetic content-type
+        header for x402 results, which carry their requirements in the body.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            Headers dict if x402 data found, None otherwise
+            Headers dict if payment required data found, None otherwise
         """
         try:
-            if isinstance(result, dict) and self._is_x402_payment_data(result.get("structuredContent")):
-                return {"content-type": "application/json"}
-            return None
+            if not self._is_payment_required(result):
+                return None
+            response_headers = self._response_headers(result)
+            if response_headers:
+                return response_headers
+            return {"content-type": "application/json"}
         except Exception as e:
             logger.error("Error extracting headers from MCP result: %s", str(e))
             return None
@@ -379,18 +441,22 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
     def extract_body(self, result: Any) -> Optional[Dict[str, Any]]:
         """Extract body from MCP Gateway tool result.
 
-        Returns the structuredContent dict directly when it contains x402 data.
+        Returns the structuredContent dict directly when it contains payment data.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            structuredContent dict if x402 data found, None otherwise
+            structuredContent dict if payment required data found, None otherwise
         """
         try:
             if isinstance(result, dict):
                 sc = result.get("structuredContent")
                 if self._is_x402_payment_data(sc):
+                    return sc
+                # MPP carries its requirement in headers; surface any structured
+                # content so error details in the body remain available.
+                if has_mpp_challenge(self._response_headers(result)) and isinstance(sc, dict):
                     return sc
             return None
         except Exception as e:

--- a/src/bedrock_agentcore/payments/integrations/langgraph/README.md
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/README.md
@@ -1,12 +1,13 @@
 # LangGraph AgentCore Payments Middleware
 
-The AgentCore Payments Middleware enables LangGraph agents to autonomously handle [x402 Payment Required](https://www.x402.org/) responses. When a tool hits a paid API that returns HTTP 402, the middleware automatically detects the payment requirement, signs the payment via PaymentManager, and retries the request with payment credentials — all transparent to the LLM.
+The AgentCore Payments Middleware enables LangGraph agents to autonomously handle [x402 Payment Required](https://www.x402.org/) and [MPP (Machine Payments Protocol)](https://mpp.dev) responses. When a tool hits a paid API that returns HTTP 402, the middleware automatically detects the payment requirement, signs the payment via PaymentManager, and retries the request with payment credentials — all transparent to the LLM.
 
 ## Overview
 
-- **Automatic x402 Payment Handling** — intercepts 402 responses, processes payment, retries with proof
+- **Automatic Payment Handling** — intercepts 402 responses, processes payment, retries with proof
+- **Multi-Protocol Support** — x402 v1/v2 and MPP, detected automatically from the 402 response
 - **Zero Wrapper Code** — no manual tool wrapping needed; just pass `middleware=[payments]` to `create_agent`
-- **Multi-Format Detection** — handles `PAYMENT_REQUIRED:` marker, raw JSON `statusCode: 402`, and x402 payloads
+- **Multi-Format Detection** — handles `PAYMENT_REQUIRED:` marker, raw JSON `statusCode: 402`, x402 payloads, and MPP `WWW-Authenticate: Payment` challenges
 - **Custom Handler Registry** — register handlers for tools with non-standard response formats
 - **Built-in Tools** — payment-aware `http_request` + payment query tools auto-registered
 - **Deterministic Error Messages** — tailored, actionable error messages returned to the LLM on failure
@@ -142,7 +143,9 @@ When a tool returns, the middleware checks for 402 in this order:
 
 1. **Custom handler** (if registered for this tool name) — full control over detection
 2. **`PAYMENT_REQUIRED:` marker** — explicit opt-in signal in content
-3. **Lenient fallback** — parses raw JSON for `statusCode: 402` or `x402Version` + `accepts` fields
+3. **Lenient fallback** — parses raw JSON for `statusCode: 402`, `x402Version` + `accepts` fields, or a
+   `WWW-Authenticate: Payment` challenge in `responseHeaders`/`headers` (MPP advertises its payment options
+   in headers rather than the body, so the challenge is itself the 402 signal)
 
 This means MCP tools and other tools that return raw JSON are handled automatically without needing the marker or a custom handler.
 
@@ -351,11 +354,12 @@ agent = create_agent(
 |-----------|------|---------|-------------|
 | `payment_manager_arn` | `str` | *required* | ARN of the payment manager resource |
 | `user_id` | `str \| None` | `None` | User ID. Required for SigV4 auth; optional with bearer token |
-| `payment_instrument_id` | `str \| None` | `None` | Instrument ID for x402 signing |
+| `payment_instrument_id` | `str \| None` | `None` | Instrument ID for payment signing |
 | `payment_session_id` | `str \| None` | `None` | Session ID for budget enforcement |
 | `payment_connector_id` | `str \| None` | `None` | Connector ID (optional) |
 | `region` | `str \| None` | `None` | AWS region |
 | `network_preferences_config` | `list[str] \| None` | `None` | Ordered CAIP-2 network identifiers |
+| `buyer_pays_gas_fees` | `bool \| None` | `None` | MPP only. Authorizes network (gas) fees charged to the buyer's wallet. `None` leaves the protocol default (buyer declines) |
 | `auto_payment` | `bool` | `True` | Enable/disable automatic 402 processing |
 | `auto_session` | `bool` | `False` | Auto-create session on first 402 |
 | `auto_session_budget` | `str` | `"1.00"` | Budget (USD) for auto-created sessions |

--- a/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
@@ -20,6 +20,7 @@ from bedrock_agentcore.payments.integrations.handlers import (
     GenericPaymentHandler,
     PaymentResponseHandler,
     get_payment_handler,
+    has_mpp_challenge,
 )
 from bedrock_agentcore.payments.manager import (
     PaymentError,
@@ -181,6 +182,17 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             if "x402Version" in parsed and "accepts" in parsed:
                 logger.debug("Fallback detection: found x402 payload in raw JSON")
                 return {"statusCode": 402, "headers": {}, "body": parsed}
+
+            # MPP advertises payment options in headers rather than the body, so a
+            # WWW-Authenticate: Payment challenge is itself the 402 signal.
+            response_headers = parsed.get("responseHeaders") or parsed.get("headers")
+            if has_mpp_challenge(response_headers):
+                logger.debug("Fallback detection: found MPP Payment challenge in response headers")
+                return {
+                    "statusCode": 402,
+                    "headers": response_headers,
+                    "body": parsed.get("structuredContent") or parsed.get("body") or {},
+                }
 
             sc = parsed.get("structuredContent")
             if isinstance(sc, dict) and "x402Version" in sc and "accepts" in sc:
@@ -365,14 +377,18 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
         return None
 
     def _generate_payment_header(self, payment_required_request: Dict[str, Any]) -> Dict[str, str]:
-        """Generate payment header via PaymentManager."""
+        """Generate payment header via PaymentManager.
+
+        The payment protocol (x402 or MPP) is detected by PaymentManager from the 402
+        response, so this method is protocol-agnostic.
+        """
         if self.config.payment_instrument_id is None:
-            raise PaymentInstrumentConfigurationRequired("payment_instrument_id is required for x402 payments.")
+            raise PaymentInstrumentConfigurationRequired("payment_instrument_id is required for payments.")
         if self.config.payment_session_id is None:
             if self.config.auto_session:
                 self._create_auto_session()
             else:
-                raise PaymentSessionConfigurationRequired("payment_session_id is required for x402 payments.")
+                raise PaymentSessionConfigurationRequired("payment_session_id is required for payments.")
 
         return self.payment_manager.generate_payment_header(
             user_id=self.config.user_id,
@@ -382,6 +398,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             network_preferences=self.config.network_preferences_config,
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
+            buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
         )
 
     def _create_auto_session(self) -> None:

--- a/src/bedrock_agentcore/payments/integrations/strands/README.md
+++ b/src/bedrock_agentcore/payments/integrations/strands/README.md
@@ -1,22 +1,22 @@
 # Strands AgentCore Payments Plugin
 
 The AgentCore Payments Plugin leverages Amazon Bedrock AgentCore Payments to provide automated payment processing
-capabilities for Strands Agents. It supports the [x402 Payment Required](https://www.x402.org/) protocol, enabling
-agents to automatically handle HTTP 402 responses by processing microtransaction payments to access paid APIs,
-MCP servers, and premium content.
+capabilities for Strands Agents. It supports the [x402 Payment Required](https://www.x402.org/) and
+[MPP (Machine Payments Protocol)](https://mpp.dev) protocols, enabling agents to automatically handle HTTP 402
+responses by processing microtransaction payments to access paid APIs, MCP servers, and premium content.
 
 ## Overview
 
-- **Automatic x402 Payment Handling** — intercepts HTTP 402 responses from tools, processes payment requirements, and retries requests with payment headers
+- **Automatic Payment Handling** — intercepts HTTP 402 responses from tools, processes payment requirements, and retries requests with payment headers
 - **Payment Query Tools** — built-in tools for agents to query payment instruments and sessions at runtime
-- **Multi-Protocol Support** — handles x402 v1 and v2 payment protocols
+- **Multi-Protocol Support** — handles x402 v1/v2 and MPP, detected automatically from the 402 response
 - **Multi-Handler Architecture** — supports generic tools, `http_request` tools, and MCP Gateway proxy tools
 - **Interrupt-Based Error Handling** — raises Strands SDK interrupts on payment failures so the agent (or application) can respond dynamically
 - **Configurable Auto-Payment** — enable or disable automatic payment processing per plugin instance
 
 ## How It Works
 
-### x402 Payment Flow
+### Payment Flow
 
 ```
 ┌─────────┐     ┌──────────┐     ┌──────────────┐     ┌────────────────┐
@@ -31,13 +31,29 @@ MCP servers, and premium content.
 ```
 
 1. Agent calls a tool (e.g., `http_request`) that hits a paid API
-2. The API returns HTTP 402 with x402 payment requirements
+2. The API returns HTTP 402 with payment requirements — x402 (body / `Payment-Required` header) or
+   MPP (`WWW-Authenticate: Payment` challenges)
 3. The plugin's `after_tool_call` hook intercepts the 402 response
 4. The plugin extracts payment requirements using the appropriate handler
-5. The plugin calls `PaymentManager.generate_payment_header()` to process the payment
-6. The payment header is applied to the tool input
+5. The plugin calls `PaymentManager.generate_payment_header()`, which detects the protocol,
+   selects a payment option, and processes the payment
+6. The payment header is applied to the tool input — `X-PAYMENT` (x402 v1),
+   `PAYMENT-SIGNATURE` (x402 v2), or `Authorization: Payment <token>` (MPP)
 7. The tool is automatically retried with the payment credentials
 8. The API returns a successful response
+
+### MPP challenge selection
+
+An MPP server may advertise several payment options, but `ProcessPayment` fulfills exactly one
+per call. The plugin delegates to `PaymentManager`, which filters to `charge`-intent,
+unexpired challenges your instrument can satisfy (`evm`/`tempo` → ETHEREUM, `solana` → SOLANA),
+orders them by `network_preferences_config`, and pays the best match. The selected challenge
+header is forwarded verbatim so its HMAC stays valid. See the
+[payments README](../../README.md#mpp-machine-payments-protocol) for the full algorithm.
+
+If a challenge does not offer seller-sponsored network fees, signing requires
+`buyer_pays_gas_fees=True` on the plugin config — the gas cost is not visible in the challenge
+`amount`, so it is not assumed on the buyer's behalf.
 
 ## Installation
 
@@ -429,6 +445,7 @@ agent("Fetch data from https://premium-api.example.com/data")
 | `payment_session_id` | `Optional[str]` | No | `None` | Payment session ID. Can be set later via `update_payment_session_id()` |
 | `region` | `Optional[str]` | No | `None` | AWS region for the payment manager |
 | `network_preferences_config` | `Optional[list[str]]` | No | `None` | List of network CAIP-2 identifiers in order of preference |
+| `buyer_pays_gas_fees` | `Optional[bool]` | No | `None` | MPP only. Authorizes network (gas) fees charged to the buyer's wallet, on top of the payment amount. `None` leaves the protocol default (buyer declines) |
 | `auto_payment` | `bool` | No | `True` | Whether to automatically process 402 payment requirements |
 | `max_interrupt_retries` | `int` | No | `5` | Maximum interrupt retries per tool use. Set to 0 to disable interrupts |
 | `agent_name` | `Optional[str]` | No | `None` | Agent name propagated via HTTP header on API calls |

--- a/src/bedrock_agentcore/payments/integrations/strands/plugin.py
+++ b/src/bedrock_agentcore/payments/integrations/strands/plugin.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class AgentCorePaymentsPlugin(Plugin):
-    """Plugin for handling X402 payment requirements and providing payment tools in Strands Agents.
+    """Plugin for handling payment requirements and providing payment tools in Strands Agents.
 
     This plugin provides tools for querying payment information and making paid HTTP calls:
     - http_request: Call a (paid) HTTP endpoint; 402 responses are settled automatically
@@ -35,9 +35,15 @@ class AgentCorePaymentsPlugin(Plugin):
     - getPaymentSession: Retrieve details about a specific payment session
 
     The plugin also intercepts tool calls and responses to handle HTTP 402 Payment Required
-    responses by processing X402 payment requirements and retrying requests with
+    responses by processing the payment requirement and retrying requests with
     appropriate payment credentials. Payment processing is controlled by the auto_payment
     configuration flag (default: True).
+
+    Both payment protocols are supported and detected automatically from the 402 response:
+    x402 (requirements in the body or the ``Payment-Required`` header, settled with an
+    ``X-PAYMENT`` / ``PAYMENT-SIGNATURE`` header) and MPP (options advertised as
+    ``WWW-Authenticate: Payment`` challenges, settled with an ``Authorization: Payment
+    <token>`` header).
 
     Attributes:
         name: Plugin identifier ("agent-core-payments-plugin")
@@ -258,6 +264,12 @@ class AgentCorePaymentsPlugin(Plugin):
             # can submit in the same second the signature was minted, hitting the
             # contract's strict ``block.timestamp > validAfter`` check and producing
             # a misleading "invalid_payload" 402 from the seller.
+            #
+            # This applies to MPP too: an evm-charge credential of type "authorization"
+            # is an EIP-3009 authorization carrying the same validAfter field. The delay
+            # is harmless for credential types that settle without it (e.g. Solana push
+            # mode, where the transaction is already confirmed) and is configurable via
+            # post_payment_retry_delay_seconds.
             delay = self.config.post_payment_retry_delay_seconds
             if delay > 0:
                 logger.info(
@@ -435,13 +447,17 @@ class AgentCorePaymentsPlugin(Plugin):
         """Process 402 payment required request and generate payment header.
 
         Calls PaymentManager.generate_payment_header with the 402 payment required request
-        and returns the payment header dictionary.
+        and returns the payment header dictionary. The payment protocol (x402 or MPP) is
+        detected from the 402 response by PaymentManager, so this method is
+        protocol-agnostic.
 
         Args:
             payment_required_request: Dictionary containing 402 payment requirements with statusCode, headers, and body
 
         Returns:
-            Dictionary with payment header name and value (e.g., {"X-PAYMENT": "base64..."})
+            Dictionary with payment header name and value. For x402:
+            {"X-PAYMENT": "base64..."} or {"PAYMENT-SIGNATURE": "base64..."}.
+            For MPP: {"Authorization": "Payment <base64url-token>"}.
 
         Raises:
             PaymentError: If payment processing fails
@@ -453,7 +469,7 @@ class AgentCorePaymentsPlugin(Plugin):
 
         if self.config.payment_instrument_id is None:
             raise PaymentInstrumentConfigurationRequired(
-                "payment_instrument_id is required for x402 payments.\n"
+                "payment_instrument_id is required for payments.\n"
                 "Setup steps:\n"
                 "1. Create instrument: PaymentManager.create_payment_instrument(connector_id, type, details, user_id)\n"
                 "2. Fund wallet: https://faucet.circle.com/ (Base Sepolia, USDC, paste wallet address)\n"
@@ -463,7 +479,7 @@ class AgentCorePaymentsPlugin(Plugin):
 
         if self.config.payment_session_id is None:
             raise PaymentSessionConfigurationRequired(
-                "payment_session_id is required for x402 payments.\n"
+                "payment_session_id is required for payments.\n"
                 "Create a session: PaymentManager.create_payment_session(expiry_time_in_minutes, user_id, limits)\n"
                 "Then pass session_id in invoke payload or plugin config.\n"
                 "Tip: use 'agentcore invoke --payment-session-id <id>' or '--auto-session' from the CLI."
@@ -478,6 +494,7 @@ class AgentCorePaymentsPlugin(Plugin):
             network_preferences=self.config.network_preferences_config,
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
+            buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
         )
 
         logger.debug("Generated payment header: %s", list(payment_header_dict.keys()))
@@ -768,16 +785,20 @@ class AgentCorePaymentsPlugin(Plugin):
         """Call an HTTP endpoint. 402 Payment Required responses are settled automatically.
 
         When the endpoint responds with HTTP 402, this plugin's after_tool_call hook
-        intercepts the result, generates an x402 payment header via the configured
-        PaymentManager, mutates ``headers`` with the X-PAYMENT (v1) or
-        PAYMENT-SIGNATURE (v2) header, and Strands re-invokes this tool — yielding
-        the final 200 response and (when applicable) a settle hash in the
-        PAYMENT-RESPONSE header.
+        intercepts the result, generates a payment header via the configured
+        PaymentManager, mutates ``headers`` with it, and Strands re-invokes this tool
+        — yielding the final 200 response and (when applicable) a settle hash in the
+        PAYMENT-RESPONSE header (x402) or a receipt in Payment-Receipt (MPP).
+
+        The header depends on the protocol detected in the 402: X-PAYMENT (x402 v1),
+        PAYMENT-SIGNATURE (x402 v2), or Authorization (MPP).
 
         Returns a Strands ToolResult dict: ``status`` is always ``success`` (HTTP
         errors are returned in the body, not raised), and ``content`` is a single
         text block. On 402 the text is prefixed with ``PAYMENT_REQUIRED:`` so the
-        SDK's payment handlers can extract the x402 payload.
+        SDK's payment handlers can extract the payment requirement. All response
+        headers are included verbatim, so MPP ``WWW-Authenticate`` challenges survive
+        intact.
 
         Args:
             url: The full URL to request.

--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -1042,17 +1042,33 @@ class PaymentManager:
             # Step 4: Detect the payment protocol and dispatch. An MPP 402 advertises
             # its payment options via 'WWW-Authenticate: Payment' challenges; x402
             # carries them in the body or the Payment-Required header.
+            #
+            # A response may advertise both. MPP is preferred, but an MPP challenge the
+            # instrument cannot satisfy must not fail the whole payment when a payable
+            # x402 option is also on offer — so fall through to x402 in that case.
             if is_mpp_payment_required(payment_required_request):
                 logger.debug("Detected MPP payment required request")
-                return self._generate_mpp_payment_header(
-                    payment_instrument_id=payment_instrument_id,
-                    payment_session_id=payment_session_id,
-                    payment_required_request=payment_required_request,
-                    user_id=user_id,
-                    network_preferences=network_preferences,
-                    client_token=client_token,
-                    buyer_pays_gas_fees=buyer_pays_gas_fees,
-                )
+                try:
+                    return self._generate_mpp_payment_header(
+                        payment_instrument_id=payment_instrument_id,
+                        payment_session_id=payment_session_id,
+                        payment_required_request=payment_required_request,
+                        user_id=user_id,
+                        network_preferences=network_preferences,
+                        client_token=client_token,
+                        buyer_pays_gas_fees=buyer_pays_gas_fees,
+                    )
+                except MppChallengeSelectionError as e:
+                    # Only selection failures are recoverable. A failure after the
+                    # payment was submitted must propagate: retrying under x402 could
+                    # charge the buyer twice.
+                    if not self._has_x402_payment_required(payment_required_request):
+                        raise PaymentError(str(e)) from e
+                    logger.info(
+                        "No satisfiable MPP challenge (%s); falling back to the x402 option "
+                        "advertised in the same 402 response",
+                        e,
+                    )
 
             # Step 4b: x402 — extract payload and detect version.
             x402_payload, x402_version = self._extract_x402_payload(payment_required_request)
@@ -1110,6 +1126,30 @@ class PaymentManager:
         except Exception as e:
             logger.error("Unexpected error during payment header generation: %s", str(e))
             raise PaymentError(f"Unexpected error: {str(e)}") from e
+
+    def _has_x402_payment_required(self, payment_required_request: Dict[str, Any]) -> bool:
+        """Check whether a 402 response also carries an x402 payment requirement.
+
+        Used to decide whether an unsatisfiable MPP challenge can fall back to x402.
+        Deliberately read-only and non-raising: this runs inside an exception handler,
+        so a malformed x402 payload must report "no x402 option" rather than mask the
+        original MPP selection failure.
+
+        Args:
+            payment_required_request: Dict with statusCode, headers, and body.
+
+        Returns:
+            True if a parseable x402 requirement with a non-empty ``accepts`` list is present.
+        """
+        try:
+            x402_payload, _ = self._extract_x402_payload(payment_required_request)
+        except PaymentError:
+            return False
+        except Exception:  # pragma: no cover - defensive; extraction should raise PaymentError
+            return False
+
+        accepts = x402_payload.get("accepts")
+        return isinstance(accepts, list) and bool(accepts)
 
     def _get_instrument_network(
         self,
@@ -1195,14 +1235,16 @@ class PaymentManager:
         logger.debug("Retrieved instrument with network: %s", network)
 
         # Step 3: Select the one challenge to fulfill.
-        try:
-            selected = select_challenge(
-                challenges,
-                instrument_network=network,
-                network_preferences=network_preferences,
-            )
-        except MppChallengeSelectionError as e:
-            raise PaymentError(str(e)) from e
+        # MppChallengeSelectionError is allowed to propagate rather than being converted
+        # to PaymentError here: generate_payment_header distinguishes it from other
+        # failures so it can fall back to a payable x402 option in the same 402 response.
+        # Callers reaching this method through generate_payment_header still see a
+        # PaymentError, since that wrapper converts it when no fallback exists.
+        selected = select_challenge(
+            challenges,
+            instrument_network=network,
+            network_preferences=network_preferences,
+        )
 
         selected_id = selected.get("id")
         logger.debug(
@@ -1220,8 +1262,19 @@ class PaymentManager:
         # Only send buyerPaysGasFees when the caller expressed an intent. Omitting it
         # leaves the protocol default in place rather than asserting a choice the
         # caller did not make.
+        #
+        # Require an actual bool and forward it unchanged. Coercing with bool() would
+        # make the string "false" authorize additional wallet charges, since every
+        # non-empty string is truthy — a silent, money-moving misread of the caller's
+        # intent. This matches the strict validation on the integration config.
         if buyer_pays_gas_fees is not None:
-            mpp_input["buyerPaysGasFees"] = bool(buyer_pays_gas_fees)
+            if not isinstance(buyer_pays_gas_fees, bool):
+                raise PaymentError(
+                    "Input Validation: buyer_pays_gas_fees must be a boolean or None, got "
+                    f"{type(buyer_pays_gas_fees).__name__}. Pass True or False explicitly — "
+                    "values are not coerced, because authorizing network fees must be unambiguous."
+                )
+            mpp_input["buyerPaysGasFees"] = buyer_pays_gas_fees
 
         payment_input = {"mpp": mpp_input}
 

--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -16,6 +16,15 @@ from botocore.exceptions import ClientError
 from bedrock_agentcore._utils.endpoints import get_data_plane_endpoint
 from bedrock_agentcore._utils.user_agent import build_user_agent_suffix
 
+from ._model_patch import patch_process_payment_model
+from .constants import MPP_AUTH_SCHEME, MPP_DEFAULT_VERSION
+from .mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -225,6 +234,10 @@ class PaymentManager:
             config=client_config,
             endpoint_url=get_data_plane_endpoint(self.region_name),
         )
+
+        # Add the MPP ProcessPayment shapes if the installed botocore predates them.
+        # No-op once botocore ships them natively. See _model_patch for details.
+        patch_process_payment_model(self._payment_client)
 
         # Register event handler to inject agent name header on every data-plane call
         if self._agent_name:
@@ -915,6 +928,7 @@ class PaymentManager:
         network_preferences: Optional[list[str]] = None,
         client_token: Optional[str] = None,
         payment_connector_id: Optional[str] = None,
+        buyer_pays_gas_fees: Optional[bool] = None,
     ) -> Dict[str, str]:
         """Generate a payment header for 402 payment required request.
 
@@ -943,10 +957,18 @@ class PaymentManager:
                 forwarded to process_payment. ProcessPayment derives the connector
                 from the payment instrument; sending paymentConnectorId on that call
                 was rejected by the API as an unknown parameter.
+            buyer_pays_gas_fees: MPP only. Authorizes the service to sign a payment whose
+                blockchain network (gas) fees are charged to the buyer's own wallet, on top
+                of the payment amount. When the challenge does not offer seller-sponsored
+                fees (``methodDetails.feePayer`` is false or absent), the service signs only
+                if this is True and otherwise fails validation, so the caller can decide.
+                Omitted or False means the buyer declines to pay network fees. Has no effect
+                on challenges where the seller already sponsors them. Ignored for x402.
 
         Returns:
-            Dictionary with header name and value (e.g., {"X-PAYMENT": "base64..."} or
-            {"PAYMENT-SIGNATURE": "base64..."}) for X402 payment required request
+            Dictionary with header name and value. For x402: {"X-PAYMENT": "base64..."}
+            (v1) or {"PAYMENT-SIGNATURE": "base64..."} (v2). For MPP:
+            {"Authorization": "Payment <base64url-token>"}
 
         Raises:
             PaymentError: For validation or processing failures
@@ -971,6 +993,11 @@ class PaymentManager:
             )
             # Returns: {"X-PAYMENT": "base64..."} or {"PAYMENT-SIGNATURE": "base64..."}
             ```
+
+        Note:
+            The payment protocol is detected from the 402 response. A
+            ``WWW-Authenticate: Payment`` header routes to MPP; otherwise the
+            response is treated as x402.
         """
         user_id = user_id.strip() if user_id else None
 
@@ -1012,31 +1039,27 @@ class PaymentManager:
                     raise PaymentError("client_token is invalid - cannot be empty")
                 logger.debug("Using provided client_token: %s", client_token[:8] + "...")
 
-            # Step 4: Extract X.402 payload and detect version.
-            # Will have another method for MPP or any other payments protocols
+            # Step 4: Detect the payment protocol and dispatch. An MPP 402 advertises
+            # its payment options via 'WWW-Authenticate: Payment' challenges; x402
+            # carries them in the body or the Payment-Required header.
+            if is_mpp_payment_required(payment_required_request):
+                logger.debug("Detected MPP payment required request")
+                return self._generate_mpp_payment_header(
+                    payment_instrument_id=payment_instrument_id,
+                    payment_session_id=payment_session_id,
+                    payment_required_request=payment_required_request,
+                    user_id=user_id,
+                    network_preferences=network_preferences,
+                    client_token=client_token,
+                    buyer_pays_gas_fees=buyer_pays_gas_fees,
+                )
+
+            # Step 4b: x402 — extract payload and detect version.
             x402_payload, x402_version = self._extract_x402_payload(payment_required_request)
             logger.debug("Extracted X.402 payload version %d", x402_version)
 
             # Step 5: Retrieve payment instrument and extract network
-            instrument = self.get_payment_instrument(
-                user_id=user_id,
-                payment_instrument_id=payment_instrument_id,
-            )
-            logger.debug("Retrieved instrument: %s", instrument)
-
-            # Extract network from nested structure: paymentInstrumentDetails.embeddedCryptoWallet.network
-            network = None
-            if "paymentInstrumentDetails" in instrument:
-                details = instrument.get("paymentInstrumentDetails", {})
-                if "embeddedCryptoWallet" in details:
-                    network = details.get("embeddedCryptoWallet", {}).get("network")
-
-            if not network:
-                raise PaymentError(
-                    "Instrument Retrieval: Missing network information - "
-                    "instrument details do not contain network information at "
-                    "paymentInstrumentDetails.embeddedCryptoWallet.network"
-                )
+            network = self._get_instrument_network(payment_instrument_id, user_id)
             logger.debug("Retrieved instrument with network: %s", network)
 
             # Step 6: Validate instrument network and select matching accept
@@ -1087,6 +1110,169 @@ class PaymentManager:
         except Exception as e:
             logger.error("Unexpected error during payment header generation: %s", str(e))
             raise PaymentError(f"Unexpected error: {str(e)}") from e
+
+    def _get_instrument_network(
+        self,
+        payment_instrument_id: str,
+        user_id: Optional[str],
+    ) -> str:
+        """Retrieve a payment instrument and extract its blockchain network.
+
+        Args:
+            payment_instrument_id: Unique identifier for the payment instrument
+            user_id: Unique identifier for the user (optional, omitted for bearer auth)
+
+        Returns:
+            The instrument's network (e.g. "ETHEREUM", "SOLANA")
+
+        Raises:
+            PaymentError: If the instrument carries no network information
+        """
+        instrument = self.get_payment_instrument(
+            user_id=user_id,
+            payment_instrument_id=payment_instrument_id,
+        )
+        logger.debug("Retrieved instrument: %s", instrument)
+
+        # Extract network from nested structure: paymentInstrumentDetails.embeddedCryptoWallet.network
+        network = None
+        if "paymentInstrumentDetails" in instrument:
+            details = instrument.get("paymentInstrumentDetails", {})
+            if "embeddedCryptoWallet" in details:
+                network = details.get("embeddedCryptoWallet", {}).get("network")
+
+        if not network:
+            raise PaymentError(
+                "Instrument Retrieval: Missing network information - "
+                "instrument details do not contain network information at "
+                "paymentInstrumentDetails.embeddedCryptoWallet.network"
+            )
+        return network
+
+    def _generate_mpp_payment_header(
+        self,
+        payment_instrument_id: str,
+        payment_session_id: str,
+        payment_required_request: Dict[str, Any],
+        user_id: Optional[str] = None,
+        network_preferences: Optional[list[str]] = None,
+        client_token: Optional[str] = None,
+        buyer_pays_gas_fees: Optional[bool] = None,
+    ) -> Dict[str, str]:
+        """Generate an MPP Authorization header for a 402 payment required response.
+
+        MPP servers advertise their payment options as ``WWW-Authenticate: Payment``
+        challenges. ProcessPayment fulfills exactly one challenge per call, so this
+        method selects the single challenge the instrument can satisfy and forwards its
+        raw header value verbatim — preserving the exact base64url ``request``/``opaque``
+        bytes the challenge HMAC binds to.
+
+        Args:
+            payment_instrument_id: Unique identifier for the payment instrument
+            payment_session_id: Unique identifier for the payment session
+            payment_required_request: Dict with statusCode, headers, and body
+            user_id: Unique identifier for the user (optional, omitted for bearer auth)
+            network_preferences: Optional network identifiers in order of preference.
+                Defaults to NETWORK_PREFERENCES from constants.
+            client_token: Idempotency token
+            buyer_pays_gas_fees: Authorizes charging blockchain network (gas) fees to the
+                buyer's wallet on top of the payment amount. Only sent when not None, so
+                omitting it preserves the service-side protocol default.
+
+        Returns:
+            Dictionary with the ready-to-send Authorization header,
+            e.g. {"Authorization": "Payment eyJ..."}
+
+        Raises:
+            PaymentError: If no challenge can be satisfied or payment processing fails
+        """
+        # Step 1: Parse the advertised challenges.
+        challenges = extract_challenges(payment_required_request)
+        logger.debug("Parsed %d MPP challenge(s) from 402 response", len(challenges))
+
+        # Step 2: Retrieve the instrument network to determine which methods we can pay.
+        network = self._get_instrument_network(payment_instrument_id, user_id)
+        logger.debug("Retrieved instrument with network: %s", network)
+
+        # Step 3: Select the one challenge to fulfill.
+        try:
+            selected = select_challenge(
+                challenges,
+                instrument_network=network,
+                network_preferences=network_preferences,
+            )
+        except MppChallengeSelectionError as e:
+            raise PaymentError(str(e)) from e
+
+        selected_id = selected.get("id")
+        logger.debug(
+            "Selected MPP challenge id=%s method=%s",
+            selected_id,
+            selected.get("method"),
+        )
+
+        # Step 4: Process the payment. The raw header value is forwarded verbatim.
+        mpp_input: Dict[str, Any] = {
+            "version": MPP_DEFAULT_VERSION,
+            "wwwAuthenticateHeaders": [selected["raw"]],
+        }
+
+        # Only send buyerPaysGasFees when the caller expressed an intent. Omitting it
+        # leaves the protocol default in place rather than asserting a choice the
+        # caller did not make.
+        if buyer_pays_gas_fees is not None:
+            mpp_input["buyerPaysGasFees"] = bool(buyer_pays_gas_fees)
+
+        payment_input = {"mpp": mpp_input}
+
+        payment_result = self.process_payment(
+            user_id=user_id,
+            payment_session_id=payment_session_id,
+            payment_instrument_id=payment_instrument_id,
+            payment_type="MPP",
+            payment_input=payment_input,
+            client_token=client_token,
+        )
+        logger.debug("MPP payment processed successfully")
+
+        # Step 5: Extract the minted credential.
+        # Defend against malformed payloads at each level rather than chaining .get():
+        # a null or non-object member would otherwise surface as an opaque AttributeError
+        # instead of a message naming the field at fault.
+        payment_output = payment_result.get("paymentOutput") if isinstance(payment_result, dict) else None
+        mpp_output = payment_output.get("mpp") if isinstance(payment_output, dict) else None
+        if not isinstance(mpp_output, dict) or not mpp_output:
+            raise PaymentError(
+                "Payment Processing: Missing mpp in payment output - payment result does not contain an MPP credential"
+            )
+
+        credential = mpp_output.get("paymentCredential")
+        if not credential or not isinstance(credential, str) or not credential.strip():
+            raise PaymentError(
+                "Payment Processing: Missing paymentCredential - MPP payment output does not "
+                "contain a payment credential"
+            )
+
+        returned_id = mpp_output.get("selectedPaymentId")
+        if returned_id and selected_id and returned_id != selected_id:
+            # The service echoes the challenge it paid. A mismatch means we would attach
+            # a credential for a different challenge than the one we selected.
+            raise PaymentError(
+                f"Payment Processing: Challenge mismatch - requested challenge "
+                f"'{selected_id}' but the service paid '{returned_id}'"
+            )
+
+        # Step 6: Build the Authorization header. The service returns a ready-to-send
+        # value; only add the scheme prefix if it is not already present.
+        credential = credential.strip()
+        scheme_prefix = f"{MPP_AUTH_SCHEME} "
+        if credential.lower().startswith(scheme_prefix.lower()):
+            header_value = credential
+        else:
+            header_value = f"{scheme_prefix}{credential}"
+
+        logger.info("Successfully generated MPP payment header for challenge %s", selected_id)
+        return {"Authorization": header_value}
 
     def __getattr__(self, name: str):
         """Dynamically forward method calls to the PaymentClient.

--- a/src/bedrock_agentcore/payments/mpp.py
+++ b/src/bedrock_agentcore/payments/mpp.py
@@ -1,0 +1,492 @@
+"""MPP (Machine Payments Protocol) challenge parsing and selection.
+
+MPP is an open protocol for machine-to-machine payments (https://mpp.dev). A server
+that requires payment answers with ``402 Payment Required`` and one or more
+``WWW-Authenticate: Payment ...`` challenges. The client picks a challenge it can
+satisfy, pays it, and retries the request with an ``Authorization: Payment <token>``
+credential.
+
+The AgentCore Payments ``ProcessPayment`` API fulfills exactly one challenge per call
+(``WwwAuthenticateHeaderList`` is constrained to a single entry), so this module
+provides the selection logic that reduces a list of advertised challenges to the one
+the caller's payment instrument can pay — mirroring how x402 accept headers are
+narrowed by network preference.
+
+Only the ``charge`` intent is implemented, across the ``evm``, ``tempo`` and ``solana``
+payment methods.
+
+Parsing is deliberately lenient about unknown auth-params: per the MPP specification,
+"Unknown parameters must be ignored by clients". The raw header value is always
+preserved verbatim so the exact base64url ``request``/``opaque`` bytes that the
+challenge HMAC binds to are forwarded to the service unchanged.
+"""
+
+import base64
+import binascii
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .constants import (
+    MPP_AUTH_SCHEME,
+    MPP_METHOD_BLOCKCHAIN,
+    MPP_SOLANA_DEFAULT_NETWORK,
+    MPP_SOLANA_NETWORK_ALIASES,
+    MPP_SUPPORTED_INTENT,
+    NETWORK_PREFERENCES,
+)
+
+logger = logging.getLogger(__name__)
+
+# Header names that may carry MPP challenges on a 402 response.
+_WWW_AUTHENTICATE = "www-authenticate"
+
+
+class MppChallengeSelectionError(Exception):
+    """Raised when no advertised MPP challenge can be satisfied.
+
+    Defined here rather than in ``manager`` to keep this module import-cycle free;
+    ``PaymentManager`` re-raises it as a ``PaymentError``.
+    """
+
+
+def _split_outside_quotes(value: str, delimiter: str = ",") -> List[str]:
+    """Split *value* on *delimiter*, ignoring delimiters inside quoted strings.
+
+    RFC 9110 auth-param values may be quoted strings containing commas, so a naive
+    ``str.split(",")`` would corrupt them.
+
+    Args:
+        value: The string to split.
+        delimiter: Single character to split on.
+
+    Returns:
+        List of parts with surrounding whitespace stripped. Empty parts are dropped.
+    """
+    parts: List[str] = []
+    current: List[str] = []
+    in_quotes = False
+    escaped = False
+
+    for char in value:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\" and in_quotes:
+            current.append(char)
+            escaped = True
+            continue
+        if char == '"':
+            in_quotes = not in_quotes
+            current.append(char)
+            continue
+        if char == delimiter and not in_quotes:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+
+    parts.append("".join(current).strip())
+    return [p for p in parts if p]
+
+
+def _unquote(value: str) -> str:
+    """Remove surrounding double quotes from an auth-param value and unescape it."""
+    value = value.strip()
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        inner = value[1:-1]
+        return inner.replace('\\"', '"').replace("\\\\", "\\")
+    return value
+
+
+def _parse_auth_param(part: str) -> Optional[tuple]:
+    """Parse a single ``key=value`` auth-param.
+
+    Args:
+        part: The auth-param text, e.g. ``id="aB3cDeF4"``.
+
+    Returns:
+        ``(lowercased_key, unquoted_value)``, or None if *part* is not a ``key=value`` pair.
+    """
+    if "=" not in part:
+        return None
+    key, _, raw_value = part.partition("=")
+    key = key.strip().lower()
+    if not key:
+        return None
+    return key, _unquote(raw_value)
+
+
+def _starts_new_auth_scheme(part: str) -> bool:
+    """Check whether *part* begins a new (non-Payment) auth-scheme.
+
+    A ``WWW-Authenticate`` field may list several challenges across different schemes,
+    separated by the same commas that separate auth-params. Per RFC 9110 a challenge
+    opens with a bare scheme token, optionally followed by its first auth-param —
+    ``Bearer`` or ``Bearer realm="x"`` — whereas an auth-param belonging to the current
+    challenge is just ``key=value``. The distinguishing feature is whitespace before
+    the ``=``: a scheme token precedes its first param, so the text left of ``=``
+    contains a space.
+
+    Args:
+        part: One comma-separated segment of the header value.
+
+    Returns:
+        True if *part* opens a scheme other than ``Payment``.
+    """
+    stripped = part.strip()
+    if not stripped:
+        return False
+
+    head = stripped.partition("=")[0]
+    # `key=value` -> no whitespace in the key. `Scheme key=value` -> whitespace.
+    # A bare token with no `=` at all is also a scheme (e.g. a valueless `Negotiate`).
+    if "=" in stripped and not head.strip().count(" "):
+        return False
+
+    token = stripped.split()[0]
+    return token.lower() != MPP_AUTH_SCHEME.lower()
+
+
+def parse_www_authenticate(header_value: str) -> List[Dict[str, Any]]:
+    """Parse ``WWW-Authenticate`` header value(s) into MPP challenges.
+
+    A single header field value may advertise more than one challenge, and servers
+    commonly emit one ``WWW-Authenticate`` line per payment option. Both forms are
+    handled: the value is split on the ``Payment`` auth-scheme token, and each
+    resulting group is parsed into auth-params.
+
+    Non-``Payment`` schemes (e.g. ``Bearer``) are ignored.
+
+    Args:
+        header_value: Raw header value, possibly containing several challenges.
+
+    Returns:
+        List of challenge dicts. Each contains the parsed auth-params (``id``,
+        ``realm``, ``method``, ``intent``, ``request``, ``expires``, ``opaque``, plus
+        any unknown params) and a ``raw`` key holding the verbatim single-challenge
+        header value to forward to ProcessPayment.
+    """
+    if not header_value or not isinstance(header_value, str):
+        return []
+
+    challenges: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    current_parts: List[str] = []
+    scheme_prefix = MPP_AUTH_SCHEME.lower() + " "
+
+    def _flush() -> None:
+        if current is not None and current_parts:
+            current["raw"] = f"{MPP_AUTH_SCHEME} " + ", ".join(current_parts)
+            challenges.append(current)
+
+    for part in _split_outside_quotes(header_value):
+        lowered = part.lower()
+        # A part that begins with the scheme name starts a new challenge.
+        if lowered.startswith(scheme_prefix) or lowered == MPP_AUTH_SCHEME.lower():
+            _flush()
+            current = {}
+            current_parts = []
+            remainder = part[len(MPP_AUTH_SCHEME) :].strip()
+            if remainder:
+                parsed = _parse_auth_param(remainder)
+                if parsed:
+                    current[parsed[0]] = parsed[1]
+                    current_parts.append(remainder)
+            continue
+
+        # A part that opens some other auth-scheme (e.g. `Bearer realm="x"`) ends the
+        # current challenge. Without this, that scheme's auth-params would be absorbed
+        # into the MPP challenge — and into its `raw` value, corrupting the exact bytes
+        # the challenge HMAC binds to.
+        if _starts_new_auth_scheme(part):
+            _flush()
+            current = None
+            current_parts = []
+            continue
+
+        if current is None:
+            # Auth-params belonging to a non-Payment scheme, or a malformed value.
+            continue
+
+        parsed = _parse_auth_param(part)
+        if parsed:
+            current[parsed[0]] = parsed[1]
+            current_parts.append(part)
+
+    _flush()
+    return challenges
+
+
+def extract_challenges(payment_required_request: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Collect all MPP challenges from a 402 payment required request.
+
+    Scans headers case-insensitively for ``WWW-Authenticate``. A header value may be a
+    single string or a list of strings (some HTTP clients expose repeated headers as a
+    list); both are supported.
+
+    Args:
+        payment_required_request: Dict with ``statusCode``, ``headers`` and ``body``.
+
+    Returns:
+        List of parsed challenge dicts, in the order advertised by the server.
+    """
+    headers = payment_required_request.get("headers") or {}
+    if not isinstance(headers, dict):
+        return []
+
+    challenges: List[Dict[str, Any]] = []
+    for key, value in headers.items():
+        if not isinstance(key, str) or key.lower() != _WWW_AUTHENTICATE:
+            continue
+        values = value if isinstance(value, (list, tuple)) else [value]
+        for entry in values:
+            challenges.extend(parse_www_authenticate(entry))
+
+    return challenges
+
+
+def is_mpp_payment_required(payment_required_request: Dict[str, Any]) -> bool:
+    """Check whether a 402 response advertises at least one MPP ``Payment`` challenge.
+
+    Used to route a 402 to the MPP code path instead of the x402 one.
+
+    Args:
+        payment_required_request: Dict with ``statusCode``, ``headers`` and ``body``.
+
+    Returns:
+        True if a parseable ``WWW-Authenticate: Payment`` challenge is present.
+    """
+    if not isinstance(payment_required_request, dict):
+        return False
+    return bool(extract_challenges(payment_required_request))
+
+
+def decode_challenge_request(challenge: Dict[str, Any]) -> Dict[str, Any]:
+    """Decode a challenge's ``request`` auth-param into its JSON object.
+
+    The ``request`` param is JCS-canonicalized JSON, base64url-encoded without padding.
+
+    Args:
+        challenge: A parsed challenge dict.
+
+    Returns:
+        The decoded request object, or an empty dict if absent or undecodable.
+        Decoding never raises — selection treats an undecodable request as an
+        unusable challenge rather than failing the whole call.
+    """
+    encoded = challenge.get("request")
+    if not encoded or not isinstance(encoded, str):
+        return {}
+
+    # base64url without padding — restore padding before decoding.
+    padded = encoded + "=" * (-len(encoded) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        request = json.loads(decoded)
+    except (binascii.Error, ValueError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.debug("MPP: failed to decode challenge request for id=%s: %s", challenge.get("id"), e)
+        return {}
+
+    if not isinstance(request, dict):
+        logger.debug("MPP: challenge request for id=%s decoded to a non-object", challenge.get("id"))
+        return {}
+    return request
+
+
+def challenge_network(challenge: Dict[str, Any]) -> Optional[str]:
+    """Derive the network identifier for a challenge, for preference ordering.
+
+    EVM-family challenges carry ``methodDetails.chainId``, which maps to the CAIP-2
+    style ``eip155:<chainId>`` identifiers used in ``NETWORK_PREFERENCES``. Solana
+    challenges carry an optional ``methodDetails.network`` (mainnet/devnet/localnet),
+    defaulting to mainnet.
+
+    Args:
+        challenge: A parsed challenge dict.
+
+    Returns:
+        Lowercased network identifier, or None if it cannot be determined.
+    """
+    method = (challenge.get("method") or "").lower()
+    request = decode_challenge_request(challenge)
+    method_details = request.get("methodDetails")
+    if not isinstance(method_details, dict):
+        method_details = {}
+
+    if MPP_METHOD_BLOCKCHAIN.get(method) == "ETHEREUM":
+        chain_id = method_details.get("chainId")
+        if isinstance(chain_id, bool) or chain_id is None:
+            return None
+        try:
+            return f"eip155:{int(chain_id)}"
+        except (TypeError, ValueError):
+            return None
+
+    if MPP_METHOD_BLOCKCHAIN.get(method) == "SOLANA":
+        network = method_details.get("network")
+        if not isinstance(network, str) or not network.strip():
+            network = MPP_SOLANA_DEFAULT_NETWORK
+        return MPP_SOLANA_NETWORK_ALIASES.get(network.strip().lower())
+
+    return None
+
+
+def _parse_expires(value: Any) -> Optional[datetime]:
+    """Parse an RFC 3339 ``expires`` auth-param into a timezone-aware datetime."""
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    # datetime.fromisoformat on Python 3.10 does not accept a trailing "Z".
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        logger.debug("MPP: unparseable expires value %r", value)
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def is_expired(challenge: Dict[str, Any], now: Optional[datetime] = None) -> bool:
+    """Check whether a challenge's ``expires`` auth-param is in the past.
+
+    A challenge with no ``expires`` param, or an unparseable one, is treated as not
+    expired — the service is the authority on validity, and discarding a challenge we
+    merely failed to parse would be worse than attempting it.
+
+    Args:
+        challenge: A parsed challenge dict.
+        now: Reference time. Defaults to the current UTC time.
+
+    Returns:
+        True if the challenge has definitively expired.
+    """
+    expires = _parse_expires(challenge.get("expires"))
+    if expires is None:
+        return False
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    return expires <= reference
+
+
+def select_challenge(
+    challenges: List[Dict[str, Any]],
+    instrument_network: str,
+    network_preferences: Optional[List[str]] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Select the one challenge to pay from those the server advertised.
+
+    Selection process (mirrors x402 accept selection):
+
+    1. Drop challenges whose ``intent`` is not ``charge`` — only charge is implemented.
+    2. Drop challenges that have definitively expired.
+    3. Keep only challenges whose ``method`` the instrument's blockchain can satisfy
+       (``evm``/``tempo`` require an ETHEREUM instrument, ``solana`` a SOLANA one).
+    4. Order the survivors by ``network_preferences`` (default ``NETWORK_PREFERENCES``),
+       deriving each challenge's network from its decoded ``request``.
+    5. Tiebreak on the soonest expiry, then on server order.
+
+    Args:
+        challenges: Parsed challenges, in the order the server advertised them.
+        instrument_network: The instrument's network (``ETHEREUM`` or ``SOLANA``).
+        network_preferences: Optional network identifiers, most preferred first.
+            Defaults to ``NETWORK_PREFERENCES``.
+        now: Reference time for expiry checks. Defaults to the current UTC time.
+
+    Returns:
+        The selected challenge dict.
+
+    Raises:
+        MppChallengeSelectionError: If no advertised challenge can be satisfied.
+    """
+    if not challenges:
+        raise MppChallengeSelectionError(
+            "MPP Challenge Selection: No challenges - the 402 response contained no "
+            "parseable 'WWW-Authenticate: Payment' challenge."
+        )
+
+    blockchain = (instrument_network or "").strip().upper()
+    if blockchain not in {"ETHEREUM", "SOLANA"}:
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: Unsupported instrument network '{instrument_network}'. "
+            f"Supported networks are ETHEREUM and SOLANA."
+        )
+
+    # Step 1 & 2: intent and expiry filters.
+    reference = now or datetime.now(timezone.utc)
+    candidates = []
+    skipped_intents: List[str] = []
+    expired_count = 0
+    for challenge in challenges:
+        intent = (challenge.get("intent") or "").strip().lower()
+        # Per draft-*-charge-00 the intent MUST be lowercase; an absent intent is
+        # treated as charge since charge is the only intent this SDK implements.
+        if intent and intent != MPP_SUPPORTED_INTENT:
+            skipped_intents.append(intent)
+            continue
+        if is_expired(challenge, reference):
+            expired_count += 1
+            continue
+        candidates.append(challenge)
+
+    if not candidates:
+        intent_detail = f": {', '.join(sorted(set(skipped_intents)))}" if skipped_intents else ""
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: No usable challenge - all {len(challenges)} advertised "
+            f"challenge(s) were rejected ({expired_count} expired, "
+            f"{len(skipped_intents)} with unsupported intent{intent_detail}). "
+            f"Only the '{MPP_SUPPORTED_INTENT}' intent is supported."
+        )
+
+    # Step 3: keep only methods the instrument can satisfy.
+    supported = []
+    seen_methods: List[str] = []
+    for challenge in candidates:
+        method = (challenge.get("method") or "").strip().lower()
+        if method:
+            seen_methods.append(method)
+        if MPP_METHOD_BLOCKCHAIN.get(method) == blockchain:
+            supported.append(challenge)
+
+    if not supported:
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: No matching challenge - no advertised payment method "
+            f"can be satisfied by an instrument on network '{blockchain}'. "
+            f"Advertised methods: {', '.join(sorted(set(seen_methods))) or 'none'}. "
+            f"Supported methods: {', '.join(sorted(MPP_METHOD_BLOCKCHAIN))}."
+        )
+
+    # Step 4: order by network preference.
+    preferences = network_preferences if network_preferences is not None else NETWORK_PREFERENCES
+    normalized_preferences = [p.lower() for p in preferences]
+
+    def sort_key(indexed):
+        index, challenge = indexed
+        network = challenge_network(challenge)
+        try:
+            rank = normalized_preferences.index(network) if network else len(normalized_preferences)
+        except ValueError:
+            rank = len(normalized_preferences)
+        # Step 5: soonest expiry first, then server order. Challenges without an
+        # expiry sort last among equals so bounded offers are taken first.
+        expires = _parse_expires(challenge.get("expires"))
+        has_expiry = 0 if expires is not None else 1
+        expiry_ts = expires.timestamp() if expires is not None else 0.0
+        return (rank, has_expiry, expiry_ts, index)
+
+    selected = min(enumerate(supported), key=sort_key)[1]
+    logger.debug(
+        "MPP: selected challenge id=%s method=%s network=%s from %d candidate(s)",
+        selected.get("id"),
+        selected.get("method"),
+        challenge_network(selected),
+        len(supported),
+    )
+    return selected

--- a/tests/bedrock_agentcore/payments/integrations/langgraph/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/integrations/langgraph/test_mpp.py
@@ -1,0 +1,262 @@
+"""Tests for MPP (Machine Payments Protocol) support in the LangGraph middleware."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.messages import ToolMessage
+
+from bedrock_agentcore.payments.integrations.langgraph import AgentCorePaymentsConfig
+from bedrock_agentcore.payments.integrations.langgraph.middleware import AgentCorePaymentsMiddleware
+from bedrock_agentcore.payments.manager import PaymentError
+
+CHALLENGE = (
+    'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+)
+MPP_CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+
+def _make_config(**overrides):
+    defaults = {
+        "payment_manager_arn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:payment-manager/pm-1",
+        "user_id": "user-1",
+        "payment_instrument_id": "instr-1",
+        "payment_session_id": "sess-1",
+        "post_payment_retry_delay_seconds": 0,
+    }
+    defaults.update(overrides)
+    return AgentCorePaymentsConfig(**defaults)
+
+
+def _make_request(tool_name="http_request", tool_args=None, tool_id="tc-1"):
+    req = MagicMock()
+    req.tool_call = {
+        "name": tool_name,
+        "args": tool_args if tool_args is not None else {"url": "http://x.com", "headers": {}},
+        "id": tool_id,
+    }
+    return req
+
+
+def _mpp_402_content(challenge=CHALLENGE):
+    """A spec-compliant PAYMENT_REQUIRED marker carrying an MPP challenge."""
+    payload = json.dumps(
+        {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge, "content-type": "application/json"},
+            "body": {},
+        }
+    )
+    return f"PAYMENT_REQUIRED: {payload}"
+
+
+def _mpp_402_raw_content(challenge=CHALLENGE):
+    """A raw JSON 402 with no marker — exercises fallback detection."""
+    return json.dumps({"responseHeaders": {"WWW-Authenticate": challenge}, "structuredContent": {}})
+
+
+def _200_content():
+    return json.dumps({"statusCode": 200, "body": {"data": "paid content"}})
+
+
+class TestMppFallbackDetection:
+    """A header-only MPP 402 must be detected without an explicit status code."""
+
+    def test_detects_mpp_challenge_in_response_headers(self):
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(_mpp_402_raw_content())
+
+        assert detected is not None
+        assert detected["statusCode"] == 402
+        assert detected["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_detects_mpp_challenge_under_headers_key(self):
+        content = json.dumps({"headers": {"WWW-Authenticate": CHALLENGE}})
+
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(content)
+
+        assert detected is not None
+        assert detected["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_ignores_bearer_challenge(self):
+        content = json.dumps({"responseHeaders": {"WWW-Authenticate": 'Bearer realm="x"'}})
+
+        assert AgentCorePaymentsMiddleware._fallback_detect_402(content) is None
+
+    def test_x402_detection_still_takes_precedence(self):
+        content = json.dumps({"x402Version": 1, "accepts": [{"network": "base-sepolia"}]})
+
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(content)
+
+        assert detected["body"]["x402Version"] == 1
+
+    def test_non_payment_response_is_not_detected(self):
+        assert AgentCorePaymentsMiddleware._fallback_detect_402(json.dumps({"statusCode": 200})) is None
+
+
+class TestMppSyncFlow:
+    """The sync path must settle MPP 402s and retry with the Authorization header."""
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_402_then_200_on_retry(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        success = ToolMessage(content=_200_content(), tool_call_id="tc-1")
+
+        calls = [0]
+
+        def handler(req):
+            calls[0] += 1
+            if calls[0] == 1:
+                return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+            return success
+
+        result = mw.wrap_tool_call(request, handler)
+
+        assert result is success
+        assert calls[0] == 2
+        mock_pm.generate_payment_header.assert_called_once()
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_authorization_header_injected_into_tool_args(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request(tool_args={"url": "http://x.com", "headers": {}})
+
+        mw.wrap_tool_call(
+            request,
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert request.tool_call["args"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_challenge_reaches_payment_manager(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        request_arg = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request_arg["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_selection_failure_returns_error_tool_message(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP Challenge Selection: No matching challenge")
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        result = mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(return_value=ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")),
+        )
+
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == "tc-1"
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_auto_payment_disabled_skips_mpp(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mw = AgentCorePaymentsMiddleware(_make_config(auto_payment=False))
+        msg = ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+
+        result = mw.wrap_tool_call(_make_request(), MagicMock(return_value=msg))
+
+        assert result is msg
+        mock_pm.generate_payment_header.assert_not_called()
+
+    @pytest.mark.parametrize("configured", [True, False, None])
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_buyer_pays_gas_fees_is_forwarded_from_config(self, mock_pm_cls, configured):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config(buyer_pays_gas_fees=configured))
+
+        mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is configured
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_x402_flow_is_unaffected(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "sig"}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        x402 = f"PAYMENT_REQUIRED: {json.dumps({'statusCode': 402, 'headers': {}, 'body': {'x402Version': 1}})}"
+
+        mw.wrap_tool_call(
+            request,
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=x402, tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert request.tool_call["args"]["headers"]["X-PAYMENT"] == "sig"
+
+
+class TestMppAsyncFlow:
+    """The async path must behave identically to the sync path."""
+
+    @pytest.mark.asyncio
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    async def test_async_402_then_200_on_retry(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        success = ToolMessage(content=_200_content(), tool_call_id="tc-1")
+
+        calls = [0]
+
+        async def handler(req):
+            calls[0] += 1
+            if calls[0] == 1:
+                return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+            return success
+
+        result = await mw.awrap_tool_call(request, handler)
+
+        assert result is success
+        assert calls[0] == 2
+        assert request.tool_call["args"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    @pytest.mark.asyncio
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    async def test_async_selection_failure_returns_error_message(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP Challenge Selection: No matching challenge")
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        async def handler(req):
+            return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+
+        result = await mw.awrap_tool_call(_make_request(), handler)
+
+        assert isinstance(result, ToolMessage)

--- a/tests/bedrock_agentcore/payments/integrations/strands/test_mpp_plugin.py
+++ b/tests/bedrock_agentcore/payments/integrations/strands/test_mpp_plugin.py
@@ -1,0 +1,321 @@
+"""Unit tests for MPP support in the Strands payments plugin."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bedrock_agentcore.payments.integrations.config import AgentCorePaymentsPluginConfig
+from bedrock_agentcore.payments.integrations.strands.plugin import AgentCorePaymentsPlugin
+from bedrock_agentcore.payments.manager import PaymentError
+
+PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/test"
+
+CHALLENGE = (
+    'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+)
+MPP_CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+
+def _create_mock_agent():
+    """Create a mock agent with a dict-backed state object."""
+    agent = MagicMock()
+    state_store = {}
+
+    def state_get(key=None):
+        if key is None:
+            return dict(state_store)
+        return state_store.get(key)
+
+    agent.state.get = MagicMock(side_effect=state_get)
+    agent.state.set = MagicMock(side_effect=lambda k, v: state_store.__setitem__(k, v))
+    agent.state.delete = MagicMock(side_effect=lambda k: state_store.pop(k, None))
+    agent._state_store = state_store
+    return agent
+
+
+def _create_event(result, tool_input=None, agent=None, invocation_state=None):
+    """Create a mock AfterToolCallEvent carrying *result*.
+
+    Pass the same *invocation_state* dict across events to simulate consecutive
+    attempts on one tool use — the plugin tracks signing and failure state there,
+    not on agent.state.
+    """
+    event = MagicMock()
+    event.agent = agent or _create_mock_agent()
+    event.result = result
+    event.tool_use = {
+        "name": "http_request",
+        "toolUseId": "tool-123",
+        "input": tool_input if tool_input is not None else {"headers": {}},
+    }
+    event.invocation_state = invocation_state if invocation_state is not None else {}
+    event.retry = False
+    return event
+
+
+def _config(**overrides):
+    kwargs = {
+        "payment_manager_arn": PAYMENT_MANAGER_ARN,
+        "user_id": "test-user",
+        "payment_instrument_id": "payment-instrument-123",
+        "payment_session_id": "payment-session-456",
+        "post_payment_retry_delay_seconds": 0,
+    }
+    kwargs.update(overrides)
+    return AgentCorePaymentsPluginConfig(**kwargs)
+
+
+def _mpp_402_result(challenge=CHALLENGE):
+    """Build an http_request tool result carrying an MPP 402."""
+    payload = {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": challenge, "content-type": "application/json"},
+        "body": {},
+    }
+    return [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]
+
+
+def _plugin_with_manager(mock_pm, config=None):
+    plugin = AgentCorePaymentsPlugin(config=config or _config())
+    plugin.payment_manager = mock_pm
+    return plugin
+
+
+class TestStrandsPluginMppFlow:
+    """The plugin must settle MPP 402s and retry with the Authorization header."""
+
+    def test_mpp_402_triggers_payment_and_retry(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        mock_pm.generate_payment_header.assert_called_once()
+
+    def test_authorization_header_is_applied_to_tool_input(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.tool_use["input"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    def test_www_authenticate_challenge_reaches_payment_manager(self):
+        """The plugin must forward the challenge header so selection can run."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        request = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request["statusCode"] == 402
+        assert request["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_existing_request_headers_are_preserved(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result(), tool_input={"headers": {"Accept": "application/json"}})
+
+        plugin.after_tool_call(event)
+
+        headers = event.tool_use["input"]["headers"]
+        assert headers["Accept"] == "application/json"
+        assert headers["Authorization"] == MPP_CREDENTIAL
+
+    def test_headers_dict_is_created_when_absent(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result(), tool_input={"url": "https://api.example.com/resource"})
+
+        plugin.after_tool_call(event)
+
+        assert event.tool_use["input"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    def test_network_preferences_are_passed_through(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm, _config(network_preferences_config=["eip155:1"]))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["network_preferences"] == ["eip155:1"]
+
+    @pytest.mark.parametrize("configured", [True, False])
+    def test_buyer_pays_gas_fees_is_forwarded_from_config(self, configured):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm, _config(buyer_pays_gas_fees=configured))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is configured
+
+    def test_buyer_pays_gas_fees_defaults_to_none(self):
+        """Unset config must not assert a gas-fee choice on the caller's behalf."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is None
+
+    def test_non_boolean_buyer_pays_gas_fees_is_rejected_by_config(self):
+        with pytest.raises(ValueError, match="buyer_pays_gas_fees must be a boolean"):
+            _config(buyer_pays_gas_fees="yes")
+
+    def test_x402_flow_is_unaffected(self):
+        """Adding MPP must not change the existing x402 behavior."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "base64-encoded"}
+        plugin = _plugin_with_manager(mock_pm)
+        payload = {
+            "statusCode": 402,
+            "headers": {},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+        event = _create_event([{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}])
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        assert event.tool_use["input"]["headers"]["X-PAYMENT"] == "base64-encoded"
+
+
+class TestStrandsPluginMppErrors:
+    """Failures on the MPP path must surface like any other payment failure."""
+
+    def test_unsatisfiable_challenge_does_not_retry(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError(
+            "MPP Challenge Selection: No matching challenge - no advertised payment method"
+        )
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is False
+        assert "Authorization" not in event.tool_use["input"].get("headers", {})
+
+    def test_payment_failure_state_is_recorded(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP selection failed")
+        plugin = _plugin_with_manager(mock_pm)
+        invocation_state = {}
+        event = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+
+        plugin.after_tool_call(event)
+
+        failure = invocation_state.get("payment_failure_tool-123")
+        assert failure is not None, f"Expected payment failure state, got {invocation_state}"
+        assert "MPP selection failed" in str(failure)
+
+    def test_second_402_after_signing_is_not_retried(self):
+        """A 402 after a successful signing means server-side rejection."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        # invocation_state is shared across attempts on the same tool use.
+        invocation_state = {}
+
+        first = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+        plugin.after_tool_call(first)
+        assert first.retry is True
+
+        second = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+        plugin.after_tool_call(second)
+
+        assert second.retry is False
+        assert mock_pm.generate_payment_header.call_count == 1
+        assert "payment_failure_tool-123" in invocation_state
+
+    def test_auto_payment_disabled_skips_mpp(self):
+        mock_pm = MagicMock()
+        plugin = _plugin_with_manager(mock_pm, _config(auto_payment=False))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        mock_pm.generate_payment_header.assert_not_called()
+
+    def test_tool_not_in_allowlist_skips_mpp(self):
+        mock_pm = MagicMock()
+        plugin = _plugin_with_manager(mock_pm, _config(payment_tool_allowlist=["other_tool"]))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        mock_pm.generate_payment_header.assert_not_called()
+
+    def test_missing_instrument_id_raises_configuration_error(self):
+        """The setup hint must not be x402-specific now that MPP shares this path."""
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config(payment_instrument_id=None))
+        plugin.payment_manager = MagicMock()
+
+        with pytest.raises(Exception) as exc_info:
+            plugin._process_payment_required_request(
+                {"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}}
+            )
+
+        assert "payment_instrument_id is required" in str(exc_info.value)
+
+
+class TestStrandsHttpRequestToolPreservesChallenges:
+    """The built-in http_request tool must not strip WWW-Authenticate."""
+
+    def test_402_response_headers_are_forwarded_verbatim(self):
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.headers = {"WWW-Authenticate": CHALLENGE, "content-type": "application/json"}
+        mock_response.json.return_value = {}
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+            result = plugin.http_request(url="https://api.example.com/resource")
+
+        text = result["content"][0]["text"]
+        assert text.startswith("PAYMENT_REQUIRED: ")
+        payload = json.loads(text[len("PAYMENT_REQUIRED: ") :])
+        assert payload["statusCode"] == 402
+        assert payload["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_round_trip_challenge_survives_json_encoding(self):
+        """Base64url request bytes must be byte-identical after the tool's JSON hop."""
+        request_bytes = base64.urlsafe_b64encode(b'{"amount":"1000"}').decode().rstrip("=")
+        challenge = f'Payment id="x", method="evm", intent="charge", request="{request_bytes}"'
+
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.headers = {"WWW-Authenticate": challenge}
+        mock_response.json.return_value = {}
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+            result = plugin.http_request(url="https://api.example.com/resource")
+
+        text = result["content"][0]["text"]
+        payload = json.loads(text[len("PAYMENT_REQUIRED: ") :])
+        assert payload["headers"]["WWW-Authenticate"] == challenge
+        assert request_bytes in payload["headers"]["WWW-Authenticate"]

--- a/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
+++ b/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
@@ -1,0 +1,202 @@
+"""Unit tests for MPP detection in the integration payment handlers."""
+
+import json
+
+import pytest
+
+from bedrock_agentcore.payments.integrations.handlers import (
+    GenericPaymentHandler,
+    HttpRequestPaymentHandler,
+    MCPRequestPaymentHandler,
+    has_mpp_challenge,
+)
+
+CHALLENGE = 'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhIjoxfQ"'
+
+
+class TestHasMppChallenge:
+    """Tests for the header-level MPP challenge probe."""
+
+    def test_detects_canonical_header(self):
+        assert has_mpp_challenge({"WWW-Authenticate": CHALLENGE}) is True
+
+    @pytest.mark.parametrize("name", ["www-authenticate", "WWW-Authenticate", "Www-Authenticate"])
+    def test_header_name_is_case_insensitive(self, name):
+        assert has_mpp_challenge({name: CHALLENGE}) is True
+
+    def test_detects_in_list_valued_header(self):
+        assert has_mpp_challenge({"www-authenticate": ['Bearer realm="x"', CHALLENGE]}) is True
+
+    def test_scheme_name_is_case_insensitive(self):
+        assert has_mpp_challenge({"www-authenticate": 'payment id="x"'}) is True
+
+    def test_rejects_bearer_scheme(self):
+        assert has_mpp_challenge({"WWW-Authenticate": 'Bearer realm="x"'}) is False
+
+    def test_detects_payment_challenge_following_another_scheme(self):
+        """A server may offer Bearer and Payment; the Payment option must still be found."""
+        header = f'Bearer realm="api", error="invalid_token", {CHALLENGE}'
+
+        assert has_mpp_challenge({"WWW-Authenticate": header}) is True
+
+    def test_rejects_scheme_merely_prefixed_with_payment(self):
+        """`PaymentXYZ` is a different scheme, not MPP."""
+        assert has_mpp_challenge({"WWW-Authenticate": 'PaymentXYZ realm="x"'}) is False
+
+    def test_rejects_bare_payment_token_with_no_auth_params(self):
+        """Nothing to fulfill, so this must not be reported as a payment requirement."""
+        assert has_mpp_challenge({"WWW-Authenticate": "Payment"}) is False
+
+    @pytest.mark.parametrize(
+        "header_value",
+        [
+            CHALLENGE,
+            f'Bearer realm="api", {CHALLENGE}',
+            'PaymentXYZ realm="x"',
+            "Payment",
+            'Bearer realm="x"',
+            "",
+        ],
+    )
+    def test_agrees_with_the_mpp_parser(self, header_value):
+        """Detection must never disagree with the parser that does the real work."""
+        from bedrock_agentcore.payments.mpp import is_mpp_payment_required
+
+        headers = {"WWW-Authenticate": header_value}
+
+        assert has_mpp_challenge(headers) == is_mpp_payment_required({"headers": headers})
+
+    def test_rejects_missing_header(self):
+        assert has_mpp_challenge({"content-type": "application/json"}) is False
+
+    @pytest.mark.parametrize("headers", [None, "string", 42, [], {"www-authenticate": 42}])
+    def test_malformed_input_is_false(self, headers):
+        assert has_mpp_challenge(headers) is False
+
+
+class TestGenericHandlerForwardsMppHeaders:
+    """The generic handler must surface WWW-Authenticate so MPP reaches PaymentManager."""
+
+    def _result(self, payload):
+        return {"content": [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]}
+
+    def test_extracts_402_status(self):
+        handler = GenericPaymentHandler()
+        result = self._result({"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}})
+
+        assert handler.extract_status_code(result) == 402
+
+    def test_forwards_www_authenticate_header_intact(self):
+        handler = GenericPaymentHandler()
+        result = self._result({"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}})
+
+        headers = handler.extract_headers(result)
+
+        assert headers["WWW-Authenticate"] == CHALLENGE
+
+    def test_applies_authorization_header_to_tool_input(self):
+        handler = GenericPaymentHandler()
+        tool_input = {"url": "https://api.example.com/resource"}
+
+        applied = handler.apply_payment_header(tool_input, {"Authorization": "Payment eyJhIjoxfQ"})
+
+        assert applied is True
+        assert tool_input["headers"]["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_authorization_header_merges_with_existing_headers(self):
+        handler = GenericPaymentHandler()
+        tool_input = {"url": "https://x", "headers": {"Accept": "application/json"}}
+
+        handler.apply_payment_header(tool_input, {"Authorization": "Payment tok"})
+
+        assert tool_input["headers"] == {"Accept": "application/json", "Authorization": "Payment tok"}
+
+
+class TestHttpRequestHandlerForwardsMppHeaders:
+    """The http_request handler's legacy text format must also carry MPP challenges."""
+
+    def test_legacy_headers_block_python_repr(self):
+        handler = HttpRequestPaymentHandler()
+        result = {
+            "content": [
+                {"text": "Status Code: 402"},
+                {"text": "Headers: " + repr({"WWW-Authenticate": CHALLENGE})},
+            ]
+        }
+
+        assert handler.extract_status_code(result) == 402
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+    def test_spec_compliant_marker_takes_precedence(self):
+        handler = HttpRequestPaymentHandler()
+        payload = {"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}}
+        result = {"content": [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]}
+
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+
+class TestMcpHandlerMppDetection:
+    """MCP Gateway returns 200 with the requirement embedded; MPP lives in headers."""
+
+    def test_infers_402_from_mpp_challenge_in_response_headers(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": CHALLENGE}, "structuredContent": {}}
+
+        assert handler.extract_status_code(result) == 402
+
+    def test_forwards_response_headers_for_mpp(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": CHALLENGE}, "structuredContent": {}}
+
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+    def test_surfaces_structured_content_as_body_for_mpp(self):
+        handler = MCPRequestPaymentHandler()
+        result = {
+            "responseHeaders": {"WWW-Authenticate": CHALLENGE},
+            "structuredContent": {"error": "payment required"},
+        }
+
+        assert handler.extract_body(result) == {"error": "payment required"}
+
+    def test_x402_detection_is_unchanged(self):
+        handler = MCPRequestPaymentHandler()
+        x402 = {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]}
+        result = {"structuredContent": x402}
+
+        assert handler.extract_status_code(result) == 402
+        assert handler.extract_body(result) == x402
+        # No upstream headers present, so the synthetic content-type is used.
+        assert handler.extract_headers(result) == {"content-type": "application/json"}
+
+    def test_x402_prefers_real_response_headers_when_present(self):
+        handler = MCPRequestPaymentHandler()
+        result = {
+            "responseHeaders": {"content-type": "application/json", "x-request-id": "abc"},
+            "structuredContent": {"x402Version": 1, "accepts": []},
+        }
+
+        assert handler.extract_headers(result)["x-request-id"] == "abc"
+
+    def test_no_payment_requirement_returns_none(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"content-type": "application/json"}, "structuredContent": {"ok": True}}
+
+        assert handler.extract_status_code(result) is None
+        assert handler.extract_headers(result) is None
+        assert handler.extract_body(result) is None
+
+    def test_bearer_challenge_is_not_a_payment_requirement(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": 'Bearer realm="x"'}, "structuredContent": {}}
+
+        assert handler.extract_status_code(result) is None
+
+    def test_applies_authorization_header_inside_parameters(self):
+        handler = MCPRequestPaymentHandler()
+        tool_input = {"toolName": "fetch", "parameters": {"url": "https://x"}}
+
+        applied = handler.apply_payment_header(tool_input, {"Authorization": "Payment tok"})
+
+        assert applied is True
+        assert tool_input["parameters"]["headers"]["Authorization"] == "Payment tok"

--- a/tests/bedrock_agentcore/payments/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/test_mpp.py
@@ -380,7 +380,7 @@ class TestChallengeNetwork:
         [
             ("mainnet", "solana-mainnet"),
             ("devnet", "solana-devnet"),
-            ("localnet", "solana-testnet"),
+            ("testnet", "solana-testnet"),
             ("MAINNET", "solana-mainnet"),
         ],
     )
@@ -388,6 +388,35 @@ class TestChallengeNetwork:
         challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network=network)))[0]
 
         assert challenge_network(challenge) == expected
+
+    def test_localnet_is_not_aliased_to_a_public_network(self):
+        """localnet is a local RPC/Surfpool environment, not Solana testnet.
+
+        Aliasing it would let a local-only challenge satisfy a solana-testnet preference.
+        """
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network="localnet")))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_payable_devnet_challenge_outranks_localnet(self):
+        """The regression this guards: a local-only challenge must not beat a payable one."""
+        header = ", ".join(
+            [
+                challenge_header("local-1", "solana", solana_request(network="localnet")),
+                challenge_header("dev-1", "solana", solana_request(network="devnet")),
+            ]
+        )
+        challenges = parse_www_authenticate(header)
+
+        selected = select_challenge(challenges, instrument_network="SOLANA")
+
+        assert selected["id"] == "dev-1"
+
+    def test_localnet_remains_selectable_when_it_is_the_only_option(self):
+        """Unranked, not unusable — a local-only challenge is still payable if alone."""
+        challenges = parse_www_authenticate(challenge_header("local-1", "solana", solana_request(network="localnet")))
+
+        assert select_challenge(challenges, instrument_network="SOLANA")["id"] == "local-1"
 
     def test_solana_defaults_to_mainnet_when_network_absent(self):
         """Per draft-solana-charge-00, methodDetails.network is optional."""

--- a/tests/bedrock_agentcore/payments/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/test_mpp.py
@@ -1,0 +1,641 @@
+"""Unit tests for MPP (Machine Payments Protocol) challenge parsing and selection."""
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from bedrock_agentcore.payments.mpp import (
+    MppChallengeSelectionError,
+    challenge_network,
+    decode_challenge_request,
+    extract_challenges,
+    is_expired,
+    is_mpp_payment_required,
+    parse_www_authenticate,
+    select_challenge,
+)
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding, as MPP requires."""
+    raw = json.dumps(obj, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def evm_request(chain_id=84532, amount="1000000"):
+    """Build an evm-charge request object per draft-evm-charge-00."""
+    return {
+        "amount": amount,
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+
+
+def solana_request(network="devnet", amount="1000000"):
+    """Build a solana-charge request object per draft-solana-charge-00."""
+    details = {}
+    if network is not None:
+        details["network"] = network
+    return {
+        "amount": amount,
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": details,
+    }
+
+
+def challenge_header(challenge_id, method, request_obj, intent="charge", expires=None, realm="api.example.com"):
+    """Build a single 'Payment ...' WWW-Authenticate challenge value."""
+    parts = [
+        f'id="{challenge_id}"',
+        f'realm="{realm}"',
+        f'method="{method}"',
+        f'intent="{intent}"',
+        f'request="{b64url(request_obj)}"',
+    ]
+    if expires:
+        parts.append(f'expires="{expires}"')
+    return "Payment " + ", ".join(parts)
+
+
+FUTURE = "2099-04-01T12:05:00Z"
+PAST = "2020-04-01T12:05:00Z"
+
+
+class TestParseWwwAuthenticate:
+    """Tests for parsing WWW-Authenticate header values into challenges."""
+
+    def test_parses_single_challenge_auth_params(self):
+        header = challenge_header("aB3cDeF4gHiJkLmN", "evm", evm_request(), expires=FUTURE)
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        c = challenges[0]
+        assert c["id"] == "aB3cDeF4gHiJkLmN"
+        assert c["realm"] == "api.example.com"
+        assert c["method"] == "evm"
+        assert c["intent"] == "charge"
+        assert c["expires"] == FUTURE
+        assert c["request"]
+
+    def test_parses_multiple_challenges_in_one_header_value(self):
+        header = ", ".join(
+            [
+                challenge_header("evm-1", "evm", evm_request()),
+                challenge_header("sol-1", "solana", solana_request()),
+            ]
+        )
+
+        challenges = parse_www_authenticate(header)
+
+        assert [c["id"] for c in challenges] == ["evm-1", "sol-1"]
+        assert [c["method"] for c in challenges] == ["evm", "solana"]
+
+    def test_preserves_raw_header_verbatim_per_challenge(self):
+        """The raw value must round-trip so the challenge HMAC stays valid."""
+        first = challenge_header("evm-1", "evm", evm_request())
+        second = challenge_header("sol-1", "solana", solana_request())
+
+        challenges = parse_www_authenticate(f"{first}, {second}")
+
+        # Each challenge's raw value contains only its own auth-params.
+        assert "evm-1" in challenges[0]["raw"]
+        assert "sol-1" not in challenges[0]["raw"]
+        assert "sol-1" in challenges[1]["raw"]
+        assert "evm-1" not in challenges[1]["raw"]
+        # The base64url request bytes survive unchanged.
+        assert b64url(evm_request()) in challenges[0]["raw"]
+
+    def test_ignores_non_payment_schemes(self):
+        header = 'Bearer realm="example", ' + challenge_header("evm-1", "evm", evm_request())
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["id"] == "evm-1"
+
+    def test_bearer_only_yields_no_challenges(self):
+        assert parse_www_authenticate('Bearer realm="example", error="invalid_token"') == []
+
+    def test_scheme_after_payment_does_not_leak_into_challenge(self):
+        """A trailing scheme's params must not be absorbed into the MPP challenge.
+
+        Leaking them would also corrupt the ``raw`` value forwarded to the service,
+        breaking the challenge HMAC.
+        """
+        header = challenge_header("evm-1", "evm", evm_request()) + ', Bearer realm="api", error="invalid_token"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert "realm" in challenges[0]  # the challenge's own realm, not Bearer's
+        assert challenges[0]["realm"] == "api.example.com"
+        assert "error" not in challenges[0]
+        assert "Bearer" not in challenges[0]["raw"]
+        assert "invalid_token" not in challenges[0]["raw"]
+
+    @pytest.mark.parametrize("other_scheme", ['Bearer realm="api"', 'Basic realm="corp"', "Negotiate"])
+    def test_trailing_schemes_are_excluded_from_raw(self, other_scheme):
+        header = f"{challenge_header('evm-1', 'evm', evm_request())}, {other_scheme}"
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["raw"] == challenge_header("evm-1", "evm", evm_request())
+
+    def test_foreign_scheme_between_two_payment_challenges(self):
+        header = ", ".join(
+            [
+                challenge_header("evm-1", "evm", evm_request()),
+                'Bearer realm="api"',
+                challenge_header("sol-1", "solana", solana_request()),
+            ]
+        )
+
+        challenges = parse_www_authenticate(header)
+
+        assert [c["id"] for c in challenges] == ["evm-1", "sol-1"]
+        assert all("Bearer" not in c["raw"] for c in challenges)
+
+    def test_quoted_value_containing_spaces_is_not_mistaken_for_a_scheme(self):
+        """`description="fast access now"` is an auth-param, not a new scheme."""
+        header = 'Payment id="x", method="evm", description="fast access now"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["description"] == "fast access now"
+
+    def test_scheme_name_is_case_insensitive(self):
+        challenges = parse_www_authenticate('payment id="x", method="evm", intent="charge"')
+
+        assert len(challenges) == 1
+        assert challenges[0]["id"] == "x"
+
+    def test_auth_param_keys_are_lowercased(self):
+        challenges = parse_www_authenticate('Payment ID="x", Method="evm"')
+
+        assert challenges[0]["id"] == "x"
+        assert challenges[0]["method"] == "evm"
+
+    def test_commas_inside_quoted_values_are_not_split(self):
+        header = 'Payment id="x", method="evm", description="Premium, fast access"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["description"] == "Premium, fast access"
+
+    def test_escaped_quote_inside_quoted_value(self):
+        header = 'Payment id="x", method="evm", description="a \\"quoted\\" word"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert challenges[0]["description"] == 'a "quoted" word'
+
+    def test_unknown_auth_params_are_retained_not_rejected(self):
+        """The spec requires clients to ignore unknown params, not fail on them."""
+        header = 'Payment id="x", method="evm", intent="charge", futureParam="v", opaque="o"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["futureparam"] == "v"
+        assert challenges[0]["opaque"] == "o"
+
+    def test_unquoted_values_are_accepted(self):
+        challenges = parse_www_authenticate("Payment id=abc, method=evm, intent=charge")
+
+        assert challenges[0]["id"] == "abc"
+        assert challenges[0]["method"] == "evm"
+
+    @pytest.mark.parametrize("value", ["", None, 123, [], {}])
+    def test_invalid_input_returns_empty_list(self, value):
+        assert parse_www_authenticate(value) == []
+
+    def test_bare_payment_scheme_without_params_is_dropped(self):
+        assert parse_www_authenticate("Payment") == []
+
+
+class TestExtractChallenges:
+    """Tests for pulling challenges out of a 402 payment required request."""
+
+    def test_extracts_from_canonical_header_name(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert [c["id"] for c in extract_challenges(req)] == ["evm-1"]
+
+    @pytest.mark.parametrize("header_name", ["www-authenticate", "WWW-Authenticate", "Www-Authenticate"])
+    def test_header_lookup_is_case_insensitive(self, header_name):
+        req = {
+            "statusCode": 402,
+            "headers": {header_name: challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert len(extract_challenges(req)) == 1
+
+    def test_extracts_from_list_valued_header(self):
+        """Some HTTP clients expose repeated headers as a list."""
+        req = {
+            "statusCode": 402,
+            "headers": {
+                "www-authenticate": [
+                    challenge_header("evm-1", "evm", evm_request()),
+                    challenge_header("sol-1", "solana", solana_request()),
+                ]
+            },
+            "body": {},
+        }
+
+        assert [c["id"] for c in extract_challenges(req)] == ["evm-1", "sol-1"]
+
+    def test_no_www_authenticate_header_yields_nothing(self):
+        req = {"statusCode": 402, "headers": {"content-type": "application/json"}, "body": {}}
+
+        assert extract_challenges(req) == []
+
+    @pytest.mark.parametrize("headers", [None, "not-a-dict", 42, []])
+    def test_malformed_headers_yield_nothing(self, headers):
+        assert extract_challenges({"statusCode": 402, "headers": headers, "body": {}}) == []
+
+
+class TestIsMppPaymentRequired:
+    """Tests for protocol detection used to route 402s to the MPP path."""
+
+    def test_true_for_mpp_challenge(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(req) is True
+
+    def test_false_for_x402_body_payload(self):
+        """An x402 402 must not be misrouted to MPP."""
+        req = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+
+        assert is_mpp_payment_required(req) is False
+
+    def test_false_for_x402_v2_payment_required_header(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"payment-required": "eyJ4NDAyVmVyc2lvbiI6Mn0="},
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(req) is False
+
+    def test_false_for_bearer_challenge(self):
+        req = {"statusCode": 402, "headers": {"WWW-Authenticate": 'Bearer realm="x"'}, "body": {}}
+
+        assert is_mpp_payment_required(req) is False
+
+    @pytest.mark.parametrize("value", [None, "string", 42, []])
+    def test_non_dict_input_is_false(self, value):
+        assert is_mpp_payment_required(value) is False
+
+
+class TestDecodeChallengeRequest:
+    """Tests for decoding the base64url JCS-JSON request auth-param."""
+
+    def test_decodes_evm_request(self):
+        challenge = parse_www_authenticate(challenge_header("evm-1", "evm", evm_request(chain_id=8453)))[0]
+
+        request = decode_challenge_request(challenge)
+
+        assert request["amount"] == "1000000"
+        assert request["methodDetails"]["chainId"] == 8453
+
+    def test_decodes_unpadded_base64url(self):
+        """MPP encodes base64url without padding; decoding must restore it."""
+        payload = {"amount": "1", "currency": "sol", "recipient": "r"}
+        encoded = b64url(payload)
+        assert not encoded.endswith("=")
+
+        challenge = parse_www_authenticate(f'Payment id="x", method="solana", request="{encoded}"')[0]
+
+        assert decode_challenge_request(challenge) == payload
+
+    @pytest.mark.parametrize(
+        "bad_request",
+        ['request="!!!not-base64!!!"', 'request="' + base64.urlsafe_b64encode(b"not json").decode() + '"'],
+    )
+    def test_undecodable_request_returns_empty_dict(self, bad_request):
+        challenge = parse_www_authenticate(f'Payment id="x", method="evm", {bad_request}')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+    def test_missing_request_returns_empty_dict(self):
+        challenge = parse_www_authenticate('Payment id="x", method="evm"')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+    def test_non_object_json_returns_empty_dict(self):
+        encoded = base64.urlsafe_b64encode(b'["a","list"]').decode().rstrip("=")
+        challenge = parse_www_authenticate(f'Payment id="x", method="evm", request="{encoded}"')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+
+class TestChallengeNetwork:
+    """Tests for deriving a preference-orderable network identifier."""
+
+    @pytest.mark.parametrize(
+        "chain_id,expected",
+        [(8453, "eip155:8453"), (1, "eip155:1"), (84532, "eip155:84532"), (4326, "eip155:4326")],
+    )
+    def test_evm_chain_id_maps_to_eip155(self, chain_id, expected):
+        challenge = parse_www_authenticate(challenge_header("x", "evm", evm_request(chain_id=chain_id)))[0]
+
+        assert challenge_network(challenge) == expected
+
+    def test_tempo_uses_evm_chain_id_mapping(self):
+        challenge = parse_www_authenticate(challenge_header("x", "tempo", evm_request(chain_id=4326)))[0]
+
+        assert challenge_network(challenge) == "eip155:4326"
+
+    def test_evm_string_chain_id_is_coerced(self):
+        request = evm_request()
+        request["methodDetails"]["chainId"] = "8453"
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) == "eip155:8453"
+
+    @pytest.mark.parametrize(
+        "network,expected",
+        [
+            ("mainnet", "solana-mainnet"),
+            ("devnet", "solana-devnet"),
+            ("localnet", "solana-testnet"),
+            ("MAINNET", "solana-mainnet"),
+        ],
+    )
+    def test_solana_network_maps_to_identifier(self, network, expected):
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network=network)))[0]
+
+        assert challenge_network(challenge) == expected
+
+    def test_solana_defaults_to_mainnet_when_network_absent(self):
+        """Per draft-solana-charge-00, methodDetails.network is optional."""
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network=None)))[0]
+
+        assert challenge_network(challenge) == "solana-mainnet"
+
+    def test_missing_chain_id_returns_none(self):
+        request = evm_request()
+        del request["methodDetails"]["chainId"]
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_boolean_chain_id_returns_none(self):
+        """bool is an int subclass; chainId=True must not become eip155:1."""
+        request = evm_request()
+        request["methodDetails"]["chainId"] = True
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_unknown_method_returns_none(self):
+        challenge = parse_www_authenticate(challenge_header("x", "bitcoin", evm_request()))[0]
+
+        assert challenge_network(challenge) is None
+
+
+class TestIsExpired:
+    """Tests for challenge expiry evaluation."""
+
+    def test_past_expires_is_expired(self):
+        challenge = {"id": "x", "expires": PAST}
+
+        assert is_expired(challenge) is True
+
+    def test_future_expires_is_not_expired(self):
+        challenge = {"id": "x", "expires": FUTURE}
+
+        assert is_expired(challenge) is False
+
+    def test_missing_expires_is_not_expired(self):
+        assert is_expired({"id": "x"}) is False
+
+    def test_unparseable_expires_is_not_expired(self):
+        """Prefer attempting a challenge over discarding one we failed to parse."""
+        assert is_expired({"id": "x", "expires": "not-a-date"}) is False
+
+    def test_expiry_exactly_now_is_expired(self):
+        now = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        assert is_expired({"expires": "2026-04-01T12:00:00Z"}, now=now) is True
+
+    def test_offset_timezone_is_honoured(self):
+        now = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        # 13:30+02:00 == 11:30Z, already past.
+        assert is_expired({"expires": "2026-04-01T13:30:00+02:00"}, now=now) is True
+        # 15:30+02:00 == 13:30Z, still ahead.
+        assert is_expired({"expires": "2026-04-01T15:30:00+02:00"}, now=now) is False
+
+    def test_naive_datetime_reference_is_treated_as_utc(self):
+        naive_now = datetime(2026, 4, 1, 12, 0, 0)
+
+        assert is_expired({"expires": "2026-04-01T11:00:00Z"}, now=naive_now) is True
+
+
+class TestSelectChallenge:
+    """Tests for the challenge selection algorithm."""
+
+    def _parse(self, *headers):
+        return parse_www_authenticate(", ".join(headers))
+
+    def test_selects_solana_challenge_for_solana_instrument(self):
+        challenges = self._parse(
+            challenge_header("evm-1", "evm", evm_request()),
+            challenge_header("sol-1", "solana", solana_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="SOLANA")
+
+        assert selected["id"] == "sol-1"
+
+    def test_selects_evm_challenge_for_ethereum_instrument(self):
+        challenges = self._parse(
+            challenge_header("sol-1", "solana", solana_request()),
+            challenge_header("evm-1", "evm", evm_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "evm-1"
+
+    def test_tempo_is_satisfied_by_ethereum_instrument(self):
+        challenges = self._parse(challenge_header("tempo-1", "tempo", evm_request(chain_id=4326)))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "tempo-1"
+
+    def test_instrument_network_is_case_insensitive(self):
+        challenges = self._parse(challenge_header("sol-1", "solana", solana_request()))
+
+        assert select_challenge(challenges, instrument_network="solana")["id"] == "sol-1"
+
+    def test_network_preference_order_decides_among_same_family(self):
+        """Base mainnet (eip155:8453) outranks Ethereum mainnet in NETWORK_PREFERENCES."""
+        challenges = self._parse(
+            challenge_header("eth-mainnet", "evm", evm_request(chain_id=1)),
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "base"
+
+    def test_explicit_network_preferences_override_default(self):
+        challenges = self._parse(
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+            challenge_header("eth-mainnet", "evm", evm_request(chain_id=1)),
+        )
+
+        selected = select_challenge(
+            challenges,
+            instrument_network="ETHEREUM",
+            network_preferences=["eip155:1", "eip155:8453"],
+        )
+
+        assert selected["id"] == "eth-mainnet"
+
+    def test_unsupported_intent_is_filtered_out(self):
+        challenges = self._parse(
+            challenge_header("sub-1", "evm", evm_request(), intent="subscription"),
+            challenge_header("charge-1", "evm", evm_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "charge-1"
+
+    def test_all_non_charge_intents_raises(self):
+        challenges = self._parse(
+            challenge_header("s-1", "evm", evm_request(), intent="session"),
+            challenge_header("s-2", "evm", evm_request(), intent="subscription"),
+        )
+
+        with pytest.raises(MppChallengeSelectionError, match="charge"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_absent_intent_is_treated_as_charge(self):
+        challenges = parse_www_authenticate(f'Payment id="x", method="evm", request="{b64url(evm_request())}"')
+
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["id"] == "x"
+
+    def test_expired_challenge_is_filtered_out(self):
+        challenges = self._parse(
+            challenge_header("old", "evm", evm_request(), expires=PAST),
+            challenge_header("fresh", "evm", evm_request(), expires=FUTURE),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "fresh"
+
+    def test_all_expired_raises(self):
+        challenges = self._parse(challenge_header("old", "evm", evm_request(), expires=PAST))
+
+        with pytest.raises(MppChallengeSelectionError, match="expired"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_soonest_expiry_wins_when_network_rank_ties(self):
+        soon = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        later = (datetime.now(timezone.utc) + timedelta(hours=5)).isoformat().replace("+00:00", "Z")
+        challenges = self._parse(
+            challenge_header("later", "evm", evm_request(chain_id=8453), expires=later),
+            challenge_header("soon", "evm", evm_request(chain_id=8453), expires=soon),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "soon"
+
+    def test_bounded_offer_preferred_over_unbounded_on_tie(self):
+        soon = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        challenges = self._parse(
+            challenge_header("no-expiry", "evm", evm_request(chain_id=8453)),
+            challenge_header("bounded", "evm", evm_request(chain_id=8453), expires=soon),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "bounded"
+
+    def test_server_order_breaks_full_tie(self):
+        challenges = self._parse(
+            challenge_header("first", "evm", evm_request(chain_id=8453)),
+            challenge_header("second", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "first"
+
+    def test_unknown_network_still_selectable_when_it_is_the_only_option(self):
+        """A challenge on an unranked chain must not be silently unusable."""
+        challenges = self._parse(challenge_header("exotic", "evm", evm_request(chain_id=999999)))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "exotic"
+
+    def test_ranked_network_beats_unranked(self):
+        challenges = self._parse(
+            challenge_header("exotic", "evm", evm_request(chain_id=999999)),
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "base"
+
+    def test_no_matching_method_raises_with_advertised_methods(self):
+        challenges = self._parse(challenge_header("sol-1", "solana", solana_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="solana"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_unknown_method_is_not_satisfiable(self):
+        challenges = self._parse(challenge_header("btc-1", "bitcoin", evm_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="No matching challenge"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_empty_challenge_list_raises(self):
+        with pytest.raises(MppChallengeSelectionError, match="No challenges"):
+            select_challenge([], instrument_network="ETHEREUM")
+
+    @pytest.mark.parametrize("network", ["BITCOIN", "", None, "  "])
+    def test_unsupported_instrument_network_raises(self, network):
+        challenges = self._parse(challenge_header("evm-1", "evm", evm_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="[Uu]nsupported instrument network"):
+            select_challenge(challenges, instrument_network=network)
+
+    def test_selected_challenge_retains_raw_header(self):
+        challenges = self._parse(challenge_header("evm-1", "evm", evm_request()))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["raw"].startswith("Payment ")
+        assert 'id="evm-1"' in selected["raw"]

--- a/tests/bedrock_agentcore/payments/test_mpp_manager.py
+++ b/tests/bedrock_agentcore/payments/test_mpp_manager.py
@@ -1,0 +1,494 @@
+"""Unit tests for the MPP payment path on PaymentManager."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bedrock_agentcore.payments.manager import PaymentError, PaymentManager
+
+PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-abc123"
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding."""
+    return base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode()).decode().rstrip("=")
+
+
+def evm_request(chain_id=84532):
+    return {
+        "amount": "1000000",
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+
+
+def solana_request(network="devnet"):
+    return {
+        "amount": "1000000",
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": {"network": network},
+    }
+
+
+def challenge_header(challenge_id, method, request_obj, intent="charge"):
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="{method}", '
+        f'intent="{intent}", request="{b64url(request_obj)}"'
+    )
+
+
+def mpp_402(*headers):
+    """Build a 402 payment required request advertising the given challenges."""
+    return {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": ", ".join(headers)},
+        "body": {},
+    }
+
+
+@pytest.fixture
+def manager():
+    """A PaymentManager with a mocked data-plane client."""
+    with patch("boto3.Session") as mock_session:
+        mock_session.return_value.region_name = "us-west-2"
+        mgr = PaymentManager(payment_manager_arn=PAYMENT_MANAGER_ARN, region_name="us-west-2")
+    mgr._payment_client = MagicMock()
+    return mgr
+
+
+def set_instrument_network(manager, network):
+    manager._payment_client.get_payment_instrument.return_value = {
+        "paymentInstrument": {
+            "paymentInstrumentId": "pi-1",
+            "paymentInstrumentDetails": {"embeddedCryptoWallet": {"network": network}},
+        }
+    }
+
+
+def set_mpp_result(manager, selected_payment_id="evm-1", credential="eyJjaGFsbGVuZ2UiOnt9fQ", version="1"):
+    manager._payment_client.process_payment.return_value = {
+        "processPayment": {
+            "processPaymentId": "pp-1",
+            "status": "PROOF_GENERATED",
+            "paymentOutput": {
+                "mpp": {
+                    "version": version,
+                    "selectedPaymentId": selected_payment_id,
+                    "paymentCredential": credential,
+                }
+            },
+        }
+    }
+
+
+class TestMppRouting:
+    """generate_payment_header must route by detected protocol."""
+
+    def test_mpp_402_returns_authorization_header(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header == {"Authorization": "Payment eyJhIjoxfQ"}
+
+    def test_mpp_sends_payment_type_mpp(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        kwargs = manager._payment_client.process_payment.call_args.kwargs
+        assert kwargs["paymentType"] == "MPP"
+        assert "cryptoX402" not in kwargs["paymentInput"]
+
+    def test_raw_challenge_header_is_forwarded_verbatim(self, manager):
+        """The challenge HMAC binds to the exact request bytes, so no re-encoding."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+        raw = challenge_header("evm-1", "evm", evm_request())
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(raw),
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert sent["wwwAuthenticateHeaders"] == [raw]
+        assert b64url(evm_request()) in sent["wwwAuthenticateHeaders"][0]
+
+    def test_exactly_one_challenge_is_sent(self, manager):
+        """The service model constrains wwwAuthenticateHeaders to a single entry."""
+        set_instrument_network(manager, "SOLANA")
+        set_mpp_result(manager, selected_payment_id="sol-1")
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(
+                challenge_header("evm-1", "evm", evm_request()),
+                challenge_header("sol-1", "solana", solana_request()),
+            ),
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert len(sent["wwwAuthenticateHeaders"]) == 1
+        assert 'id="sol-1"' in sent["wwwAuthenticateHeaders"][0]
+
+    def test_mpp_version_is_numeric_string(self, manager):
+        """The model constrains version to ^[0-9]+$."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        version = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]["version"]
+        assert version.isdigit()
+
+    def test_x402_402_still_uses_crypto_x402_path(self, manager):
+        """MPP detection must not regress the existing x402 flow."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+        x402_request = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {
+                "x402Version": 1,
+                "accepts": [{"scheme": "exact", "network": "base-sepolia", "maxAmountRequired": "1000"}],
+            },
+        }
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=x402_request,
+        )
+
+        assert "X-PAYMENT" in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "CRYPTO_X402"
+
+    def test_client_token_is_forwarded(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            client_token="my-token-123",
+        )
+
+        assert manager._payment_client.process_payment.call_args.kwargs["clientToken"] == "my-token-123"
+
+    def _mpp_input(self, manager):
+        return manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+
+    def _process_mpp(self, manager, **kwargs):
+        return manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            **kwargs,
+        )
+
+    def test_buyer_pays_gas_fees_omitted_when_not_specified(self, manager):
+        """Omitting the field must leave the service-side protocol default in place."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager)
+
+        assert "buyerPaysGasFees" not in self._mpp_input(manager)
+
+    def test_buyer_pays_gas_fees_true_is_forwarded(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=True)
+
+        assert self._mpp_input(manager)["buyerPaysGasFees"] is True
+
+    def test_buyer_pays_gas_fees_false_is_forwarded_explicitly(self, manager):
+        """False is a deliberate refusal and must be sent, not treated as unset."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=False)
+
+        assert self._mpp_input(manager)["buyerPaysGasFees"] is False
+
+    @pytest.mark.parametrize("value,expected", [(1, True), (0, False)])
+    def test_buyer_pays_gas_fees_is_coerced_to_bool(self, manager, value, expected):
+        """The model types this as Boolean, so truthy inputs must not leak through as ints."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=value)
+
+        forwarded = self._mpp_input(manager)["buyerPaysGasFees"]
+        assert forwarded is expected
+        assert isinstance(forwarded, bool)
+
+    def test_buyer_pays_gas_fees_not_sent_on_x402_path(self, manager):
+        """The field is MPP-only and must never appear in a cryptoX402 input."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request={
+                "statusCode": 402,
+                "headers": {"content-type": "application/json"},
+                "body": {"x402Version": 1, "accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+            },
+            buyer_pays_gas_fees=True,
+        )
+
+        payment_input = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]
+        assert "mpp" not in payment_input
+        assert "buyerPaysGasFees" not in payment_input["cryptoX402"]
+
+    def test_network_preferences_are_applied(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="eth-1")
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(
+                challenge_header("base-1", "evm", evm_request(chain_id=8453)),
+                challenge_header("eth-1", "evm", evm_request(chain_id=1)),
+            ),
+            network_preferences=["eip155:1", "eip155:8453"],
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert 'id="eth-1"' in sent["wwwAuthenticateHeaders"][0]
+
+    def test_non_402_status_code_is_rejected(self, manager):
+        request = mpp_402(challenge_header("evm-1", "evm", evm_request()))
+        request["statusCode"] = 200
+
+        with pytest.raises(PaymentError, match="Expected statusCode 402"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=request,
+            )
+
+
+class TestMppCredentialHandling:
+    """Tests for turning the service's output into an Authorization header."""
+
+    def test_scheme_prefix_is_added_when_absent(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_existing_scheme_prefix_is_not_duplicated(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="Payment eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_missing_mpp_output_raises(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {}}}}
+        }
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    @pytest.mark.parametrize(
+        "payment_output",
+        [
+            None,
+            {"mpp": None},
+            {"mpp": "not-a-dict"},
+            {"mpp": {}},
+            {"mpp": []},
+        ],
+    )
+    def test_malformed_payment_output_raises_actionable_error(self, manager, payment_output):
+        """A null or non-object member must name the field, not leak an AttributeError."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {"processPayment": {"paymentOutput": payment_output}}
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    @pytest.mark.parametrize("credential", [None, "", "   ", 123])
+    def test_missing_credential_raises(self, manager, credential):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {
+                "paymentOutput": {
+                    "mpp": {
+                        "version": "1",
+                        "selectedPaymentId": "evm-1",
+                        "paymentCredential": credential,
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(PaymentError, match="Missing paymentCredential"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_challenge_id_mismatch_raises(self, manager):
+        """Attaching a credential for a challenge we did not select would fail upstream."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="some-other-id")
+
+        with pytest.raises(PaymentError, match="Challenge mismatch"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_absent_selected_payment_id_is_tolerated(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"mpp": {"version": "1", "paymentCredential": "eyJhIjoxfQ"}}}
+        }
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+
+class TestMppSelectionErrors:
+    """Selection failures must surface as PaymentError, not leak internal types."""
+
+    def test_no_satisfiable_method_raises_payment_error(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError, match="No matching challenge"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("sol-1", "solana", solana_request())),
+            )
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_unsupported_instrument_network_raises_payment_error(self, manager):
+        set_instrument_network(manager, "BITCOIN")
+
+        with pytest.raises(PaymentError, match="[Uu]nsupported instrument network"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_instrument_without_network_raises(self, manager):
+        manager._payment_client.get_payment_instrument.return_value = {
+            "paymentInstrument": {"paymentInstrumentId": "pi-1", "paymentInstrumentDetails": {}}
+        }
+
+        with pytest.raises(PaymentError, match="Missing network information"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+
+class TestMppBearerAuth:
+    """MPP must work under CUSTOM_JWT bearer auth, where userId is omitted."""
+
+    def test_bearer_auth_omits_user_id(self):
+        with patch("boto3.Session") as mock_session:
+            mock_session.return_value.region_name = "us-west-2"
+            mgr = PaymentManager(
+                payment_manager_arn=PAYMENT_MANAGER_ARN,
+                region_name="us-west-2",
+                bearer_token="jwt-token",
+            )
+        mgr._payment_client = MagicMock()
+        set_instrument_network(mgr, "ETHEREUM")
+        set_mpp_result(mgr)
+
+        header = mgr.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert "Authorization" in header
+        assert "userId" not in mgr._payment_client.process_payment.call_args.kwargs

--- a/tests/bedrock_agentcore/payments/test_mpp_manager.py
+++ b/tests/bedrock_agentcore/payments/test_mpp_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from bedrock_agentcore.payments.manager import PaymentError, PaymentManager
+from bedrock_agentcore.payments.manager import InsufficientBudget, PaymentError, PaymentManager
 
 PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-abc123"
 
@@ -244,16 +244,41 @@ class TestMppRouting:
 
         assert self._mpp_input(manager)["buyerPaysGasFees"] is False
 
-    @pytest.mark.parametrize("value,expected", [(1, True), (0, False)])
-    def test_buyer_pays_gas_fees_is_coerced_to_bool(self, manager, value, expected):
-        """The model types this as Boolean, so truthy inputs must not leak through as ints."""
+    @pytest.mark.parametrize("value", ["false", "true", "no", 1, 0, [], {"a": 1}])
+    def test_non_boolean_buyer_pays_gas_fees_is_rejected_not_coerced(self, manager, value):
+        """Coercion would let the string "false" authorize wallet charges.
+
+        Every non-empty string is truthy, so bool("false") is True. Authorizing network
+        fees must be unambiguous, so non-bool values are rejected rather than coerced.
+        """
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        with pytest.raises(PaymentError, match="buyer_pays_gas_fees must be a boolean or None"):
+            self._process_mpp(manager, buyer_pays_gas_fees=value)
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_string_false_never_authorizes_gas_fees(self, manager):
+        """Regression guard for the specific money-moving misread."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        with pytest.raises(PaymentError):
+            self._process_mpp(manager, buyer_pays_gas_fees="false")
+
+        # Nothing was sent at all, so nothing could have been authorized.
+        manager._payment_client.process_payment.assert_not_called()
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_values_are_forwarded_unchanged(self, manager, value):
         set_instrument_network(manager, "ETHEREUM")
         set_mpp_result(manager)
 
         self._process_mpp(manager, buyer_pays_gas_fees=value)
 
         forwarded = self._mpp_input(manager)["buyerPaysGasFees"]
-        assert forwarded is expected
+        assert forwarded is value
         assert isinstance(forwarded, bool)
 
     def test_buyer_pays_gas_fees_not_sent_on_x402_path(self, manager):
@@ -426,6 +451,121 @@ class TestMppCredentialHandling:
         )
 
         assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+
+class TestDualProtocolFallback:
+    """A 402 may advertise both MPP and x402; an unsatisfiable MPP option must not fail it."""
+
+    X402_BODY = {
+        "x402Version": 1,
+        "accepts": [{"scheme": "exact", "network": "base-sepolia", "maxAmountRequired": "1000"}],
+    }
+
+    def _dual_402(self, challenge, body=None):
+        return {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge},
+            "body": body if body is not None else self.X402_BODY,
+        }
+
+    def _set_x402_result(self, manager):
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+
+    def _generate(self, manager, challenge, body=None):
+        return manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=self._dual_402(challenge, body),
+        )
+
+    def test_mpp_is_preferred_when_satisfiable(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="evm-1")
+
+        header = self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        assert "Authorization" in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "MPP"
+
+    def test_falls_back_to_x402_when_mpp_is_unsatisfiable(self, manager):
+        """A SOLANA-only MPP challenge with an ETHEREUM instrument must use the x402 option."""
+        set_instrument_network(manager, "ETHEREUM")
+        self._set_x402_result(manager)
+
+        header = self._generate(manager, challenge_header("sol-1", "solana", solana_request()))
+
+        assert "X-PAYMENT" in header
+        assert "Authorization" not in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "CRYPTO_X402"
+
+    def test_raises_when_mpp_unsatisfiable_and_no_x402_present(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError, match="No matching challenge"):
+            self._generate(manager, challenge_header("sol-1", "solana", solana_request()), body={})
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"x402Version": 1, "accepts": []},
+            {"x402Version": 1},
+            {"accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+        ],
+    )
+    def test_no_fallback_without_a_usable_x402_option(self, manager, body):
+        """An absent, empty or malformed x402 payload is not a fallback target."""
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError):
+            self._generate(manager, challenge_header("sol-1", "solana", solana_request()), body=body)
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_post_submission_failure_does_not_fall_back(self, manager):
+        """Falling back after a submitted payment could charge the buyer twice."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.side_effect = InsufficientBudget("Insufficient budget")
+
+        with pytest.raises(PaymentError):
+            self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        attempts = [c.kwargs["paymentType"] for c in manager._payment_client.process_payment.call_args_list]
+        assert attempts == ["MPP"], f"Expected exactly one submission, got {attempts}"
+
+    def test_missing_mpp_output_does_not_fall_back(self, manager):
+        """A malformed MPP response is post-submission, so it must not retry as x402."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {"processPayment": {"paymentOutput": {}}}
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        attempts = [c.kwargs["paymentType"] for c in manager._payment_client.process_payment.call_args_list]
+        assert attempts == ["MPP"]
+
+    def test_x402_only_402_is_unaffected(self, manager):
+        """No MPP challenge present — the x402 path must behave exactly as before."""
+        set_instrument_network(manager, "ETHEREUM")
+        self._set_x402_result(manager)
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request={
+                "statusCode": 402,
+                "headers": {"content-type": "application/json"},
+                "body": self.X402_BODY,
+            },
+        )
+
+        assert "X-PAYMENT" in header
 
 
 class TestMppSelectionErrors:

--- a/tests/bedrock_agentcore/payments/test_mpp_model_patch.py
+++ b/tests/bedrock_agentcore/payments/test_mpp_model_patch.py
@@ -1,0 +1,254 @@
+"""Unit tests for the MPP service-model patch.
+
+These tests exercise the patch against a real boto3 client so they fail loudly if a
+future botocore release changes the internals the patch relies on, or ships MPP
+natively (in which case the patch must become a no-op rather than double-apply).
+"""
+
+from unittest.mock import MagicMock
+
+import botocore.session
+import pytest
+from botocore.exceptions import ParamValidationError
+
+from bedrock_agentcore.payments._model_patch import patch_process_payment_model
+
+PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-abcdefghij"
+
+
+def make_client():
+    """Build a client whose service model is isolated from other clients.
+
+    botocore caches loaded service models per-session, so clients from the same
+    session share one shape map — patching one would leak into the others and make
+    these tests order-dependent. A fresh botocore Session gives each client its own
+    copy of the model.
+    """
+    return botocore.session.Session().create_client(
+        "bedrock-agentcore",
+        region_name="us-west-2",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+    )
+
+
+@pytest.fixture
+def client():
+    """A bedrock-agentcore client with an isolated service model and dummy credentials."""
+    return make_client()
+
+
+def shape_map(client):
+    return client.meta.service_model._shape_resolver._shape_map
+
+
+class TestPatchProcessPaymentModel:
+    """Tests for injecting MPP shapes into the loaded service model."""
+
+    def test_adds_mpp_member_to_payment_input_union(self, client):
+        patch_process_payment_model(client)
+
+        assert "mpp" in shape_map(client)["PaymentInput"]["members"]
+
+    def test_adds_mpp_member_to_payment_output_union(self, client):
+        patch_process_payment_model(client)
+
+        assert "mpp" in shape_map(client)["PaymentOutput"]["members"]
+
+    def test_adds_mpp_to_payment_type_enum(self, client):
+        patch_process_payment_model(client)
+
+        assert "MPP" in shape_map(client)["PaymentType"]["enum"]
+
+    def test_preserves_existing_crypto_x402_member(self, client):
+        patch_process_payment_model(client)
+
+        assert "cryptoX402" in shape_map(client)["PaymentInput"]["members"]
+        assert "CRYPTO_X402" in shape_map(client)["PaymentType"]["enum"]
+
+    def test_is_idempotent(self, client):
+        assert patch_process_payment_model(client) is True
+        assert patch_process_payment_model(client) is False
+
+        # The enum must not accumulate duplicates.
+        assert shape_map(client)["PaymentType"]["enum"].count("MPP") == 1
+
+    def test_returns_false_when_model_already_supports_mpp(self, client):
+        """Once botocore ships MPP natively, the patch must do nothing."""
+        shape_map(client)["PaymentInput"]["members"]["mpp"] = {"shape": "MppPaymentInput"}
+
+        assert patch_process_payment_model(client) is False
+
+    def test_returns_false_on_unexpected_botocore_internals(self):
+        """A botocore refactor must degrade quietly, not raise at client init."""
+        broken = MagicMock()
+        del broken.meta.service_model._shape_resolver._shape_map
+
+        assert patch_process_payment_model(broken) is False
+
+    def test_injected_shapes_carry_the_modelled_constraints(self, client):
+        """The shapes must mirror the service Smithy model.
+
+        botocore enforces only some of these client-side (see TestParamValidation),
+        but the model must still describe the service contract accurately.
+        """
+        patch_process_payment_model(client)
+        shapes = shape_map(client)
+
+        assert shapes["WwwAuthenticateHeaderList"]["min"] == 1
+        assert shapes["WwwAuthenticateHeaderList"]["max"] == 1
+        assert shapes["WwwAuthenticateHeader"]["max"] == 16384
+        assert shapes["MppVersion"]["pattern"] == "^[0-9]+$"
+        assert shapes["MppPaymentCredential"]["max"] == 32768
+        assert shapes["MppSelectedPaymentId"]["max"] == 512
+
+    def test_credential_shape_is_marked_sensitive(self, client):
+        """The credential is bearer-like and must be kept out of logs and traces."""
+        patch_process_payment_model(client)
+
+        assert shape_map(client)["MppPaymentCredential"]["sensitive"] is True
+
+    def test_buyer_pays_gas_fees_is_an_optional_boolean(self, client):
+        patch_process_payment_model(client)
+        shapes = shape_map(client)
+
+        member = shapes["MppPaymentInput"]["members"]["buyerPaysGasFees"]
+        assert shapes[member["shape"]]["type"] == "boolean"
+        # Optional: the buyer declining gas fees is the protocol default.
+        assert "buyerPaysGasFees" not in shapes["MppPaymentInput"]["required"]
+
+    def test_required_members_match_the_model(self, client):
+        patch_process_payment_model(client)
+        shapes = shape_map(client)
+
+        assert set(shapes["MppPaymentInput"]["required"]) == {"version", "wwwAuthenticateHeaders"}
+        assert set(shapes["MppPaymentOutput"]["required"]) == {
+            "version",
+            "selectedPaymentId",
+            "paymentCredential",
+        }
+
+    def test_does_not_mutate_installed_botocore_data_files(self, client):
+        """The patch must only touch the in-memory model, never botocore on disk."""
+        patch_process_payment_model(client)
+
+        untouched = make_client()
+        assert "mpp" not in shape_map(untouched)["PaymentInput"]["members"]
+
+
+class TestParamValidation:
+    """The patch must make botocore accept MPP params it would otherwise reject.
+
+    Note: botocore's client-side validator enforces ``min`` length but not ``max``
+    length or ``pattern`` — those constraints are enforced by the service. Tests here
+    assert only what botocore actually checks; the modelled bounds are asserted
+    against the shape map in TestPatchProcessPaymentModel instead.
+    """
+
+    VALID_ARGS = {
+        "paymentManagerArn": PAYMENT_MANAGER_ARN,
+        "paymentSessionId": "payment-session-" + "a" * 20,
+        "paymentInstrumentId": "payment-instrument-" + "b" * 20,
+        "clientToken": "c" * 33,
+    }
+
+    def test_mpp_input_is_rejected_before_patching(self, client):
+        """Documents the problem the patch solves."""
+        with pytest.raises(ParamValidationError, match='Unknown parameter in paymentInput: "mpp"'):
+            client.process_payment(
+                paymentType="MPP",
+                paymentInput={"mpp": {"version": "1", "wwwAuthenticateHeaders": ['Payment id="a"']}},
+                **self.VALID_ARGS,
+            )
+
+    def test_mpp_input_passes_validation_after_patching(self, client):
+        patch_process_payment_model(client)
+
+        # Validation now passes, so the call proceeds to signing/transport and fails
+        # there instead — any exception except ParamValidationError means the params
+        # were accepted client-side.
+        with pytest.raises(Exception) as exc_info:
+            client.process_payment(
+                paymentType="MPP",
+                paymentInput={"mpp": {"version": "1", "wwwAuthenticateHeaders": ['Payment id="a"']}},
+                **self.VALID_ARGS,
+            )
+
+        assert not isinstance(exc_info.value, ParamValidationError)
+
+    def test_empty_header_list_is_still_rejected(self, client):
+        """The model constrains wwwAuthenticateHeaders to exactly one entry."""
+        patch_process_payment_model(client)
+
+        with pytest.raises(ParamValidationError):
+            client.process_payment(
+                paymentType="MPP",
+                paymentInput={"mpp": {"version": "1", "wwwAuthenticateHeaders": []}},
+                **self.VALID_ARGS,
+            )
+
+    def test_buyer_pays_gas_fees_passes_validation(self, client):
+        patch_process_payment_model(client)
+
+        with pytest.raises(Exception) as exc_info:
+            client.process_payment(
+                paymentType="MPP",
+                paymentInput={
+                    "mpp": {
+                        "version": "1",
+                        "wwwAuthenticateHeaders": ['Payment id="a"'],
+                        "buyerPaysGasFees": True,
+                    }
+                },
+                **self.VALID_ARGS,
+            )
+
+        assert not isinstance(exc_info.value, ParamValidationError)
+
+    def test_non_boolean_buyer_pays_gas_fees_is_rejected(self, client):
+        patch_process_payment_model(client)
+
+        with pytest.raises(ParamValidationError):
+            client.process_payment(
+                paymentType="MPP",
+                paymentInput={
+                    "mpp": {
+                        "version": "1",
+                        "wwwAuthenticateHeaders": ['Payment id="a"'],
+                        "buyerPaysGasFees": "yes",
+                    }
+                },
+                **self.VALID_ARGS,
+            )
+
+    def test_x402_input_still_validates_after_patching(self, client):
+        """The patch must not disturb the existing x402 path."""
+        patch_process_payment_model(client)
+
+        with pytest.raises(Exception) as exc_info:
+            client.process_payment(
+                paymentType="CRYPTO_X402",
+                paymentInput={"cryptoX402": {"version": "1", "payload": {"scheme": "exact"}}},
+                **self.VALID_ARGS,
+            )
+
+        assert not isinstance(exc_info.value, ParamValidationError)
+
+
+class TestPaymentManagerAppliesPatch:
+    """PaymentManager must patch its client at construction time."""
+
+    def test_manager_client_supports_mpp_after_init(self):
+        from unittest.mock import patch
+
+        from bedrock_agentcore.payments.manager import PaymentManager
+
+        real_client = make_client()
+        assert "mpp" not in shape_map(real_client)["PaymentInput"]["members"]
+
+        with patch("boto3.Session") as mock_session:
+            mock_session.return_value.region_name = "us-west-2"
+            mock_session.return_value.client.return_value = real_client
+            PaymentManager(payment_manager_arn=PAYMENT_MANAGER_ARN, region_name="us-west-2")
+
+        assert "mpp" in shape_map(real_client)["PaymentInput"]["members"]

--- a/tests_integ/payments/integrations/strands/test_plugin_integration.py
+++ b/tests_integ/payments/integrations/strands/test_plugin_integration.py
@@ -226,6 +226,357 @@ class TestAgentCorePaymentsPlugin:
 
 
 @pytest.mark.integration
+class TestAgentCorePaymentsPluginMpp:
+    """Integration tests for MPP (Machine Payments Protocol) handling in the plugin.
+
+    MPP servers advertise payment options as ``WWW-Authenticate: Payment`` challenges on
+    a 402 response, rather than in the body like x402. These tests exercise that path
+    against the live MPP reference endpoint.
+
+    To run the live tests:
+        export BEDROCK_TEST_REGION="us-west-2"
+        export TEST_PAYMENT_MANAGER_ARN="arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-123"
+        export TEST_PAYMENT_INSTRUMENT_ID="payment-instrument-xxx"
+        export TEST_PAYMENT_SESSION_ID="payment-session-xxx"
+        export TEST_USER_ID="test-user"
+        export TEST_MPP_RESOURCE_URL="https://mpp.dev/api/ping/paid"
+        pytest tests_integ/payments/integrations/strands/test_plugin_integration.py::\
+            TestAgentCorePaymentsPluginMpp -v -s
+    """
+
+    DEFAULT_MPP_URL = "https://mpp.dev/api/ping/paid"
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test environment."""
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.mpp_url = os.environ.get("TEST_MPP_RESOURCE_URL", cls.DEFAULT_MPP_URL)
+
+    def _make_config(self, **overrides):
+        """Build a plugin config from the configured test resources."""
+        kwargs = {
+            "payment_manager_arn": os.environ.get("TEST_PAYMENT_MANAGER_ARN"),
+            "user_id": self.user_id,
+            "payment_instrument_id": os.environ.get("TEST_PAYMENT_INSTRUMENT_ID"),
+            "payment_session_id": os.environ.get("TEST_PAYMENT_SESSION_ID"),
+            "region": self.region,
+            # No chain-advance wait needed: these tests assert on signing, not settlement.
+            "post_payment_retry_delay_seconds": 0,
+        }
+        kwargs.update(overrides)
+        return AgentCorePaymentsPluginConfig(**kwargs)
+
+    @staticmethod
+    def _require_payment_resources():
+        """Skip unless a payment manager, instrument and session are all configured."""
+        missing = [
+            name
+            for name in ("TEST_PAYMENT_MANAGER_ARN", "TEST_PAYMENT_INSTRUMENT_ID", "TEST_PAYMENT_SESSION_ID")
+            if not os.environ.get(name)
+        ]
+        if missing:
+            pytest.skip(f"Not configured: {', '.join(missing)}")
+
+    def _fetch_live_402(self):
+        """Fetch a real MPP 402 and return it as a payment_required_request dict."""
+        import httpx
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            response = client.get(self.mpp_url)
+
+        assert response.status_code == 402, (
+            f"Expected 402 from {self.mpp_url}, got {response.status_code}. "
+            "The MPP reference endpoint may have changed."
+        )
+        return {"statusCode": 402, "headers": dict(response.headers), "body": {}}
+
+    def test_live_mpp_endpoint_advertises_payment_challenge(self):
+        """The live MPP endpoint must return a 402 the SDK recognizes as MPP.
+
+        Needs no AWS credentials — it validates only detection and parsing.
+        """
+        from bedrock_agentcore.payments.mpp import extract_challenges, is_mpp_payment_required
+
+        payment_required_request = self._fetch_live_402()
+
+        assert is_mpp_payment_required(payment_required_request), (
+            f"No MPP challenge found in headers: {payment_required_request['headers']}"
+        )
+
+        challenges = extract_challenges(payment_required_request)
+        assert challenges, "At least one challenge must be parsed"
+        for challenge in challenges:
+            assert challenge.get("id"), f"Challenge missing id: {challenge}"
+            assert challenge.get("method"), f"Challenge missing method: {challenge}"
+            assert challenge["raw"].startswith("Payment ")
+            logger.info(
+                "Live challenge: id=%s method=%s intent=%s expires=%s",
+                challenge.get("id"),
+                challenge.get("method"),
+                challenge.get("intent"),
+                challenge.get("expires"),
+            )
+
+    def test_plugin_http_request_preserves_live_challenge(self):
+        """The plugin's http_request tool must surface the challenge for detection.
+
+        MPP challenges travel in headers, so a tool that drops or rewrites response
+        headers would silently break auto-payment. Needs no AWS credentials.
+        """
+        from bedrock_agentcore.payments.integrations.handlers import get_payment_handler
+
+        config = self._make_config(
+            payment_manager_arn=os.environ.get(
+                "TEST_PAYMENT_MANAGER_ARN",
+                "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/mypaymentmanager-cyrc25gr4c",
+            )
+        )
+        plugin = AgentCorePaymentsPlugin(config=config)
+
+        result = plugin.http_request(url=self.mpp_url)
+
+        handler = get_payment_handler("http_request", {"url": self.mpp_url, "headers": {}})
+        assert handler.extract_status_code(result["content"]) == 402
+        headers = handler.extract_headers(result["content"])
+        assert headers is not None
+
+        challenge = next((v for k, v in headers.items() if k.lower() == "www-authenticate"), None)
+        assert challenge is not None, f"WWW-Authenticate not preserved by http_request: {headers}"
+        assert challenge.strip().lower().startswith("payment")
+        logger.info("http_request preserved the MPP challenge: %s...", challenge[:80])
+
+    def test_plugin_settles_live_mpp_402(self):
+        """Plugin signs a real MPP challenge and applies the Authorization header.
+
+        Requires AWS credentials and MPP entitlement on the account. When the account
+        is not yet enabled for MPP, the service returns AccessDeniedException; the test
+        skips in that case rather than reporting a false failure, but still asserts the
+        request shape was accepted.
+        """
+        self._require_payment_resources()
+
+        plugin = AgentCorePaymentsPlugin(config=self._make_config())
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager") as mock_cls:
+            mock_cls.return_value = PaymentManager(
+                payment_manager_arn=plugin.config.payment_manager_arn,
+                region_name=self.region,
+            )
+            plugin.init_agent(MagicMock())
+
+        payment_required_request = self._fetch_live_402()
+
+        try:
+            header = plugin._process_payment_required_request(payment_required_request)
+        except PaymentError as e:
+            message = str(e)
+            lowered = message.lower()
+            for shape_hint in ("unknown parameter", "validationexception"):
+                assert shape_hint not in lowered, f"MPP request shape was rejected: {message}"
+            pytest.skip(f"MPP payment not completed (expected without account entitlement): {message}")
+
+        assert set(header) == {"Authorization"}, f"MPP must yield only an Authorization header, got {list(header)}"
+        assert header["Authorization"].startswith("Payment ")
+        assert "X-PAYMENT" not in header
+        logger.info("Plugin settled the live MPP challenge and produced an Authorization header")
+
+    def test_agent_pays_live_mpp_endpoint(self):
+        """End-to-end: a Strands agent fetches an MPP-gated resource via the plugin.
+
+        The plugin intercepts the 402, settles the challenge, attaches the
+        Authorization header, and Strands retries the tool.
+        """
+        self._require_payment_resources()
+
+        plugin = AgentCorePaymentsPlugin(config=self._make_config())
+        agent = Agent(
+            system_prompt=(
+                "You are a helpful assistant. Use the http_request tool to fetch URLs. "
+                "Report the final response you receive."
+            ),
+            plugins=[plugin],
+        )
+
+        result = self.invoke_agent_with_payment_handling(
+            agent,
+            f"Please fetch {self.mpp_url} and tell me what it returned.",
+            plugin=plugin,
+        )
+
+        logger.info("Agent stop_reason: %s", result.stop_reason)
+        logger.info("MPP agent flow completed")
+
+    def invoke_agent_with_payment_handling(self, agent, prompt, plugin=None, max_iterations=10):
+        """Reuse the x402 interrupt-handling wrapper for the MPP flow."""
+        return TestAgentCorePaymentsPlugin.invoke_agent_with_payment_handling(
+            self, agent, prompt, plugin=plugin, max_iterations=max_iterations
+        )
+
+
+@pytest.mark.integration
+class TestMppPostPaymentFailureFlow:
+    """Hook-flow scenarios for MPP payments.
+
+    Mock-driven: these fully mock PaymentManager, do not hit AWS, and require no
+    credentials. They cover the plugin's after_tool_call hook end to end for MPP.
+    """
+
+    CHALLENGE = (
+        'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+    )
+    CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test environment."""
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+
+    def _make_mpp_402_event(self, tool_use_id, invocation_state=None, tool_input=None, body=None):
+        """Create a mock AfterToolCallEvent carrying an MPP 402 (challenge in headers)."""
+        payment_required = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": self.CHALLENGE, "content-type": "application/problem+json"},
+            "body": body if body is not None else {},
+        }
+
+        event = MagicMock()
+        event.tool_use = {
+            "name": "http_request",
+            "toolUseId": tool_use_id,
+            "input": tool_input if tool_input is not None else {"url": "https://mpp.dev/api/ping/paid", "headers": {}},
+        }
+        event.result = [{"text": f"PAYMENT_REQUIRED: {json.dumps(payment_required)}"}]
+        event.invocation_state = invocation_state if invocation_state is not None else {}
+        event.retry = False
+        event.agent = MagicMock()
+        event.agent.state.get = MagicMock(return_value=None)
+        event.agent.state.set = MagicMock()
+        event.agent.state.delete = MagicMock()
+        return event
+
+    def _make_plugin(self, mock_pm):
+        config = AgentCorePaymentsPluginConfig(
+            payment_manager_arn="arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/test",
+            user_id=self.user_id,
+            payment_instrument_id="payment-instrument-123",
+            payment_session_id="payment-session-456",
+            region=self.region,
+            post_payment_retry_delay_seconds=0,
+        )
+        plugin = AgentCorePaymentsPlugin(config=config)
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager", return_value=mock_pm):
+            plugin.init_agent(MagicMock())
+        plugin.payment_manager = mock_pm
+        return plugin
+
+    def test_mpp_402_signs_and_retries_with_authorization(self):
+        """A 402 carrying a Payment challenge is signed and retried."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": self.CREDENTIAL}
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        event = self._make_mpp_402_event("tool-mpp", invocation_state=invocation_state, tool_input=tool_input)
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        assert tool_input["headers"]["Authorization"] == self.CREDENTIAL
+        assert invocation_state.get("payment_signed_tool-mpp") is True
+
+        # The challenge must reach PaymentManager so selection can run.
+        request_arg = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request_arg["headers"]["WWW-Authenticate"] == self.CHALLENGE
+        logger.info("MPP 402 signed, Authorization header applied, retry requested")
+
+    def test_mpp_402_after_signing_stops(self):
+        """A second MPP 402 after signing is a server rejection, not a retry case."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": self.CREDENTIAL}
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+
+        first = self._make_mpp_402_event("tool-mpp2", invocation_state=invocation_state, tool_input=tool_input)
+        plugin.after_tool_call(first)
+        assert first.retry is True
+
+        second = self._make_mpp_402_event(
+            "tool-mpp2",
+            invocation_state=invocation_state,
+            tool_input=tool_input,
+            body={"error": "verification-failed"},
+        )
+        plugin.after_tool_call(second)
+
+        assert second.retry is False
+        assert mock_pm.generate_payment_header.call_count == 1
+        assert "payment_failure_tool-mpp2" in invocation_state
+        logger.info("Second MPP 402 after signing stopped and stored failure state")
+
+    def test_mpp_selection_failure_does_not_retry(self):
+        """An unsatisfiable challenge must not retry or leave a payment header."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError(
+            "MPP Challenge Selection: No matching challenge - no advertised payment method can be satisfied"
+        )
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        event = self._make_mpp_402_event("tool-mpp3", invocation_state=invocation_state, tool_input=tool_input)
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is False
+        assert "Authorization" not in tool_input["headers"]
+        assert "payment_failure_tool-mpp3" in invocation_state
+        logger.info("MPP selection failure stopped cleanly with no header applied")
+
+    def test_x402_and_mpp_use_independent_state(self):
+        """An x402 tool use and an MPP tool use must not share signing state."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = [
+            {"X-PAYMENT": "x402-proof"},
+            {"Authorization": self.CREDENTIAL},
+        ]
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+
+        x402_input = {"url": "https://nickeljoke.vercel.app/api/joke", "headers": {}}
+        x402_payload = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+        }
+        x402_event = MagicMock()
+        x402_event.tool_use = {"name": "http_request", "toolUseId": "tool-x402", "input": x402_input}
+        x402_event.result = [{"text": f"PAYMENT_REQUIRED: {json.dumps(x402_payload)}"}]
+        x402_event.invocation_state = invocation_state
+        x402_event.retry = False
+        x402_event.agent = MagicMock()
+        x402_event.agent.state.get = MagicMock(return_value=None)
+
+        plugin.after_tool_call(x402_event)
+        assert x402_event.retry is True
+        assert x402_input["headers"]["X-PAYMENT"] == "x402-proof"
+
+        mpp_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        mpp_event = self._make_mpp_402_event("tool-mpp4", invocation_state=invocation_state, tool_input=mpp_input)
+        plugin.after_tool_call(mpp_event)
+
+        assert mpp_event.retry is True
+        assert mpp_input["headers"]["Authorization"] == self.CREDENTIAL
+        assert "X-PAYMENT" not in mpp_input["headers"]
+        assert mock_pm.generate_payment_header.call_count == 2
+        logger.info("x402 and MPP tool uses tracked independently with protocol-correct headers")
+
+
+@pytest.mark.integration
 class TestPaymentHandlerExtraction:
     """Integration tests for payment handler extraction with real handler instances."""
 

--- a/tests_integ/payments/test_mpp_payment.py
+++ b/tests_integ/payments/test_mpp_payment.py
@@ -1,0 +1,420 @@
+"""Integration tests for MPP (Machine Payments Protocol) payment processing.
+
+These tests exercise the MPP path end to end against the real ProcessPayment API:
+challenge selection, ``paymentType="MPP"`` submission, and credential minting.
+
+SETUP INSTRUCTIONS:
+===================
+
+1. Set the following environment variables before running tests:
+
+   # Required: AWS region
+   export BEDROCK_TEST_REGION="us-west-2"
+
+   # Required: Payment manager ARN (created via control plane)
+   export TEST_PAYMENT_MANAGER_ARN="arn:aws:bedrock:us-west-2:123456789012:payment-manager/pm-123"
+
+   # Required: Payment connector ID (created via control plane)
+   export TEST_PAYMENT_CONNECTOR_ID="pc-123"
+
+   # Required for live payment tests: a funded instrument and an open session.
+   # Without these, only the offline selection/detection tests run.
+   export TEST_PAYMENT_INSTRUMENT_ID="payment-instrument-..."
+   export TEST_PAYMENT_SESSION_ID="payment-session-..."
+
+   # Optional: User ID for testing (default: generated)
+   export TEST_USER_ID="test-user"
+
+   # Optional: an MPP-enabled resource that answers 402 with a
+   # 'WWW-Authenticate: Payment' challenge. When set, test_live_402_challenge
+   # fetches a real challenge instead of using a synthetic one.
+   export TEST_MPP_RESOURCE_URL="https://api.example.com/api/paid"
+
+2. Ensure AWS credentials are configured (see tests_integ/payments/README.md).
+
+3. Run the tests:
+   pytest tests_integ/payments/test_mpp_payment.py -v
+
+SERVICE SIDE VERIFICATION:
+==========================
+
+Monitor service logs to verify:
+- ProcessPayment invoked with paymentType=MPP
+- The wwwAuthenticateHeaders value matches the challenge byte-for-byte
+- MppPaymentOutput.selectedPaymentId echoes the submitted challenge id
+- The minted credential is not written to logs (it is @sensitive)
+"""
+
+import base64
+import json
+import os
+import uuid
+
+import pytest
+
+from bedrock_agentcore.payments.manager import PaymentError, PaymentManager
+from bedrock_agentcore.payments.mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
+REQUIRES_MANAGER = pytest.mark.skipif(
+    not os.environ.get("TEST_PAYMENT_MANAGER_ARN"),
+    reason="TEST_PAYMENT_MANAGER_ARN environment variable not set",
+)
+
+REQUIRES_LIVE_PAYMENT = pytest.mark.skipif(
+    not (
+        os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        and os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        and os.environ.get("TEST_PAYMENT_SESSION_ID")
+    ),
+    reason="TEST_PAYMENT_MANAGER_ARN, TEST_PAYMENT_INSTRUMENT_ID and TEST_PAYMENT_SESSION_ID must be set",
+)
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding, as MPP requires."""
+    return base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode()).decode().rstrip("=")
+
+
+def evm_challenge(challenge_id="evm-1", chain_id=84532, amount="1000"):
+    """Build an evm-charge challenge per draft-evm-charge-00."""
+    request = {
+        "amount": amount,
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="evm", '
+        f'intent="charge", request="{b64url(request)}"'
+    )
+
+
+def solana_challenge(challenge_id="sol-1", network="devnet", amount="1000"):
+    """Build a solana-charge challenge per draft-solana-charge-00."""
+    request = {
+        "amount": amount,
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": {"network": network},
+    }
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="solana", '
+        f'intent="charge", request="{b64url(request)}"'
+    )
+
+
+def mpp_402(*challenges):
+    """Build a 402 payment required request advertising the given challenges."""
+    return {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": ", ".join(challenges)},
+        "body": {},
+    }
+
+
+@pytest.mark.integration
+class TestMppModelSupport:
+    """The SDK must be able to submit MPP regardless of the installed botocore version."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        default_arn = "arn:aws:bedrock:us-west-2:123456789012:payment-manager/pm-test"
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN", default_arn)
+
+    def test_manager_client_accepts_mpp_payment_input(self):
+        """A real client built by PaymentManager must model paymentInput.mpp."""
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+
+        shapes = manager._payment_client.meta.service_model._shape_resolver._shape_map
+
+        assert "mpp" in shapes["PaymentInput"]["members"]
+        assert "mpp" in shapes["PaymentOutput"]["members"]
+        assert "MPP" in shapes["PaymentType"]["enum"]
+
+    def test_crypto_x402_support_is_retained(self):
+        """The MPP additions must not disturb the shipped x402 contract."""
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+
+        shapes = manager._payment_client.meta.service_model._shape_resolver._shape_map
+
+        assert "cryptoX402" in shapes["PaymentInput"]["members"]
+        assert "CRYPTO_X402" in shapes["PaymentType"]["enum"]
+
+
+@pytest.mark.integration
+class TestMppChallengeSelection:
+    """Selection is pure logic, so it is verified without calling the service."""
+
+    def test_detects_mpp_402(self):
+        assert is_mpp_payment_required(mpp_402(evm_challenge())) is True
+
+    def test_does_not_claim_x402_402(self):
+        x402 = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+
+        assert is_mpp_payment_required(x402) is False
+
+    def test_selects_challenge_matching_instrument_blockchain(self):
+        challenges = extract_challenges(mpp_402(evm_challenge(), solana_challenge()))
+
+        assert select_challenge(challenges, instrument_network="SOLANA")["id"] == "sol-1"
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["id"] == "evm-1"
+
+    def test_selected_raw_header_round_trips_byte_for_byte(self):
+        """The challenge HMAC binds to these exact bytes."""
+        raw = evm_challenge()
+        challenges = extract_challenges(mpp_402(raw))
+
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["raw"] == raw
+
+    def test_unsatisfiable_challenge_raises(self):
+        challenges = extract_challenges(mpp_402(solana_challenge()))
+
+        with pytest.raises(MppChallengeSelectionError):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+
+@pytest.mark.integration
+class TestMppProcessPayment:
+    """Tests that call the real ProcessPayment API with paymentType=MPP."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.instrument_id = os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        cls.session_id = os.environ.get("TEST_PAYMENT_SESSION_ID")
+
+        if cls.payment_manager_arn:
+            cls.manager = PaymentManager(
+                payment_manager_arn=cls.payment_manager_arn,
+                region_name=cls.region,
+            )
+        else:
+            cls.manager = None
+
+    def _instrument_network(self):
+        """Read the configured instrument's blockchain so tests pick a payable challenge."""
+        instrument = self.manager.get_payment_instrument(
+            payment_instrument_id=self.instrument_id,
+            user_id=self.user_id,
+        )
+        return instrument["paymentInstrumentDetails"]["embeddedCryptoWallet"]["network"]
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_process_payment_accepts_mpp_payment_type(self):
+        """ProcessPayment must accept paymentType=MPP and an MppPaymentInput."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        payment_input = {
+            "mpp": {
+                "version": "1",
+                "wwwAuthenticateHeaders": [challenge],
+            }
+        }
+
+        # The synthetic challenge is not signed by a real merchant, so the service is
+        # expected to reject it on verification. What this test proves is that the
+        # request shape itself is accepted: a ValidationException naming 'mpp',
+        # 'paymentType' or 'paymentInput' would mean the contract is wrong.
+        try:
+            response = self.manager.process_payment(
+                user_id=self.user_id,
+                payment_session_id=self.session_id,
+                payment_instrument_id=self.instrument_id,
+                payment_type="MPP",
+                payment_input=payment_input,
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            message = str(e).lower()
+            for shape_hint in ("unknown parameter", "paymenttype", "paymentinput"):
+                assert shape_hint not in message, f"MPP request shape was rejected: {e}"
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+        else:
+            assert isinstance(response, dict)
+            assert "mpp" in response.get("paymentOutput", {})
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_generate_payment_header_routes_mpp_402_to_authorization(self):
+        """An MPP 402 must yield an Authorization header, not an x402 one."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        try:
+            header = self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request=mpp_402(challenge),
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+
+        assert set(header) == {"Authorization"}
+        assert header["Authorization"].startswith("Payment ")
+        assert "X-PAYMENT" not in header
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_buyer_pays_gas_fees_is_accepted_by_the_service(self):
+        """ProcessPayment must accept the optional buyerPaysGasFees flag."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        try:
+            self.manager.process_payment(
+                user_id=self.user_id,
+                payment_session_id=self.session_id,
+                payment_instrument_id=self.instrument_id,
+                payment_type="MPP",
+                payment_input={
+                    "mpp": {
+                        "version": "1",
+                        "wwwAuthenticateHeaders": [challenge],
+                        "buyerPaysGasFees": True,
+                    }
+                },
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            message = str(e).lower()
+            assert "buyerpaysgasfees" not in message, f"buyerPaysGasFees was rejected: {e}"
+            assert "unknown parameter" not in message, f"MPP request shape was rejected: {e}"
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+
+    @REQUIRES_MANAGER
+    def test_unsatisfiable_challenge_fails_before_calling_service(self):
+        """Selection failures must not burn a ProcessPayment call or session budget."""
+        instrument_id = self.instrument_id or "payment-instrument-unused"
+
+        with pytest.raises(PaymentError, match="No matching challenge|Missing network information"):
+            self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=instrument_id,
+                payment_session_id=self.session_id or "payment-session-unused",
+                # Only a bitcoin challenge is advertised; no instrument can satisfy it.
+                payment_required_request=mpp_402(
+                    'Payment id="btc-1", realm="api.example.com", method="bitcoin", intent="charge"'
+                ),
+                client_token=str(uuid.uuid4()),
+            )
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_expired_challenge_is_rejected_locally(self):
+        """An expired challenge must be filtered out before the service is called."""
+        expired_request = b64url(
+            {
+                "amount": "1",
+                "currency": "0xUSDC",
+                "recipient": "0xabc",
+                "methodDetails": {"chainId": 84532},
+            }
+        )
+        expired = (
+            'Payment id="old-1", realm="api.example.com", method="evm", '
+            'intent="charge", expires="2020-01-01T00:00:00Z", '
+            f'request="{expired_request}"'
+        )
+
+        with pytest.raises(PaymentError, match="expired|No usable challenge"):
+            self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request=mpp_402(expired),
+                client_token=str(uuid.uuid4()),
+            )
+
+
+@pytest.mark.integration
+class TestMppLiveResource:
+    """Tests against a real MPP-enabled endpoint, when one is configured."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.resource_url = os.environ.get("TEST_MPP_RESOURCE_URL")
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.instrument_id = os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        cls.session_id = os.environ.get("TEST_PAYMENT_SESSION_ID")
+
+    @pytest.mark.skipif(
+        not os.environ.get("TEST_MPP_RESOURCE_URL"),
+        reason="TEST_MPP_RESOURCE_URL environment variable not set",
+    )
+    def test_live_402_challenge_is_parseable(self):
+        """A real server's 402 must produce at least one usable challenge."""
+        import httpx
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            response = client.get(self.resource_url)
+
+        assert response.status_code == 402, f"Expected 402, got {response.status_code}"
+
+        payment_required_request = {
+            "statusCode": response.status_code,
+            "headers": dict(response.headers),
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(payment_required_request), (
+            f"No MPP challenge in response headers: {dict(response.headers)}"
+        )
+
+        challenges = extract_challenges(payment_required_request)
+        assert challenges
+        # Every challenge must carry the auth-params selection depends on.
+        for challenge in challenges:
+            assert challenge.get("id"), f"Challenge missing id: {challenge}"
+            assert challenge.get("method"), f"Challenge missing method: {challenge}"
+            assert challenge["raw"].startswith("Payment ")
+
+    @pytest.mark.skipif(
+        not (
+            os.environ.get("TEST_MPP_RESOURCE_URL")
+            and os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+            and os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+            and os.environ.get("TEST_PAYMENT_SESSION_ID")
+        ),
+        reason="TEST_MPP_RESOURCE_URL, TEST_PAYMENT_MANAGER_ARN, TEST_PAYMENT_INSTRUMENT_ID "
+        "and TEST_PAYMENT_SESSION_ID must be set",
+    )
+    def test_end_to_end_pay_and_retry(self):
+        """Full loop: 402 → select → pay → retry with Authorization → 200."""
+        import httpx
+
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            first = client.get(self.resource_url)
+            assert first.status_code == 402
+
+            header = manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request={
+                    "statusCode": first.status_code,
+                    "headers": dict(first.headers),
+                    "body": {},
+                },
+                client_token=str(uuid.uuid4()),
+            )
+            assert "Authorization" in header
+
+            retry = client.get(self.resource_url, headers=header)
+
+        assert retry.status_code == 200, f"Retry after payment failed: {retry.status_code} {retry.text[:300]}"


### PR DESCRIPTION
Add MPP alongside the existing x402 protocol in ProcessPayment. MPP servers answer 402 with WWW-Authenticate: Payment challenges; the SDK selects the one challenge the payment instrument can satisfy and mints an Authorization header.

Core:
- mpp.py: parse WWW-Authenticate challenges and select one (charge-intent, unexpired, method the instrument satisfies: evm/tempo->ETHEREUM, solana->SOLANA; ordered by NETWORK_PREFERENCES). The selected challenge is forwarded verbatim so the challenge HMAC stays valid.
- generate_payment_header auto-detects protocol from the 402 and returns {"Authorization": "Payment <token>"} for MPP; x402 path unchanged.
- Optional buyer_pays_gas_fees passthrough (MPP buyerPaysGasFees).
- _model_patch.py: inject MPP shapes into the loaded botocore model when the installed release predates them; idempotent, no-op once shipped natively, never mutates installed botocore.

Integrations:
- Strands plugin and LangGraph middleware detect MPP 402s (WWW-Authenticate) and settle them; buyer_pays_gas_fees exposed on the shared config.

Tests: unit coverage for parsing, selection, model patch, manager routing, and both integrations; integ tests gated on TEST_* env vars.

Verified against the live mpp.dev 402 and prod ProcessPayment (request shape accepted; end-to-end settlement pending account MPP entitlement).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
