### PR TITLE
feat(payments): add MPP, x402 upto, and Quick Create support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Check package
         run: |
-          uv pip install twine==6.2.0
+          uv pip install twine==7.0.0
           uv run twine check dist/*
 
       - name: Upload artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,7 @@ jobs:
 
       - name: Check package
         run: |
-          uv pip install twine==7.0.0
-          uv run twine check dist/*
+          uvx --from twine==7.0.0 twine check dist/*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "boto3>=1.43.35",
-    "botocore>=1.43.35",
+    "boto3>=1.43.72",
+    "botocore>=1.43.72",
     "pydantic>=2.0.0,<2.41.3",
     "urllib3>=1.26.0",
     "starlette>=0.46.2",

--- a/src/bedrock_agentcore/payments/README.md
+++ b/src/bedrock_agentcore/payments/README.md
@@ -1,13 +1,16 @@
 # Bedrock AgentCore payments SDK
 
 High-level Python SDK for AWS Bedrock AgentCore payments service with support for payment instrument management,
-session-based payment limits, and x402 payment processing for AI agent microtransactions.
+session-based payment limits, and internet native payment protocols support such as x402 and MPP for AI agent microtransactions.
 
 ## Overview
 
 The Bedrock AgentCore Payments SDK enables AI agents to process microtransaction payments to access paid APIs,
-MCP servers, and premium content. The SDK supports the [x402 Payment Required](https://www.x402.org/) protocol,
-allowing agents to automatically handle HTTP 402 responses and complete cryptocurrency transactions on behalf of users.
+MCP servers, and premium content. The SDK supports two payment protocols — [x402 Payment
+Required](https://www.x402.org/) and [MPP (Machine Payments Protocol)](https://mpp.dev) — allowing agents to
+automatically handle HTTP 402 responses and complete transactions on behalf of users. The protocol is detected
+from the 402 response, so a single `generate_payment_header` call covers both
+(see [Payment Header Generation](#payment-header-generation) and [MPP](#mpp-machine-payments-protocol)).
 
 ### Architecture
 
@@ -33,7 +36,7 @@ PaymentClient (Control Plane)
 |-----------|-------|---------|
 | `PaymentClient` | Control plane | Create and manage payment infrastructure (managers, connectors, credential providers) |
 | `PaymentManager` | Data plane | Payment operations (instruments, sessions, payment processing, header generation) |
-| `AgentCorePaymentsPlugin` | Framework integration | Strands Agents plugin for automatic x402 payment handling ([see Strands README](integrations/strands/README.md)) |
+| `AgentCorePaymentsPlugin` | Framework integration | Strands Agents plugin for automatic x402 and MPP payment handling ([see Strands README](integrations/strands/README.md)) |
 
 ## Installation
 
@@ -349,12 +352,48 @@ payment = manager.process_payment(
 )
 ```
 
+For MPP, pass `payment_type="MPP"` and forward the raw challenge header verbatim:
+
+```python
+payment = manager.process_payment(
+    payment_session_id=payment_session_id,
+    payment_instrument_id=payment_instrument_id,
+    payment_type="MPP",
+    payment_input={
+        "mpp": {
+            "version": "1",
+            # Exactly one challenge per call, passed exactly as the server sent it.
+            "wwwAuthenticateHeaders": [
+                'Payment id="aB3cDeF4", realm="api.example.com", method="evm", '
+                'intent="charge", request="eyJhbW91bnQ..."'
+            ],
+            # Optional. Authorizes charging network (gas) fees to the buyer's wallet.
+            "buyerPaysGasFees": True,
+        }
+    },
+    user_id="test-user-123",
+)
+# payment["paymentOutput"]["mpp"] -> {"version", "selectedPaymentId", "paymentCredential"}
+```
+
+Most callers should prefer `generate_payment_header` below, which selects the challenge and
+builds the `Authorization` header for you.
+
 ---
 
 ### Payment Header Generation
 
-Generate x402 payment headers for HTTP 402 Payment Required responses. This is the core method
-used by the Strands plugin under the hood:
+Generate payment headers for HTTP 402 Payment Required responses. This is the core method
+used by the Strands plugin under the hood.
+
+Two protocols are supported and the protocol is **detected automatically** from the 402
+response, so callers use the same method for both:
+
+| 402 response contains | Protocol | Returned header |
+|---|---|---|
+| `WWW-Authenticate: Payment ...` | MPP | `{"Authorization": "Payment <token>"}` |
+| `x402Version` + `accepts` in the body | x402 v1 | `{"X-PAYMENT": "base64..."}` |
+| `Payment-Required` header | x402 v2 | `{"PAYMENT-SIGNATURE": "base64..."}` |
 
 ```python
 header = manager.generate_payment_header(
@@ -383,12 +422,150 @@ header = manager.generate_payment_header(
 # Returns: {"X-PAYMENT": "base64..."} (v1) or {"PAYMENT-SIGNATURE": "base64..."} (v2)
 ```
 
-**Network selection process:**
+**Network selection process (x402):**
 1. Filter accepts to those matching the instrument's blockchain type (Ethereum or Solana)
 2. Use provided `network_preferences` or fall back to the default `NETWORK_PREFERENCES`
 3. Pick the first network from preferences that matches a filtered accept
 4. If no match found, return the first filtered accept
 
+---
+
+### MPP (Machine Payments Protocol)
+
+[MPP](https://mpp.dev) servers answer with `402 Payment Required` and advertise their payment
+options as `WWW-Authenticate: Payment` challenges. The same `generate_payment_header` call
+handles them — pass the 402 response through and attach the returned header on retry:
+
+```python
+header = manager.generate_payment_header(
+    payment_instrument_id=payment_instrument_id,
+    payment_session_id=payment_session_id,
+    payment_required_request={
+        "statusCode": 402,
+        "headers": {
+            # One challenge per payment option. Repeated headers may also be
+            # passed as a list of strings.
+            "WWW-Authenticate": (
+                'Payment id="aB3cDeF4", realm="api.example.com", method="evm", '
+                'intent="charge", request="eyJhbW91bnQ...", expires="2026-04-01T12:05:00Z", '
+                'Payment id="sol-1", realm="api.example.com", method="solana", '
+                'intent="charge", request="eyJhbW91bnQ..."'
+            ),
+        },
+        "body": {},
+    },
+    user_id="test-user-123",
+)
+# Returns: {"Authorization": "Payment <base64url-token>"}
+
+# Retry the original request with the header attached.
+response = httpx.get("https://api.example.com/resource", headers=header)
+```
+
+**Supported methods and intents**
+
+| Payment method | Satisfied by instrument network |
+|---|---|
+| `evm` | `ETHEREUM` |
+| `tempo` | `ETHEREUM` (Tempo is an EVM chain) |
+| `solana` | `SOLANA` |
+
+Only the `charge` intent is implemented. Challenges advertising `session` or `subscription`
+are filtered out. A challenge with no `intent` param is treated as `charge`.
+
+**Challenge selection process**
+
+`ProcessPayment` fulfills exactly one challenge per call, so the SDK reduces the advertised
+options to the single one your instrument can pay:
+
+1. Drop challenges whose `intent` is not `charge`
+2. Drop challenges whose `expires` is in the past
+3. Keep only challenges whose `method` the instrument's blockchain can satisfy
+4. Order the survivors by `network_preferences` (default `NETWORK_PREFERENCES`), deriving each
+   challenge's network from its decoded `request` — `methodDetails.chainId` becomes
+   `eip155:<chainId>`, and Solana's `methodDetails.network` becomes `solana-mainnet` /
+   `solana-devnet` / `solana-testnet` (defaults to mainnet when absent)
+5. Break ties on the soonest expiry, then on the order the server advertised them
+
+Selection failures raise `PaymentError` **before** any service call, so an unsatisfiable 402
+never consumes session budget.
+
+The selected challenge's raw header value is forwarded to the service **verbatim**. This is
+deliberate: the challenge HMAC binds to the exact base64url `request`/`opaque` bytes, so the
+SDK never re-encodes them. Unknown auth-params are preserved rather than rejected, per the
+specification's "unknown parameters must be ignored by clients" rule.
+
+**Network (gas) fees**
+
+An MPP challenge advertises who sponsors blockchain network fees via its
+`methodDetails.feePayer` flag: `true` means the seller sponsors them, `false` or absent (the
+protocol default) means the buyer pays them from the paying wallet, on top of the challenge
+`amount`.
+
+Because that extra cost is **not visible in the challenge `amount`**, the service does not
+assume the buyer accepts it. When a challenge does not offer seller-sponsored fees, the payment
+is signed only if you pass `buyer_pays_gas_fees=True`; otherwise it fails with a validation
+error so you can decide — or obtain a challenge whose seller sponsors fees.
+
+```python
+header = manager.generate_payment_header(
+    payment_instrument_id=payment_instrument_id,
+    payment_session_id=payment_session_id,
+    payment_required_request=payment_required_request,
+    user_id="test-user-123",
+    # Explicitly accept paying network fees from the buyer's wallet.
+    buyer_pays_gas_fees=True,
+)
+```
+
+The parameter is optional and tri-state:
+
+| Value | Meaning |
+|---|---|
+| omitted / `None` | Field is not sent; the protocol default applies (buyer declines) |
+| `False` | Buyer explicitly declines to pay network fees |
+| `True` | Buyer authorizes network fees charged to their own wallet |
+
+Only `True`, `False`, or `None` are accepted — other values raise `PaymentError` rather than
+being coerced. This is deliberate: `bool("false")` is `True` in Python, so coercion would let the
+string `"false"` authorize wallet charges. Authorizing network fees must be unambiguous.
+
+It has no effect on challenges where the seller already sponsors fees
+(`methodDetails.feePayer=true`), and is ignored on the x402 path. Both framework integrations
+expose it as `buyer_pays_gas_fees` on their config.
+
+**Responses advertising both MPP and x402**
+
+Some endpoints advertise both protocols in the same 402. MPP is preferred, but if no advertised
+MPP challenge is satisfiable by the payment instrument and the response also carries a usable
+x402 requirement, the SDK falls back to x402 rather than failing the payment:
+
+| 402 contents | Outcome |
+|---|---|
+| Satisfiable MPP challenge (± x402) | Paid via MPP → `Authorization` |
+| MPP challenge the instrument cannot satisfy **+** usable x402 `accepts` | Falls back to x402 → `X-PAYMENT` |
+| MPP challenge the instrument cannot satisfy, no usable x402 | `PaymentError` |
+
+The fallback applies **only** to challenge-selection failures, which happen before anything is
+submitted. A failure after the payment has been sent to the service always propagates — retrying
+under x402 at that point could charge the buyer twice.
+
+**Working with challenges directly**
+
+The parsing and selection helpers are exported for callers who need them:
+
+```python
+from bedrock_agentcore.payments import (
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
+if is_mpp_payment_required(payment_required_request):
+    challenges = extract_challenges(payment_required_request)
+    selected = select_challenge(challenges, instrument_network="ETHEREUM")
+    print(selected["id"], selected["method"], selected["raw"])
+```
 ---
 
 ### Deleting Resources
@@ -663,7 +840,7 @@ except PaymentError as e:
 | `list_payment_sessions()` | List payment sessions for a user |
 | `delete_payment_session()` | Delete a payment session (hard delete) |
 | `process_payment()` | Process a payment transaction |
-| `generate_payment_header()` | Generate x402 payment headers for 402 responses |
+| `generate_payment_header()` | Generate payment headers for 402 responses (x402 or MPP, auto-detected) |
 
 ### PaymentManager Constructor Parameters
 

--- a/src/bedrock_agentcore/payments/README.md
+++ b/src/bedrock_agentcore/payments/README.md
@@ -61,8 +61,9 @@ source .venv/bin/activate
 
 ## Prerequisites
 
-AgentCore Payments connects to external payment providers for wallet operations. You must obtain
-credentials from at least one supported provider before creating a Payment Connector.
+AgentCore Payments connects to external payment providers for wallet operations. Manual connectors
+require provider credentials. Coinbase CDP connectors can instead use Quick Create, where the service
+provisions credentials after OAuth consent.
 
 **Supported providers:**
 - **Coinbase CDP** — API key ID, API key secret, and wallet secret
@@ -212,6 +213,28 @@ For Stripe Privy, use `"StripePrivy"` as the `credential_provider_vendor` with t
     "authorization_key": os.environ.get("STRIPE_PRIVY_AUTH_KEY", ""),  # optional
 }
 ```
+
+Coinbase CDP also supports Quick Create without a credential provider ARN:
+
+```python
+from bedrock_agentcore.payments import PaymentClient, PaymentConnectorProvisionMode
+
+payment_client = PaymentClient(region_name="us-east-1")
+connector = payment_client.create_payment_connector(
+    payment_manager_id="payment-manager-id",
+    name="coinbase-quick-create",
+    connector_type="CoinbaseCDP",
+    credential_provider_configurations=[],
+    provision_mode=PaymentConnectorProvisionMode.QUICK_CREATE,
+)
+
+print(connector["authorizationUrl"])
+```
+
+Quick Create initially returns `PENDING_AUTHENTICATION`. Open the authorization URL, complete
+consent, and then poll `get_payment_connector()` until it returns `READY`. Because consent requires
+user interaction, `wait_for_ready=True` cannot be used when creating a Quick Create connector.
+`get_payment_connector()` returns the live authorization URL only while authorization is pending.
 
 ---
 
@@ -427,6 +450,23 @@ header = manager.generate_payment_header(
 2. Use provided `network_preferences` or fall back to the default `NETWORK_PREFERENCES`
 3. Pick the first network from preferences that matches a filtered accept
 4. If no match found, return the first filtered accept
+
+For x402 `upto` requirements, `permit2_allowance_limit` can opt into the required Permit2
+allowance transaction:
+
+```python
+header = manager.generate_payment_header(
+    payment_instrument_id=payment_instrument_id,
+    payment_session_id=payment_session_id,
+    payment_required_request=payment_required_request,
+    user_id="user-123",
+    permit2_allowance_limit="1000000",
+)
+```
+
+The value is a positive ASCII integer of 1–78 digits in the asset's smallest denomination.
+It is sent only when the selected x402 requirement uses `scheme="upto"` and is omitted for
+`exact` or scheme-less requirements.
 
 ---
 
@@ -890,6 +930,7 @@ except PaymentError as e:
 | `PaymentManagerStatus` | Payment manager resource statuses (CREATING, READY, etc.) |
 | `PaymentConnectorStatus` | Payment connector statuses |
 | `PaymentConnectorType` | Supported connector types (CoinbaseCDP, StripePrivy) |
+| `PaymentConnectorProvisionMode` | Connector provisioning modes (MANUAL, QUICK_CREATE) |
 | `PaymentsAuthorizerType` | Authorizer types (AWS_IAM, CUSTOM_JWT) |
 | `NETWORK_PREFERENCES` | Default blockchain network preference order |
 | `DEFAULT_MAX_RESULTS` | Default pagination limit (100) |

--- a/src/bedrock_agentcore/payments/__init__.py
+++ b/src/bedrock_agentcore/payments/__init__.py
@@ -7,6 +7,7 @@ from .constants import (
     PaymentConnectorType,
     PaymentManagerStatus,
     PaymentsAuthorizerType,
+    PaymentType,
 )
 from .manager import (
     InsufficientBudget,
@@ -18,6 +19,13 @@ from .manager import (
     PaymentSessionConfigurationRequired,
     PaymentSessionExpired,
     PaymentSessionNotFound,
+)
+from .mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    parse_www_authenticate,
+    select_challenge,
 )
 
 __all__ = [
@@ -35,5 +43,12 @@ __all__ = [
     "PaymentConnectorStatus",
     "PaymentConnectorType",
     "PaymentsAuthorizerType",
+    "PaymentType",
     "DEFAULT_MAX_RESULTS",
+    # MPP (Machine Payments Protocol)
+    "MppChallengeSelectionError",
+    "extract_challenges",
+    "is_mpp_payment_required",
+    "parse_www_authenticate",
+    "select_challenge",
 ]

--- a/src/bedrock_agentcore/payments/__init__.py
+++ b/src/bedrock_agentcore/payments/__init__.py
@@ -3,6 +3,7 @@
 from .client import PaymentClient
 from .constants import (
     DEFAULT_MAX_RESULTS,
+    PaymentConnectorProvisionMode,
     PaymentConnectorStatus,
     PaymentConnectorType,
     PaymentManagerStatus,
@@ -42,6 +43,7 @@ __all__ = [
     "PaymentManagerStatus",
     "PaymentConnectorStatus",
     "PaymentConnectorType",
+    "PaymentConnectorProvisionMode",
     "PaymentsAuthorizerType",
     "PaymentType",
     "DEFAULT_MAX_RESULTS",

--- a/src/bedrock_agentcore/payments/_validation.py
+++ b/src/bedrock_agentcore/payments/_validation.py
@@ -1,0 +1,18 @@
+"""Shared validation for payments SDK inputs."""
+
+import re
+from typing import Optional
+
+_PERMIT2_ALLOWANCE_LIMIT_PATTERN = re.compile(r"[0-9]{1,78}\Z")
+
+
+def validate_permit2_allowance_limit(value: Optional[str]) -> None:
+    """Validate a Permit2 allowance against the service model constraints."""
+    if value is None:
+        return
+    if not isinstance(value, str):
+        raise ValueError(
+            f"permit2_allowance_limit must be a string in the asset's smallest denomination, got {type(value).__name__}"
+        )
+    if not _PERMIT2_ALLOWANCE_LIMIT_PATTERN.fullmatch(value) or int(value) <= 0:
+        raise ValueError(f"permit2_allowance_limit must be a positive ASCII integer of 1-78 digits, got {value!r}")

--- a/src/bedrock_agentcore/payments/client.py
+++ b/src/bedrock_agentcore/payments/client.py
@@ -658,10 +658,10 @@ class PaymentClient:
         credential_provider_configurations: List[Dict[str, Any]],
         description: Optional[str] = None,
         client_token: Optional[str] = None,
-        provision_mode: Optional[str] = None,
         wait_for_ready: bool = False,
         max_wait: int = 300,
         poll_interval: int = 10,
+        provision_mode: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Create a payment connector for a provider.
 
@@ -676,14 +676,14 @@ class PaymentClient:
                 provisions the credential provider after OAuth consent.
             description: Optional description
             client_token: Optional idempotency token. If not provided, a UUID will be generated.
+            wait_for_ready: Whether to wait for connector to reach READY status
+            max_wait: Maximum seconds to wait if wait_for_ready is True
+            poll_interval: Seconds between checks if wait_for_ready is True
             provision_mode: Optional provisioning mode ("MANUAL" or "QUICK_CREATE"; see
                 :class:`~bedrock_agentcore.payments.constants.PaymentConnectorProvisionMode`).
                 Defaults to the service default (MANUAL) when omitted. With "QUICK_CREATE" the
                 connector is created in PENDING_AUTHENTICATION and the response carries an
                 ``authorizationUrl`` the user must open to complete OAuth consent.
-            wait_for_ready: Whether to wait for connector to reach READY status
-            max_wait: Maximum seconds to wait if wait_for_ready is True
-            poll_interval: Seconds between checks if wait_for_ready is True
 
         Returns:
             Dictionary with paymentConnectorId and status, plus authorizationUrl when the

--- a/src/bedrock_agentcore/payments/client.py
+++ b/src/bedrock_agentcore/payments/client.py
@@ -658,6 +658,7 @@ class PaymentClient:
         credential_provider_configurations: List[Dict[str, Any]],
         description: Optional[str] = None,
         client_token: Optional[str] = None,
+        provision_mode: Optional[str] = None,
         wait_for_ready: bool = False,
         max_wait: int = 300,
         poll_interval: int = 10,
@@ -670,15 +671,23 @@ class PaymentClient:
             connector_type: Connector type (e.g., CoinbaseCDP)
             credential_provider_configurations: List of credential provider configurations.
                 Each config should be a dict with provider name as key and credential config as value.
-                Example: [{"coinbaseCDP": {"credentialProviderArn": "arn:..."}}]
+                Example: [{"coinbaseCDP": {"credentialProviderArn": "arn:..."}}].
+                For QUICK_CREATE provision mode this must be an empty list ``[]`` — the service
+                provisions the credential provider after OAuth consent.
             description: Optional description
             client_token: Optional idempotency token. If not provided, a UUID will be generated.
+            provision_mode: Optional provisioning mode ("MANUAL" or "QUICK_CREATE"; see
+                :class:`~bedrock_agentcore.payments.constants.PaymentConnectorProvisionMode`).
+                Defaults to the service default (MANUAL) when omitted. With "QUICK_CREATE" the
+                connector is created in PENDING_AUTHENTICATION and the response carries an
+                ``authorizationUrl`` the user must open to complete OAuth consent.
             wait_for_ready: Whether to wait for connector to reach READY status
             max_wait: Maximum seconds to wait if wait_for_ready is True
             poll_interval: Seconds between checks if wait_for_ready is True
 
         Returns:
-            Dictionary with paymentConnectorId and status
+            Dictionary with paymentConnectorId and status, plus authorizationUrl when the
+            service returns one (QUICK_CREATE connectors in PENDING_AUTHENTICATION).
 
         Raises:
             ClientError: If creation fails
@@ -705,10 +714,14 @@ class PaymentClient:
             if self._is_not_blank(description):
                 params["description"] = description
 
+            if self._is_not_blank(provision_mode):
+                params["provisionMode"] = provision_mode
+
             response = self.payments_cp_client.create_payment_connector(**params)
 
             payment_connector_id = response.get("paymentConnectorId")
             status = response.get("status")
+            authorization_url = response.get("authorizationUrl")
 
             logger.info("Payment connector created: %s (status: %s)", payment_connector_id, status)
 
@@ -728,10 +741,16 @@ class PaymentClient:
                 )
                 status = response.get("status")
 
-            return {
+            result = {
                 "paymentConnectorId": payment_connector_id,
                 "status": status,
             }
+            # Present only for QUICK_CREATE connectors awaiting OAuth consent
+            # (status PENDING_AUTHENTICATION); omitted otherwise.
+            if self._is_not_blank(authorization_url):
+                result["authorizationUrl"] = authorization_url
+
+            return result
 
         except ClientError as e:
             logger.error("Failed to create payment connector: %s", e)

--- a/src/bedrock_agentcore/payments/client.py
+++ b/src/bedrock_agentcore/payments/client.py
@@ -20,6 +20,8 @@ from bedrock_agentcore._utils.endpoints import get_control_plane_endpoint
 from bedrock_agentcore._utils.user_agent import build_user_agent_suffix
 from bedrock_agentcore.services.identity import IdentityClient
 
+from .constants import PaymentConnectorProvisionMode, PaymentConnectorStatus
+
 logger = logging.getLogger(__name__)
 
 
@@ -661,7 +663,7 @@ class PaymentClient:
         wait_for_ready: bool = False,
         max_wait: int = 300,
         poll_interval: int = 10,
-        provision_mode: Optional[str] = None,
+        provision_mode: Optional[Union[str, PaymentConnectorProvisionMode]] = None,
     ) -> Dict[str, Any]:
         """Create a payment connector for a provider.
 
@@ -692,7 +694,17 @@ class PaymentClient:
         Raises:
             ClientError: If creation fails
             TimeoutError: If wait_for_ready is True and max_wait is exceeded
+            ValueError: If wait_for_ready is used with QUICK_CREATE
         """
+        normalized_provision_mode = (
+            provision_mode.value if isinstance(provision_mode, PaymentConnectorProvisionMode) else provision_mode
+        )
+        if normalized_provision_mode == PaymentConnectorProvisionMode.QUICK_CREATE.value and wait_for_ready:
+            raise ValueError(
+                "wait_for_ready cannot be used with QUICK_CREATE; complete authorization first, "
+                "then poll get_payment_connector() for READY"
+            )
+
         if client_token is None:
             client_token = str(uuid.uuid4())
 
@@ -714,8 +726,8 @@ class PaymentClient:
             if self._is_not_blank(description):
                 params["description"] = description
 
-            if self._is_not_blank(provision_mode):
-                params["provisionMode"] = provision_mode
+            if self._is_not_blank(normalized_provision_mode):
+                params["provisionMode"] = normalized_provision_mode
 
             response = self.payments_cp_client.create_payment_connector(**params)
 
@@ -747,7 +759,7 @@ class PaymentClient:
             }
             # Present only for QUICK_CREATE connectors awaiting OAuth consent
             # (status PENDING_AUTHENTICATION); omitted otherwise.
-            if self._is_not_blank(authorization_url):
+            if status == PaymentConnectorStatus.PENDING_AUTHENTICATION.value and self._is_not_blank(authorization_url):
                 result["authorizationUrl"] = authorization_url
 
             return result
@@ -775,7 +787,7 @@ class PaymentClient:
                 paymentManagerId=payment_manager_id, paymentConnectorId=payment_connector_id
             )
 
-            return {
+            result = {
                 "paymentConnectorId": response.get("paymentConnectorId"),
                 "paymentManagerId": response.get("paymentManagerId"),
                 "name": response.get("name"),
@@ -785,6 +797,12 @@ class PaymentClient:
                 "createdAt": response.get("createdAt"),
                 "updatedAt": response.get("lastUpdatedAt"),
             }
+            authorization_url = response.get("authorizationUrl")
+            if response.get("status") == PaymentConnectorStatus.PENDING_AUTHENTICATION.value and self._is_not_blank(
+                authorization_url
+            ):
+                result["authorizationUrl"] = authorization_url
+            return result
 
         except ClientError as e:
             logger.error("Failed to get payment connector: %s", e)

--- a/src/bedrock_agentcore/payments/constants.py
+++ b/src/bedrock_agentcore/payments/constants.py
@@ -34,6 +34,14 @@ class PaymentConnectorType(Enum):
     STRIPE_PRIVY = "StripePrivy"
 
 
+class PaymentType(Enum):
+    """Payment protocols supported by ProcessPayment."""
+
+    CRYPTO_X402 = "CRYPTO_X402"
+    # MPP does not differentiate between crypto and fiat — one value covers both.
+    MPP = "MPP"
+
+
 class PaymentsAuthorizerType(Enum):
     """Payment manager authorizer types."""
 
@@ -70,3 +78,42 @@ NETWORK_PREFERENCES = [
     "eip155:84532",  # Base Sepolia (testnet)
     "eip155:11155111",  # Ethereum Sepolia (Test)
 ]
+
+# ─────────────────────────────────────────────────────────────
+# MPP (Machine Payments Protocol) — https://mpp.dev
+# ─────────────────────────────────────────────────────────────
+
+# Default MPP protocol version sent to ProcessPayment. The service model constrains
+# this to a bare numeric string (^[0-9]+$).
+MPP_DEFAULT_VERSION = "1"
+
+# The `Payment` auth-scheme name used in `WWW-Authenticate` / `Authorization` headers.
+MPP_AUTH_SCHEME = "Payment"
+
+# Only the `charge` intent is implemented. Challenges advertising `session` or
+# `subscription` are filtered out during selection.
+MPP_SUPPORTED_INTENT = "charge"
+
+# Payment method identifiers, mapped to the blockchain family of the payment
+# instrument that can satisfy them. Tempo is an EVM chain, so it maps to ETHEREUM.
+MPP_METHOD_BLOCKCHAIN = {
+    "evm": "ETHEREUM",
+    "tempo": "ETHEREUM",
+    "solana": "SOLANA",
+}
+
+# Maps a Solana `methodDetails.network` value to the network identifier used in
+# NETWORK_PREFERENCES. Per draft-solana-charge-00 the field is optional and
+# defaults to mainnet.
+#
+# `localnet` is deliberately absent. It denotes a distinct local RPC/Surfpool
+# environment, not Solana testnet; aliasing it would let a local-only challenge
+# satisfy a solana-testnet preference and outrank a genuinely payable devnet
+# challenge. Unmapped values are left unranked rather than misranked — they remain
+# selectable when they are the only option, but never win on preference order.
+MPP_SOLANA_NETWORK_ALIASES = {
+    "mainnet": "solana-mainnet",
+    "devnet": "solana-devnet",
+    "testnet": "solana-testnet",
+}
+MPP_SOLANA_DEFAULT_NETWORK = "mainnet"

--- a/src/bedrock_agentcore/payments/constants.py
+++ b/src/bedrock_agentcore/payments/constants.py
@@ -25,6 +25,11 @@ class PaymentConnectorStatus(Enum):
     CREATE_FAILED = "CREATE_FAILED"
     UPDATE_FAILED = "UPDATE_FAILED"
     DELETE_FAILED = "DELETE_FAILED"
+    # Quick Create (QUICK_CREATE provision mode) statuses
+    PENDING_AUTHENTICATION = "PENDING_AUTHENTICATION"
+    PROVISIONING = "PROVISIONING"
+    AUTHENTICATION_EXPIRED = "AUTHENTICATION_EXPIRED"
+    AUTHENTICATION_FAILED = "AUTHENTICATION_FAILED"
 
 
 class PaymentConnectorType(Enum):
@@ -32,6 +37,18 @@ class PaymentConnectorType(Enum):
 
     COINBASE_CDP = "CoinbaseCDP"
     STRIPE_PRIVY = "StripePrivy"
+
+
+class PaymentConnectorProvisionMode(Enum):
+    """Payment connector provisioning modes.
+
+    MANUAL (the default) requires the caller to supply the credential provider
+    configuration up front. QUICK_CREATE lets the service orchestrate OAuth
+    consent and provision the credential provider on the caller's behalf.
+    """
+
+    MANUAL = "MANUAL"
+    QUICK_CREATE = "QUICK_CREATE"
 
 
 class PaymentType(Enum):

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -50,6 +50,11 @@ class AgentCorePaymentsPluginConfig:
             When None (default), errors produce deterministic ToolMessages directly.
         max_error_retries: Maximum times the error callback can return RETRY per tool call.
             Default 3. Set to 0 to disable the callback entirely.
+        buyer_pays_gas_fees: MPP only. Authorizes charging blockchain network (gas) fees to
+            the buyer's wallet, on top of the payment amount. MPP challenges advertise who
+            sponsors fees via methodDetails.feePayer; when the seller does not, the service
+            signs only if this is True and otherwise fails validation. None (default) leaves
+            the protocol default in place and the field unsent. Ignored for x402.
     """
 
     payment_manager_arn: str
@@ -73,6 +78,7 @@ class AgentCorePaymentsPluginConfig:
     auto_session_expiry_minutes: int = 60
     on_payment_error: Optional[Callable] = None
     max_error_retries: int = 3
+    buyer_pays_gas_fees: Optional[bool] = None
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
@@ -133,6 +139,11 @@ class AgentCorePaymentsPluginConfig:
             raise ValueError(f"max_error_retries must be an int, got {type(self.max_error_retries).__name__}")
         if self.max_error_retries < 0:
             raise ValueError(f"max_error_retries must be >= 0, got {self.max_error_retries}")
+
+        if self.buyer_pays_gas_fees is not None and not isinstance(self.buyer_pays_gas_fees, bool):
+            raise ValueError(
+                f"buyer_pays_gas_fees must be a boolean or None, got {type(self.buyer_pays_gas_fees).__name__}"
+            )
 
     def update_payment_session_id(self, payment_session_id: str) -> None:
         """Update the payment session ID.

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
+from .._validation import validate_permit2_allowance_limit
 from .handlers import PaymentResponseHandler
 
 
@@ -151,16 +152,7 @@ class AgentCorePaymentsPluginConfig:
                 f"buyer_pays_gas_fees must be a boolean or None, got {type(self.buyer_pays_gas_fees).__name__}"
             )
 
-        if self.permit2_allowance_limit is not None:
-            if not isinstance(self.permit2_allowance_limit, str):
-                raise ValueError(
-                    "permit2_allowance_limit must be a string in the asset's smallest denomination, "
-                    f"got {type(self.permit2_allowance_limit).__name__}"
-                )
-            if not self.permit2_allowance_limit.isdigit() or int(self.permit2_allowance_limit) <= 0:
-                raise ValueError(
-                    f"permit2_allowance_limit must be a positive integer string, got {self.permit2_allowance_limit!r}"
-                )
+        validate_permit2_allowance_limit(self.permit2_allowance_limit)
 
     def update_payment_session_id(self, payment_session_id: str) -> None:
         """Update the payment session ID.

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -69,7 +69,6 @@ class AgentCorePaymentsPluginConfig:
     payment_connector_id: Optional[str] = None
     region: Optional[str] = None
     network_preferences_config: Optional[List[str]] = None
-    permit2_allowance_limit: Optional[str] = None
     auto_payment: bool = True
     agent_name: Optional[str] = None
     bearer_token: Optional[str] = None
@@ -85,6 +84,7 @@ class AgentCorePaymentsPluginConfig:
     on_payment_error: Optional[Callable] = None
     max_error_retries: int = 3
     buyer_pays_gas_fees: Optional[bool] = None
+    permit2_allowance_limit: Optional[str] = None
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -159,8 +159,7 @@ class AgentCorePaymentsPluginConfig:
                 )
             if not self.permit2_allowance_limit.isdigit() or int(self.permit2_allowance_limit) <= 0:
                 raise ValueError(
-                    "permit2_allowance_limit must be a positive integer string, "
-                    f"got {self.permit2_allowance_limit!r}"
+                    f"permit2_allowance_limit must be a positive integer string, got {self.permit2_allowance_limit!r}"
                 )
 
     def update_payment_session_id(self, payment_session_id: str) -> None:

--- a/src/bedrock_agentcore/payments/integrations/config.py
+++ b/src/bedrock_agentcore/payments/integrations/config.py
@@ -24,6 +24,11 @@ class AgentCorePaymentsPluginConfig:
         payment_connector_id: Payment connector ID (optional).
         region: AWS region for the payment manager.
         network_preferences_config: Ordered list of network CAIP2 identifiers.
+        permit2_allowance_limit: Optional maximum Permit2 allowance to grant, as a decimal
+            string in the asset's smallest denomination (for example, "1000000" for 1 USDC
+            at 6 decimals). Only applies to the x402 "upto" scheme; when set, the integration
+            forwards it so ProcessPayment submits an on-chain approve for the Permit2 contract
+            before signing. Leave unset (default) for the "exact" scheme.
         auto_payment: Whether to automatically process 402 responses. Default True.
         agent_name: Agent name propagated via HTTP header on data-plane calls.
         bearer_token: Static JWT for OAuth/CUSTOM_JWT auth. Mutually exclusive with token_provider.
@@ -64,6 +69,7 @@ class AgentCorePaymentsPluginConfig:
     payment_connector_id: Optional[str] = None
     region: Optional[str] = None
     network_preferences_config: Optional[List[str]] = None
+    permit2_allowance_limit: Optional[str] = None
     auto_payment: bool = True
     agent_name: Optional[str] = None
     bearer_token: Optional[str] = None
@@ -144,6 +150,18 @@ class AgentCorePaymentsPluginConfig:
             raise ValueError(
                 f"buyer_pays_gas_fees must be a boolean or None, got {type(self.buyer_pays_gas_fees).__name__}"
             )
+
+        if self.permit2_allowance_limit is not None:
+            if not isinstance(self.permit2_allowance_limit, str):
+                raise ValueError(
+                    "permit2_allowance_limit must be a string in the asset's smallest denomination, "
+                    f"got {type(self.permit2_allowance_limit).__name__}"
+                )
+            if not self.permit2_allowance_limit.isdigit() or int(self.permit2_allowance_limit) <= 0:
+                raise ValueError(
+                    "permit2_allowance_limit must be a positive integer string, "
+                    f"got {self.permit2_allowance_limit!r}"
+                )
 
     def update_payment_session_id(self, payment_session_id: str) -> None:
         """Update the payment session ID.

--- a/src/bedrock_agentcore/payments/integrations/handlers.py
+++ b/src/bedrock_agentcore/payments/integrations/handlers.py
@@ -1,8 +1,13 @@
-"""Tool-specific handlers for X.402 payment processing.
+"""Tool-specific handlers for payment processing.
 
 This module provides handlers for extracting payment information from different tool responses.
 Each handler is responsible for parsing tool-specific response formats and extracting
-HTTP status codes and X.402 payment requirements.
+HTTP status codes and payment requirements.
+
+Both supported protocols are handled: x402 (payment requirements in the response body or
+the ``Payment-Required`` header) and MPP (payment options advertised as
+``WWW-Authenticate: Payment`` challenges). Because handlers surface the full header
+dictionary, MPP challenges reach ``PaymentManager.generate_payment_header`` unmodified.
 """
 
 import ast
@@ -12,6 +17,33 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# Header carrying MPP payment challenges on a 402 response.
+_WWW_AUTHENTICATE = "www-authenticate"
+
+# The MPP auth-scheme name, lowercased for case-insensitive comparison.
+_MPP_SCHEME = "payment"
+
+
+def has_mpp_challenge(headers: Any) -> bool:
+    """Check whether a header mapping advertises a usable MPP ``Payment`` challenge.
+
+    Delegates to the MPP parser so detection and parsing can never disagree. A
+    hand-rolled prefix check here would drift: it would miss a ``Payment`` challenge
+    that follows another scheme (``Bearer ..., Payment ...``) and would falsely match
+    a hypothetical ``PaymentXYZ`` scheme.
+
+    Args:
+        headers: A header dictionary (case-insensitive keys) or any other value.
+
+    Returns:
+        True if a parseable ``WWW-Authenticate: Payment`` challenge is present.
+    """
+    from bedrock_agentcore.payments.mpp import is_mpp_payment_required
+
+    if not isinstance(headers, dict):
+        return False
+    return is_mpp_payment_required({"headers": headers})
 
 
 class PaymentResponseHandler(ABC):
@@ -336,21 +368,46 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
         """
         return isinstance(data, dict) and "x402Version" in data and "accepts" in data
 
+    @staticmethod
+    def _response_headers(result: Any) -> Dict[str, Any]:
+        """Extract the upstream response headers from an MCP Gateway result.
+
+        Returns:
+            The ``responseHeaders`` dict, or an empty dict if absent.
+        """
+        if not isinstance(result, dict):
+            return {}
+        headers = result.get("responseHeaders")
+        return headers if isinstance(headers, dict) else {}
+
+    def _is_payment_required(self, result: Any) -> bool:
+        """Check whether the MCP result represents a payment-required response.
+
+        Covers x402 (payment data in structuredContent) and MPP (a
+        ``WWW-Authenticate: Payment`` challenge in the upstream response headers).
+        """
+        if not isinstance(result, dict):
+            return False
+        if self._is_x402_payment_data(result.get("structuredContent")):
+            return True
+        return has_mpp_challenge(self._response_headers(result))
+
     def extract_status_code(self, result: Any) -> Optional[int]:
         """Extract status code from MCP Gateway tool result.
 
-        MCP Gateway returns HTTP 200 with x402 payment data embedded in
-        structuredContent, so there is no explicit 402 status code. We infer
-        402 from the presence of x402Version + accepts fields.
+        MCP Gateway returns HTTP 200 with the payment requirement embedded in the
+        response, so there is no explicit 402 status code. We infer 402 from the
+        presence of x402Version + accepts fields, or an MPP ``Payment`` challenge
+        in the upstream response headers.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            402 if x402 payment data found, None otherwise
+            402 if payment required data found, None otherwise
         """
         try:
-            if isinstance(result, dict) and self._is_x402_payment_data(result.get("structuredContent")):
+            if self._is_payment_required(result):
                 return 402
             return None
         except Exception as e:
@@ -360,18 +417,23 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
     def extract_headers(self, result: Any) -> Optional[Dict[str, Any]]:
         """Extract headers from MCP Gateway tool result.
 
-        Returns content-type header when structuredContent contains x402 data.
+        Returns the upstream ``responseHeaders`` when present — MPP challenges live
+        there and must be forwarded intact. Falls back to a synthetic content-type
+        header for x402 results, which carry their requirements in the body.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            Headers dict if x402 data found, None otherwise
+            Headers dict if payment required data found, None otherwise
         """
         try:
-            if isinstance(result, dict) and self._is_x402_payment_data(result.get("structuredContent")):
-                return {"content-type": "application/json"}
-            return None
+            if not self._is_payment_required(result):
+                return None
+            response_headers = self._response_headers(result)
+            if response_headers:
+                return response_headers
+            return {"content-type": "application/json"}
         except Exception as e:
             logger.error("Error extracting headers from MCP result: %s", str(e))
             return None
@@ -379,18 +441,22 @@ class MCPRequestPaymentHandler(PaymentResponseHandler):
     def extract_body(self, result: Any) -> Optional[Dict[str, Any]]:
         """Extract body from MCP Gateway tool result.
 
-        Returns the structuredContent dict directly when it contains x402 data.
+        Returns the structuredContent dict directly when it contains payment data.
 
         Args:
             result: The tool result from AfterToolCallEvent
 
         Returns:
-            structuredContent dict if x402 data found, None otherwise
+            structuredContent dict if payment required data found, None otherwise
         """
         try:
             if isinstance(result, dict):
                 sc = result.get("structuredContent")
                 if self._is_x402_payment_data(sc):
+                    return sc
+                # MPP carries its requirement in headers; surface any structured
+                # content so error details in the body remain available.
+                if has_mpp_challenge(self._response_headers(result)) and isinstance(sc, dict):
                     return sc
             return None
         except Exception as e:

--- a/src/bedrock_agentcore/payments/integrations/handlers.py
+++ b/src/bedrock_agentcore/payments/integrations/handlers.py
@@ -16,6 +16,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
+from bedrock_agentcore.payments.mpp import is_mpp_payment_required
+
 logger = logging.getLogger(__name__)
 
 # Header carrying MPP payment challenges on a 402 response.
@@ -39,8 +41,6 @@ def has_mpp_challenge(headers: Any) -> bool:
     Returns:
         True if a parseable ``WWW-Authenticate: Payment`` challenge is present.
     """
-    from bedrock_agentcore.payments.mpp import is_mpp_payment_required
-
     if not isinstance(headers, dict):
         return False
     return is_mpp_payment_required({"headers": headers})

--- a/src/bedrock_agentcore/payments/integrations/langgraph/README.md
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/README.md
@@ -1,12 +1,13 @@
 # LangGraph AgentCore Payments Middleware
 
-The AgentCore Payments Middleware enables LangGraph agents to autonomously handle [x402 Payment Required](https://www.x402.org/) responses. When a tool hits a paid API that returns HTTP 402, the middleware automatically detects the payment requirement, signs the payment via PaymentManager, and retries the request with payment credentials — all transparent to the LLM.
+The AgentCore Payments Middleware enables LangGraph agents to autonomously handle [x402 Payment Required](https://www.x402.org/) and [MPP (Machine Payments Protocol)](https://mpp.dev) responses. When a tool hits a paid API that returns HTTP 402, the middleware automatically detects the payment requirement, signs the payment via PaymentManager, and retries the request with payment credentials — all transparent to the LLM.
 
 ## Overview
 
-- **Automatic x402 Payment Handling** — intercepts 402 responses, processes payment, retries with proof
+- **Automatic Payment Handling** — intercepts 402 responses, processes payment, retries with proof
+- **Multi-Protocol Support** — x402 v1/v2 and MPP, detected automatically from the 402 response
 - **Zero Wrapper Code** — no manual tool wrapping needed; just pass `middleware=[payments]` to `create_agent`
-- **Multi-Format Detection** — handles `PAYMENT_REQUIRED:` marker, raw JSON `statusCode: 402`, and x402 payloads
+- **Multi-Format Detection** — handles `PAYMENT_REQUIRED:` marker, raw JSON `statusCode: 402`, x402 payloads, and MPP `WWW-Authenticate: Payment` challenges
 - **Custom Handler Registry** — register handlers for tools with non-standard response formats
 - **Built-in Tools** — payment-aware `http_request` + payment query tools auto-registered
 - **Deterministic Error Messages** — tailored, actionable error messages returned to the LLM on failure
@@ -142,7 +143,9 @@ When a tool returns, the middleware checks for 402 in this order:
 
 1. **Custom handler** (if registered for this tool name) — full control over detection
 2. **`PAYMENT_REQUIRED:` marker** — explicit opt-in signal in content
-3. **Lenient fallback** — parses raw JSON for `statusCode: 402` or `x402Version` + `accepts` fields
+3. **Lenient fallback** — parses raw JSON for `statusCode: 402`, `x402Version` + `accepts` fields, or a
+   `WWW-Authenticate: Payment` challenge in `responseHeaders`/`headers` (MPP advertises its payment options
+   in headers rather than the body, so the challenge is itself the 402 signal)
 
 This means MCP tools and other tools that return raw JSON are handled automatically without needing the marker or a custom handler.
 
@@ -351,11 +354,12 @@ agent = create_agent(
 |-----------|------|---------|-------------|
 | `payment_manager_arn` | `str` | *required* | ARN of the payment manager resource |
 | `user_id` | `str \| None` | `None` | User ID. Required for SigV4 auth; optional with bearer token |
-| `payment_instrument_id` | `str \| None` | `None` | Instrument ID for x402 signing |
+| `payment_instrument_id` | `str \| None` | `None` | Instrument ID for payment signing |
 | `payment_session_id` | `str \| None` | `None` | Session ID for budget enforcement |
 | `payment_connector_id` | `str \| None` | `None` | Connector ID (optional) |
 | `region` | `str \| None` | `None` | AWS region |
 | `network_preferences_config` | `list[str] \| None` | `None` | Ordered CAIP-2 network identifiers |
+| `buyer_pays_gas_fees` | `bool \| None` | `None` | MPP only. Authorizes network (gas) fees charged to the buyer's wallet. `None` leaves the protocol default (buyer declines) |
 | `auto_payment` | `bool` | `True` | Enable/disable automatic 402 processing |
 | `auto_session` | `bool` | `False` | Auto-create session on first 402 |
 | `auto_session_budget` | `str` | `"1.00"` | Budget (USD) for auto-created sessions |

--- a/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
@@ -501,6 +501,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             return result
 
         payment_required_request = None
+        payment_header = None
         try:
             payment_required_request = self._extract_payment_request(detection)
             payment_header = self._generate_payment_header(payment_required_request)
@@ -535,6 +536,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
                     tool_name=detection.tool_name,
                     tool_args=detection.tool_args,
                     payment_required_request=payment_required_request,
+                    payment_header=payment_header,
                     request=request,
                     handler=handler,
                 )
@@ -548,6 +550,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
         tool_name: str,
         tool_args: Dict[str, Any],
         payment_required_request: Optional[Dict[str, Any]],
+        payment_header: Optional[Dict[str, str]],
         request: "ToolCallRequest",
         handler: Callable,
     ) -> Optional[Union[ToolMessage, Command]]:
@@ -585,7 +588,8 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             logger.info("on_payment_error returned RETRY (attempt %d/%d)", retry_count, self.config.max_error_retries)
 
             try:
-                payment_header = self._generate_payment_header(payment_required_request or {})
+                if payment_header is None:
+                    payment_header = self._generate_payment_header(payment_required_request or {})
 
                 inject_error = self._inject_for_error_retry(request, tool_name, tool_args, payment_header)
                 if inject_error is not None:
@@ -636,6 +640,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             return result
 
         payment_required_request = None
+        payment_header = None
         try:
             payment_required_request = self._extract_payment_request(detection)
             payment_header = await asyncio.to_thread(self._generate_payment_header, payment_required_request)
@@ -670,6 +675,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
                     tool_name=detection.tool_name,
                     tool_args=detection.tool_args,
                     payment_required_request=payment_required_request,
+                    payment_header=payment_header,
                     request=request,
                     handler=handler,
                 )
@@ -683,6 +689,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
         tool_name: str,
         tool_args: Dict[str, Any],
         payment_required_request: Optional[Dict[str, Any]],
+        payment_header: Optional[Dict[str, str]],
         request: "ToolCallRequest",
         handler: Callable,
     ) -> Optional[Union[ToolMessage, Command]]:
@@ -718,7 +725,10 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             )
 
             try:
-                payment_header = await asyncio.to_thread(self._generate_payment_header, payment_required_request or {})
+                if payment_header is None:
+                    payment_header = await asyncio.to_thread(
+                        self._generate_payment_header, payment_required_request or {}
+                    )
 
                 inject_error = self._inject_for_error_retry(request, tool_name, tool_args, payment_header)
                 if inject_error is not None:

--- a/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
@@ -399,6 +399,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
             buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
+            permit2_allowance_limit=self.config.permit2_allowance_limit,
         )
 
     def _create_auto_session(self) -> None:

--- a/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
+++ b/src/bedrock_agentcore/payments/integrations/langgraph/middleware.py
@@ -20,6 +20,7 @@ from bedrock_agentcore.payments.integrations.handlers import (
     GenericPaymentHandler,
     PaymentResponseHandler,
     get_payment_handler,
+    has_mpp_challenge,
 )
 from bedrock_agentcore.payments.manager import (
     PaymentError,
@@ -181,6 +182,17 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             if "x402Version" in parsed and "accepts" in parsed:
                 logger.debug("Fallback detection: found x402 payload in raw JSON")
                 return {"statusCode": 402, "headers": {}, "body": parsed}
+
+            # MPP advertises payment options in headers rather than the body, so a
+            # WWW-Authenticate: Payment challenge is itself the 402 signal.
+            response_headers = parsed.get("responseHeaders") or parsed.get("headers")
+            if has_mpp_challenge(response_headers):
+                logger.debug("Fallback detection: found MPP Payment challenge in response headers")
+                return {
+                    "statusCode": 402,
+                    "headers": response_headers,
+                    "body": parsed.get("structuredContent") or parsed.get("body") or {},
+                }
 
             sc = parsed.get("structuredContent")
             if isinstance(sc, dict) and "x402Version" in sc and "accepts" in sc:
@@ -365,14 +377,18 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
         return None
 
     def _generate_payment_header(self, payment_required_request: Dict[str, Any]) -> Dict[str, str]:
-        """Generate payment header via PaymentManager."""
+        """Generate payment header via PaymentManager.
+
+        The payment protocol (x402 or MPP) is detected by PaymentManager from the 402
+        response, so this method is protocol-agnostic.
+        """
         if self.config.payment_instrument_id is None:
-            raise PaymentInstrumentConfigurationRequired("payment_instrument_id is required for x402 payments.")
+            raise PaymentInstrumentConfigurationRequired("payment_instrument_id is required for payments.")
         if self.config.payment_session_id is None:
             if self.config.auto_session:
                 self._create_auto_session()
             else:
-                raise PaymentSessionConfigurationRequired("payment_session_id is required for x402 payments.")
+                raise PaymentSessionConfigurationRequired("payment_session_id is required for payments.")
 
         return self.payment_manager.generate_payment_header(
             user_id=self.config.user_id,
@@ -382,6 +398,7 @@ class AgentCorePaymentsMiddleware(AgentMiddleware):
             network_preferences=self.config.network_preferences_config,
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
+            buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
         )
 
     def _create_auto_session(self) -> None:

--- a/src/bedrock_agentcore/payments/integrations/strands/README.md
+++ b/src/bedrock_agentcore/payments/integrations/strands/README.md
@@ -1,22 +1,22 @@
 # Strands AgentCore Payments Plugin
 
 The AgentCore Payments Plugin leverages Amazon Bedrock AgentCore Payments to provide automated payment processing
-capabilities for Strands Agents. It supports the [x402 Payment Required](https://www.x402.org/) protocol, enabling
-agents to automatically handle HTTP 402 responses by processing microtransaction payments to access paid APIs,
-MCP servers, and premium content.
+capabilities for Strands Agents. It supports the [x402 Payment Required](https://www.x402.org/) and
+[MPP (Machine Payments Protocol)](https://mpp.dev) protocols, enabling agents to automatically handle HTTP 402
+responses by processing microtransaction payments to access paid APIs, MCP servers, and premium content.
 
 ## Overview
 
-- **Automatic x402 Payment Handling** — intercepts HTTP 402 responses from tools, processes payment requirements, and retries requests with payment headers
+- **Automatic Payment Handling** — intercepts HTTP 402 responses from tools, processes payment requirements, and retries requests with payment headers
 - **Payment Query Tools** — built-in tools for agents to query payment instruments and sessions at runtime
-- **Multi-Protocol Support** — handles x402 v1 and v2 payment protocols
+- **Multi-Protocol Support** — handles x402 v1/v2 and MPP, detected automatically from the 402 response
 - **Multi-Handler Architecture** — supports generic tools, `http_request` tools, and MCP Gateway proxy tools
 - **Interrupt-Based Error Handling** — raises Strands SDK interrupts on payment failures so the agent (or application) can respond dynamically
 - **Configurable Auto-Payment** — enable or disable automatic payment processing per plugin instance
 
 ## How It Works
 
-### x402 Payment Flow
+### Payment Flow
 
 ```
 ┌─────────┐     ┌──────────┐     ┌──────────────┐     ┌────────────────┐
@@ -31,13 +31,29 @@ MCP servers, and premium content.
 ```
 
 1. Agent calls a tool (e.g., `http_request`) that hits a paid API
-2. The API returns HTTP 402 with x402 payment requirements
+2. The API returns HTTP 402 with payment requirements — x402 (body / `Payment-Required` header) or
+   MPP (`WWW-Authenticate: Payment` challenges)
 3. The plugin's `after_tool_call` hook intercepts the 402 response
 4. The plugin extracts payment requirements using the appropriate handler
-5. The plugin calls `PaymentManager.generate_payment_header()` to process the payment
-6. The payment header is applied to the tool input
+5. The plugin calls `PaymentManager.generate_payment_header()`, which detects the protocol,
+   selects a payment option, and processes the payment
+6. The payment header is applied to the tool input — `X-PAYMENT` (x402 v1),
+   `PAYMENT-SIGNATURE` (x402 v2), or `Authorization: Payment <token>` (MPP)
 7. The tool is automatically retried with the payment credentials
 8. The API returns a successful response
+
+### MPP challenge selection
+
+An MPP server may advertise several payment options, but `ProcessPayment` fulfills exactly one
+per call. The plugin delegates to `PaymentManager`, which filters to `charge`-intent,
+unexpired challenges your instrument can satisfy (`evm`/`tempo` → ETHEREUM, `solana` → SOLANA),
+orders them by `network_preferences_config`, and pays the best match. The selected challenge
+header is forwarded verbatim so its HMAC stays valid. See the
+[payments README](../../README.md#mpp-machine-payments-protocol) for the full algorithm.
+
+If a challenge does not offer seller-sponsored network fees, signing requires
+`buyer_pays_gas_fees=True` on the plugin config — the gas cost is not visible in the challenge
+`amount`, so it is not assumed on the buyer's behalf.
 
 ## Installation
 
@@ -429,6 +445,7 @@ agent("Fetch data from https://premium-api.example.com/data")
 | `payment_session_id` | `Optional[str]` | No | `None` | Payment session ID. Can be set later via `update_payment_session_id()` |
 | `region` | `Optional[str]` | No | `None` | AWS region for the payment manager |
 | `network_preferences_config` | `Optional[list[str]]` | No | `None` | List of network CAIP-2 identifiers in order of preference |
+| `buyer_pays_gas_fees` | `Optional[bool]` | No | `None` | MPP only. Authorizes network (gas) fees charged to the buyer's wallet, on top of the payment amount. `None` leaves the protocol default (buyer declines) |
 | `auto_payment` | `bool` | No | `True` | Whether to automatically process 402 payment requirements |
 | `max_interrupt_retries` | `int` | No | `5` | Maximum interrupt retries per tool use. Set to 0 to disable interrupts |
 | `agent_name` | `Optional[str]` | No | `None` | Agent name propagated via HTTP header on API calls |

--- a/src/bedrock_agentcore/payments/integrations/strands/plugin.py
+++ b/src/bedrock_agentcore/payments/integrations/strands/plugin.py
@@ -495,6 +495,7 @@ class AgentCorePaymentsPlugin(Plugin):
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
             buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
+            permit2_allowance_limit=self.config.permit2_allowance_limit,
         )
 
         logger.debug("Generated payment header: %s", list(payment_header_dict.keys()))

--- a/src/bedrock_agentcore/payments/integrations/strands/plugin.py
+++ b/src/bedrock_agentcore/payments/integrations/strands/plugin.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class AgentCorePaymentsPlugin(Plugin):
-    """Plugin for handling X402 payment requirements and providing payment tools in Strands Agents.
+    """Plugin for handling payment requirements and providing payment tools in Strands Agents.
 
     This plugin provides tools for querying payment information and making paid HTTP calls:
     - http_request: Call a (paid) HTTP endpoint; 402 responses are settled automatically
@@ -35,9 +35,15 @@ class AgentCorePaymentsPlugin(Plugin):
     - getPaymentSession: Retrieve details about a specific payment session
 
     The plugin also intercepts tool calls and responses to handle HTTP 402 Payment Required
-    responses by processing X402 payment requirements and retrying requests with
+    responses by processing the payment requirement and retrying requests with
     appropriate payment credentials. Payment processing is controlled by the auto_payment
     configuration flag (default: True).
+
+    Both payment protocols are supported and detected automatically from the 402 response:
+    x402 (requirements in the body or the ``Payment-Required`` header, settled with an
+    ``X-PAYMENT`` / ``PAYMENT-SIGNATURE`` header) and MPP (options advertised as
+    ``WWW-Authenticate: Payment`` challenges, settled with an ``Authorization: Payment
+    <token>`` header).
 
     Attributes:
         name: Plugin identifier ("agent-core-payments-plugin")
@@ -258,6 +264,12 @@ class AgentCorePaymentsPlugin(Plugin):
             # can submit in the same second the signature was minted, hitting the
             # contract's strict ``block.timestamp > validAfter`` check and producing
             # a misleading "invalid_payload" 402 from the seller.
+            #
+            # This applies to MPP too: an evm-charge credential of type "authorization"
+            # is an EIP-3009 authorization carrying the same validAfter field. The delay
+            # is harmless for credential types that settle without it (e.g. Solana push
+            # mode, where the transaction is already confirmed) and is configurable via
+            # post_payment_retry_delay_seconds.
             delay = self.config.post_payment_retry_delay_seconds
             if delay > 0:
                 logger.info(
@@ -435,13 +447,17 @@ class AgentCorePaymentsPlugin(Plugin):
         """Process 402 payment required request and generate payment header.
 
         Calls PaymentManager.generate_payment_header with the 402 payment required request
-        and returns the payment header dictionary.
+        and returns the payment header dictionary. The payment protocol (x402 or MPP) is
+        detected from the 402 response by PaymentManager, so this method is
+        protocol-agnostic.
 
         Args:
             payment_required_request: Dictionary containing 402 payment requirements with statusCode, headers, and body
 
         Returns:
-            Dictionary with payment header name and value (e.g., {"X-PAYMENT": "base64..."})
+            Dictionary with payment header name and value. For x402:
+            {"X-PAYMENT": "base64..."} or {"PAYMENT-SIGNATURE": "base64..."}.
+            For MPP: {"Authorization": "Payment <base64url-token>"}.
 
         Raises:
             PaymentError: If payment processing fails
@@ -453,7 +469,7 @@ class AgentCorePaymentsPlugin(Plugin):
 
         if self.config.payment_instrument_id is None:
             raise PaymentInstrumentConfigurationRequired(
-                "payment_instrument_id is required for x402 payments.\n"
+                "payment_instrument_id is required for payments.\n"
                 "Setup steps:\n"
                 "1. Create instrument: PaymentManager.create_payment_instrument(connector_id, type, details, user_id)\n"
                 "2. Fund wallet: https://faucet.circle.com/ (Base Sepolia, USDC, paste wallet address)\n"
@@ -463,7 +479,7 @@ class AgentCorePaymentsPlugin(Plugin):
 
         if self.config.payment_session_id is None:
             raise PaymentSessionConfigurationRequired(
-                "payment_session_id is required for x402 payments.\n"
+                "payment_session_id is required for payments.\n"
                 "Create a session: PaymentManager.create_payment_session(expiry_time_in_minutes, user_id, limits)\n"
                 "Then pass session_id in invoke payload or plugin config.\n"
                 "Tip: use 'agentcore invoke --payment-session-id <id>' or '--auto-session' from the CLI."
@@ -478,6 +494,7 @@ class AgentCorePaymentsPlugin(Plugin):
             network_preferences=self.config.network_preferences_config,
             client_token=str(uuid.uuid4()),
             payment_connector_id=self.config.payment_connector_id,
+            buyer_pays_gas_fees=self.config.buyer_pays_gas_fees,
         )
 
         logger.debug("Generated payment header: %s", list(payment_header_dict.keys()))
@@ -768,16 +785,20 @@ class AgentCorePaymentsPlugin(Plugin):
         """Call an HTTP endpoint. 402 Payment Required responses are settled automatically.
 
         When the endpoint responds with HTTP 402, this plugin's after_tool_call hook
-        intercepts the result, generates an x402 payment header via the configured
-        PaymentManager, mutates ``headers`` with the X-PAYMENT (v1) or
-        PAYMENT-SIGNATURE (v2) header, and Strands re-invokes this tool — yielding
-        the final 200 response and (when applicable) a settle hash in the
-        PAYMENT-RESPONSE header.
+        intercepts the result, generates a payment header via the configured
+        PaymentManager, mutates ``headers`` with it, and Strands re-invokes this tool
+        — yielding the final 200 response and (when applicable) a settle hash in the
+        PAYMENT-RESPONSE header (x402) or a receipt in Payment-Receipt (MPP).
+
+        The header depends on the protocol detected in the 402: X-PAYMENT (x402 v1),
+        PAYMENT-SIGNATURE (x402 v2), or Authorization (MPP).
 
         Returns a Strands ToolResult dict: ``status`` is always ``success`` (HTTP
         errors are returned in the body, not raised), and ``content`` is a single
         text block. On 402 the text is prefixed with ``PAYMENT_REQUIRED:`` so the
-        SDK's payment handlers can extract the x402 payload.
+        SDK's payment handlers can extract the payment requirement. All response
+        headers are included verbatim, so MPP ``WWW-Authenticate`` challenges survive
+        intact.
 
         Args:
             url: The full URL to request.

--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -16,6 +16,7 @@ from botocore.exceptions import ClientError
 from bedrock_agentcore._utils.endpoints import get_data_plane_endpoint
 from bedrock_agentcore._utils.user_agent import build_user_agent_suffix
 
+from ._validation import validate_permit2_allowance_limit
 from .constants import MPP_AUTH_SCHEME, MPP_DEFAULT_VERSION
 from .mpp import (
     MppChallengeSelectionError,
@@ -1098,7 +1099,12 @@ class PaymentManager:
             # level (sibling of version/payload); ProcessPayment submits the on-chain
             # approve before signing. Omitted entirely when not set so the "exact"
             # flow is unaffected.
-            if permit2_allowance_limit is not None:
+            scheme = selected_accept.get("scheme")
+            if permit2_allowance_limit is not None and isinstance(scheme, str) and scheme.strip().lower() == "upto":
+                try:
+                    validate_permit2_allowance_limit(permit2_allowance_limit)
+                except ValueError as e:
+                    raise PaymentError(f"Input Validation: {e}") from e
                 payment_input["cryptoX402"]["permit2AllowanceLimit"] = permit2_allowance_limit
 
             # ProcessPayment does not accept paymentConnectorId — the connector is

--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -16,6 +16,14 @@ from botocore.exceptions import ClientError
 from bedrock_agentcore._utils.endpoints import get_data_plane_endpoint
 from bedrock_agentcore._utils.user_agent import build_user_agent_suffix
 
+from .constants import MPP_AUTH_SCHEME, MPP_DEFAULT_VERSION
+from .mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -915,6 +923,7 @@ class PaymentManager:
         network_preferences: Optional[list[str]] = None,
         client_token: Optional[str] = None,
         payment_connector_id: Optional[str] = None,
+        buyer_pays_gas_fees: Optional[bool] = None,
     ) -> Dict[str, str]:
         """Generate a payment header for 402 payment required request.
 
@@ -943,10 +952,18 @@ class PaymentManager:
                 forwarded to process_payment. ProcessPayment derives the connector
                 from the payment instrument; sending paymentConnectorId on that call
                 was rejected by the API as an unknown parameter.
+            buyer_pays_gas_fees: MPP only. Authorizes the service to sign a payment whose
+                blockchain network (gas) fees are charged to the buyer's own wallet, on top
+                of the payment amount. When the challenge does not offer seller-sponsored
+                fees (``methodDetails.feePayer`` is false or absent), the service signs only
+                if this is True and otherwise fails validation, so the caller can decide.
+                Omitted or False means the buyer declines to pay network fees. Has no effect
+                on challenges where the seller already sponsors them. Ignored for x402.
 
         Returns:
-            Dictionary with header name and value (e.g., {"X-PAYMENT": "base64..."} or
-            {"PAYMENT-SIGNATURE": "base64..."}) for X402 payment required request
+            Dictionary with header name and value. For x402: {"X-PAYMENT": "base64..."}
+            (v1) or {"PAYMENT-SIGNATURE": "base64..."} (v2). For MPP:
+            {"Authorization": "Payment <base64url-token>"}
 
         Raises:
             PaymentError: For validation or processing failures
@@ -971,6 +988,11 @@ class PaymentManager:
             )
             # Returns: {"X-PAYMENT": "base64..."} or {"PAYMENT-SIGNATURE": "base64..."}
             ```
+
+        Note:
+            The payment protocol is detected from the 402 response. A
+            ``WWW-Authenticate: Payment`` header routes to MPP; otherwise the
+            response is treated as x402.
         """
         user_id = user_id.strip() if user_id else None
 
@@ -1012,31 +1034,43 @@ class PaymentManager:
                     raise PaymentError("client_token is invalid - cannot be empty")
                 logger.debug("Using provided client_token: %s", client_token[:8] + "...")
 
-            # Step 4: Extract X.402 payload and detect version.
-            # Will have another method for MPP or any other payments protocols
+            # Step 4: Detect the payment protocol and dispatch. An MPP 402 advertises
+            # its payment options via 'WWW-Authenticate: Payment' challenges; x402
+            # carries them in the body or the Payment-Required header.
+            #
+            # A response may advertise both. MPP is preferred, but an MPP challenge the
+            # instrument cannot satisfy must not fail the whole payment when a payable
+            # x402 option is also on offer — so fall through to x402 in that case.
+            if is_mpp_payment_required(payment_required_request):
+                logger.debug("Detected MPP payment required request")
+                try:
+                    return self._generate_mpp_payment_header(
+                        payment_instrument_id=payment_instrument_id,
+                        payment_session_id=payment_session_id,
+                        payment_required_request=payment_required_request,
+                        user_id=user_id,
+                        network_preferences=network_preferences,
+                        client_token=client_token,
+                        buyer_pays_gas_fees=buyer_pays_gas_fees,
+                    )
+                except MppChallengeSelectionError as e:
+                    # Only selection failures are recoverable. A failure after the
+                    # payment was submitted must propagate: retrying under x402 could
+                    # charge the buyer twice.
+                    if not self._has_x402_payment_required(payment_required_request):
+                        raise PaymentError(str(e)) from e
+                    logger.info(
+                        "No satisfiable MPP challenge (%s); falling back to the x402 option "
+                        "advertised in the same 402 response",
+                        e,
+                    )
+
+            # Step 4b: x402 — extract payload and detect version.
             x402_payload, x402_version = self._extract_x402_payload(payment_required_request)
             logger.debug("Extracted X.402 payload version %d", x402_version)
 
             # Step 5: Retrieve payment instrument and extract network
-            instrument = self.get_payment_instrument(
-                user_id=user_id,
-                payment_instrument_id=payment_instrument_id,
-            )
-            logger.debug("Retrieved instrument: %s", instrument)
-
-            # Extract network from nested structure: paymentInstrumentDetails.embeddedCryptoWallet.network
-            network = None
-            if "paymentInstrumentDetails" in instrument:
-                details = instrument.get("paymentInstrumentDetails", {})
-                if "embeddedCryptoWallet" in details:
-                    network = details.get("embeddedCryptoWallet", {}).get("network")
-
-            if not network:
-                raise PaymentError(
-                    "Instrument Retrieval: Missing network information - "
-                    "instrument details do not contain network information at "
-                    "paymentInstrumentDetails.embeddedCryptoWallet.network"
-                )
+            network = self._get_instrument_network(payment_instrument_id, user_id)
             logger.debug("Retrieved instrument with network: %s", network)
 
             # Step 6: Validate instrument network and select matching accept
@@ -1087,6 +1121,206 @@ class PaymentManager:
         except Exception as e:
             logger.error("Unexpected error during payment header generation: %s", str(e))
             raise PaymentError(f"Unexpected error: {str(e)}") from e
+
+    def _has_x402_payment_required(self, payment_required_request: Dict[str, Any]) -> bool:
+        """Check whether a 402 response also carries an x402 payment requirement.
+
+        Used to decide whether an unsatisfiable MPP challenge can fall back to x402.
+        Deliberately read-only and non-raising: this runs inside an exception handler,
+        so a malformed x402 payload must report "no x402 option" rather than mask the
+        original MPP selection failure.
+
+        Args:
+            payment_required_request: Dict with statusCode, headers, and body.
+
+        Returns:
+            True if a parseable x402 requirement with a non-empty ``accepts`` list is present.
+        """
+        try:
+            x402_payload, _ = self._extract_x402_payload(payment_required_request)
+        except PaymentError:
+            return False
+        except Exception:  # pragma: no cover - defensive; extraction should raise PaymentError
+            return False
+
+        accepts = x402_payload.get("accepts")
+        return isinstance(accepts, list) and bool(accepts)
+
+    def _get_instrument_network(
+        self,
+        payment_instrument_id: str,
+        user_id: Optional[str],
+    ) -> str:
+        """Retrieve a payment instrument and extract its blockchain network.
+
+        Args:
+            payment_instrument_id: Unique identifier for the payment instrument
+            user_id: Unique identifier for the user (optional, omitted for bearer auth)
+
+        Returns:
+            The instrument's network (e.g. "ETHEREUM", "SOLANA")
+
+        Raises:
+            PaymentError: If the instrument carries no network information
+        """
+        instrument = self.get_payment_instrument(
+            user_id=user_id,
+            payment_instrument_id=payment_instrument_id,
+        )
+        logger.debug("Retrieved instrument: %s", instrument)
+
+        # Extract network from nested structure: paymentInstrumentDetails.embeddedCryptoWallet.network
+        network = None
+        if "paymentInstrumentDetails" in instrument:
+            details = instrument.get("paymentInstrumentDetails", {})
+            if "embeddedCryptoWallet" in details:
+                network = details.get("embeddedCryptoWallet", {}).get("network")
+
+        if not network:
+            raise PaymentError(
+                "Instrument Retrieval: Missing network information - "
+                "instrument details do not contain network information at "
+                "paymentInstrumentDetails.embeddedCryptoWallet.network"
+            )
+        return network
+
+    def _generate_mpp_payment_header(
+        self,
+        payment_instrument_id: str,
+        payment_session_id: str,
+        payment_required_request: Dict[str, Any],
+        user_id: Optional[str] = None,
+        network_preferences: Optional[list[str]] = None,
+        client_token: Optional[str] = None,
+        buyer_pays_gas_fees: Optional[bool] = None,
+    ) -> Dict[str, str]:
+        """Generate an MPP Authorization header for a 402 payment required response.
+
+        MPP servers advertise their payment options as ``WWW-Authenticate: Payment``
+        challenges. ProcessPayment fulfills exactly one challenge per call, so this
+        method selects the single challenge the instrument can satisfy and forwards its
+        raw header value verbatim — preserving the exact base64url ``request``/``opaque``
+        bytes the challenge HMAC binds to.
+
+        Args:
+            payment_instrument_id: Unique identifier for the payment instrument
+            payment_session_id: Unique identifier for the payment session
+            payment_required_request: Dict with statusCode, headers, and body
+            user_id: Unique identifier for the user (optional, omitted for bearer auth)
+            network_preferences: Optional network identifiers in order of preference.
+                Defaults to NETWORK_PREFERENCES from constants.
+            client_token: Idempotency token
+            buyer_pays_gas_fees: Authorizes charging blockchain network (gas) fees to the
+                buyer's wallet on top of the payment amount. Only sent when not None, so
+                omitting it preserves the service-side protocol default.
+
+        Returns:
+            Dictionary with the ready-to-send Authorization header,
+            e.g. {"Authorization": "Payment eyJ..."}
+
+        Raises:
+            PaymentError: If no challenge can be satisfied or payment processing fails
+        """
+        # Step 1: Parse the advertised challenges.
+        challenges = extract_challenges(payment_required_request)
+        logger.debug("Parsed %d MPP challenge(s) from 402 response", len(challenges))
+
+        # Step 2: Retrieve the instrument network to determine which methods we can pay.
+        network = self._get_instrument_network(payment_instrument_id, user_id)
+        logger.debug("Retrieved instrument with network: %s", network)
+
+        # Step 3: Select the one challenge to fulfill.
+        # MppChallengeSelectionError is allowed to propagate rather than being converted
+        # to PaymentError here: generate_payment_header distinguishes it from other
+        # failures so it can fall back to a payable x402 option in the same 402 response.
+        # Callers reaching this method through generate_payment_header still see a
+        # PaymentError, since that wrapper converts it when no fallback exists.
+        selected = select_challenge(
+            challenges,
+            instrument_network=network,
+            network_preferences=network_preferences,
+        )
+
+        selected_id = selected.get("id")
+        logger.debug(
+            "Selected MPP challenge id=%s method=%s",
+            selected_id,
+            selected.get("method"),
+        )
+
+        # Step 4: Process the payment. The raw header value is forwarded verbatim.
+        mpp_input: Dict[str, Any] = {
+            "version": MPP_DEFAULT_VERSION,
+            "wwwAuthenticateHeaders": [selected["raw"]],
+        }
+
+        # Only send buyerPaysGasFees when the caller expressed an intent. Omitting it
+        # leaves the protocol default in place rather than asserting a choice the
+        # caller did not make.
+        #
+        # Require an actual bool and forward it unchanged. Coercing with bool() would
+        # make the string "false" authorize additional wallet charges, since every
+        # non-empty string is truthy — a silent, money-moving misread of the caller's
+        # intent. This matches the strict validation on the integration config.
+        if buyer_pays_gas_fees is not None:
+            if not isinstance(buyer_pays_gas_fees, bool):
+                raise PaymentError(
+                    "Input Validation: buyer_pays_gas_fees must be a boolean or None, got "
+                    f"{type(buyer_pays_gas_fees).__name__}. Pass True or False explicitly — "
+                    "values are not coerced, because authorizing network fees must be unambiguous."
+                )
+            mpp_input["buyerPaysGasFees"] = buyer_pays_gas_fees
+
+        payment_input = {"mpp": mpp_input}
+
+        payment_result = self.process_payment(
+            user_id=user_id,
+            payment_session_id=payment_session_id,
+            payment_instrument_id=payment_instrument_id,
+            payment_type="MPP",
+            payment_input=payment_input,
+            client_token=client_token,
+        )
+        logger.debug("MPP payment processed successfully")
+
+        # Step 5: Extract the minted credential.
+        # Defend against malformed payloads at each level rather than chaining .get():
+        # a null or non-object member would otherwise surface as an opaque AttributeError
+        # instead of a message naming the field at fault.
+        payment_output = payment_result.get("paymentOutput") if isinstance(payment_result, dict) else None
+        mpp_output = payment_output.get("mpp") if isinstance(payment_output, dict) else None
+        if not isinstance(mpp_output, dict) or not mpp_output:
+            raise PaymentError(
+                "Payment Processing: Missing mpp in payment output - payment result does not contain an MPP credential"
+            )
+
+        credential = mpp_output.get("paymentCredential")
+        if not credential or not isinstance(credential, str) or not credential.strip():
+            raise PaymentError(
+                "Payment Processing: Missing paymentCredential - MPP payment output does not "
+                "contain a payment credential"
+            )
+
+        returned_id = mpp_output.get("selectedPaymentId")
+        if returned_id and selected_id and returned_id != selected_id:
+            # The service echoes the challenge it paid. A mismatch means we would attach
+            # a credential for a different challenge than the one we selected.
+            raise PaymentError(
+                f"Payment Processing: Challenge mismatch - requested challenge "
+                f"'{selected_id}' but the service paid '{returned_id}'"
+            )
+
+        # Step 6: Build the Authorization header. The service returns a ready-to-send
+        # value; only add the scheme prefix if it is not already present.
+        credential = credential.strip()
+        scheme_prefix = f"{MPP_AUTH_SCHEME} "
+        if credential.lower().startswith(scheme_prefix.lower()):
+            header_value = credential
+        else:
+            header_value = f"{scheme_prefix}{credential}"
+
+        logger.info("Successfully generated MPP payment header for challenge %s", selected_id)
+        return {"Authorization": header_value}
 
     def __getattr__(self, name: str):
         """Dynamically forward method calls to the PaymentClient.

--- a/src/bedrock_agentcore/payments/manager.py
+++ b/src/bedrock_agentcore/payments/manager.py
@@ -924,6 +924,7 @@ class PaymentManager:
         client_token: Optional[str] = None,
         payment_connector_id: Optional[str] = None,
         buyer_pays_gas_fees: Optional[bool] = None,
+        permit2_allowance_limit: Optional[str] = None,
     ) -> Dict[str, str]:
         """Generate a payment header for 402 payment required request.
 
@@ -959,6 +960,13 @@ class PaymentManager:
                 if this is True and otherwise fails validation, so the caller can decide.
                 Omitted or False means the buyer declines to pay network fees. Has no effect
                 on challenges where the seller already sponsors them. Ignored for x402.
+            permit2_allowance_limit: Optional maximum Permit2 allowance to grant, as a
+                decimal string in the asset's smallest denomination (for example,
+                "1000000" for 1 USDC at 6 decimals). Only applies to the x402 "upto"
+                scheme; when set, ProcessPayment submits an on-chain approve for the
+                Permit2 contract before signing. Supplying it for the "exact" scheme is
+                a validation error. Omit it (the default) to leave the cryptoX402 input
+                unchanged.
 
         Returns:
             Dictionary with header name and value. For x402: {"X-PAYMENT": "base64..."}
@@ -1085,6 +1093,13 @@ class PaymentManager:
                     "payload": selected_accept,
                 }
             }
+
+            # Opt-in Permit2 allowance for the "upto" scheme. Sits at the cryptoX402
+            # level (sibling of version/payload); ProcessPayment submits the on-chain
+            # approve before signing. Omitted entirely when not set so the "exact"
+            # flow is unaffected.
+            if permit2_allowance_limit is not None:
+                payment_input["cryptoX402"]["permit2AllowanceLimit"] = permit2_allowance_limit
 
             # ProcessPayment does not accept paymentConnectorId — the connector is
             # resolved server-side from the payment instrument. The argument is

--- a/src/bedrock_agentcore/payments/mpp.py
+++ b/src/bedrock_agentcore/payments/mpp.py
@@ -25,6 +25,7 @@ import base64
 import binascii
 import json
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -41,6 +42,8 @@ logger = logging.getLogger(__name__)
 
 # Header names that may carry MPP challenges on a 402 response.
 _WWW_AUTHENTICATE = "www-authenticate"
+_REQUIRED_CHALLENGE_FIELDS = ("id", "realm", "method", "intent", "request")
+_BASE64URL_PATTERN = re.compile(r"[A-Za-z0-9_-]+\Z")
 
 
 class MppChallengeSelectionError(Exception):
@@ -164,7 +167,7 @@ def parse_www_authenticate(header_value: str) -> List[Dict[str, Any]]:
         header_value: Raw header value, possibly containing several challenges.
 
     Returns:
-        List of challenge dicts. Each contains the parsed auth-params (``id``,
+        List of valid challenge dicts. Each contains the parsed auth-params (``id``,
         ``realm``, ``method``, ``intent``, ``request``, ``expires``, ``opaque``, plus
         any unknown params) and a ``raw`` key holding the verbatim single-challenge
         header value to forward to ProcessPayment.
@@ -180,7 +183,10 @@ def parse_www_authenticate(header_value: str) -> List[Dict[str, Any]]:
     def _flush() -> None:
         if current is not None and current_parts:
             current["raw"] = f"{MPP_AUTH_SCHEME} " + ", ".join(current_parts)
-            challenges.append(current)
+            if _is_valid_challenge(current):
+                challenges.append(current)
+            else:
+                logger.debug("MPP: discarded malformed challenge id=%s", current.get("id"))
 
     for part in _split_outside_quotes(header_value):
         lowered = part.lower()
@@ -278,13 +284,13 @@ def decode_challenge_request(challenge: Dict[str, Any]) -> Dict[str, Any]:
         unusable challenge rather than failing the whole call.
     """
     encoded = challenge.get("request")
-    if not encoded or not isinstance(encoded, str):
+    if not encoded or not isinstance(encoded, str) or not _BASE64URL_PATTERN.fullmatch(encoded):
         return {}
 
     # base64url without padding — restore padding before decoding.
     padded = encoded + "=" * (-len(encoded) % 4)
     try:
-        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        decoded = base64.b64decode(padded.encode("ascii"), altchars=b"-_", validate=True)
         request = json.loads(decoded)
     except (binascii.Error, ValueError, json.JSONDecodeError, UnicodeDecodeError) as e:
         logger.debug("MPP: failed to decode challenge request for id=%s: %s", challenge.get("id"), e)
@@ -294,6 +300,20 @@ def decode_challenge_request(challenge: Dict[str, Any]) -> Dict[str, Any]:
         logger.debug("MPP: challenge request for id=%s decoded to a non-object", challenge.get("id"))
         return {}
     return request
+
+
+def _is_valid_challenge(challenge: Dict[str, Any]) -> bool:
+    """Return whether a parsed challenge satisfies the core MPP requirements."""
+    for field in _REQUIRED_CHALLENGE_FIELDS:
+        value = challenge.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return False
+
+    method = challenge["method"]
+    if not method.isascii() or not method.isalpha() or method.lower() != method:
+        return False
+
+    return bool(decode_challenge_request(challenge))
 
 
 def challenge_network(challenge: Dict[str, Any]) -> Optional[str]:
@@ -406,10 +426,11 @@ def select_challenge(
     Raises:
         MppChallengeSelectionError: If no advertised challenge can be satisfied.
     """
+    challenges = [challenge for challenge in challenges if _is_valid_challenge(challenge)]
     if not challenges:
         raise MppChallengeSelectionError(
             "MPP Challenge Selection: No challenges - the 402 response contained no "
-            "parseable 'WWW-Authenticate: Payment' challenge."
+            "valid 'WWW-Authenticate: Payment' challenge."
         )
 
     blockchain = (instrument_network or "").strip().upper()
@@ -425,10 +446,8 @@ def select_challenge(
     skipped_intents: List[str] = []
     expired_count = 0
     for challenge in challenges:
-        intent = (challenge.get("intent") or "").strip().lower()
-        # Per draft-*-charge-00 the intent MUST be lowercase; an absent intent is
-        # treated as charge since charge is the only intent this SDK implements.
-        if intent and intent != MPP_SUPPORTED_INTENT:
+        intent = challenge["intent"].strip().lower()
+        if intent != MPP_SUPPORTED_INTENT:
             skipped_intents.append(intent)
             continue
         if is_expired(challenge, reference):

--- a/src/bedrock_agentcore/payments/mpp.py
+++ b/src/bedrock_agentcore/payments/mpp.py
@@ -1,0 +1,492 @@
+"""MPP (Machine Payments Protocol) challenge parsing and selection.
+
+MPP is an open protocol for machine-to-machine payments (https://mpp.dev). A server
+that requires payment answers with ``402 Payment Required`` and one or more
+``WWW-Authenticate: Payment ...`` challenges. The client picks a challenge it can
+satisfy, pays it, and retries the request with an ``Authorization: Payment <token>``
+credential.
+
+The AgentCore Payments ``ProcessPayment`` API fulfills exactly one challenge per call
+(``WwwAuthenticateHeaderList`` is constrained to a single entry), so this module
+provides the selection logic that reduces a list of advertised challenges to the one
+the caller's payment instrument can pay — mirroring how x402 accept headers are
+narrowed by network preference.
+
+Only the ``charge`` intent is implemented, across the ``evm``, ``tempo`` and ``solana``
+payment methods.
+
+Parsing is deliberately lenient about unknown auth-params: per the MPP specification,
+"Unknown parameters must be ignored by clients". The raw header value is always
+preserved verbatim so the exact base64url ``request``/``opaque`` bytes that the
+challenge HMAC binds to are forwarded to the service unchanged.
+"""
+
+import base64
+import binascii
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .constants import (
+    MPP_AUTH_SCHEME,
+    MPP_METHOD_BLOCKCHAIN,
+    MPP_SOLANA_DEFAULT_NETWORK,
+    MPP_SOLANA_NETWORK_ALIASES,
+    MPP_SUPPORTED_INTENT,
+    NETWORK_PREFERENCES,
+)
+
+logger = logging.getLogger(__name__)
+
+# Header names that may carry MPP challenges on a 402 response.
+_WWW_AUTHENTICATE = "www-authenticate"
+
+
+class MppChallengeSelectionError(Exception):
+    """Raised when no advertised MPP challenge can be satisfied.
+
+    Defined here rather than in ``manager`` to keep this module import-cycle free;
+    ``PaymentManager`` re-raises it as a ``PaymentError``.
+    """
+
+
+def _split_outside_quotes(value: str, delimiter: str = ",") -> List[str]:
+    """Split *value* on *delimiter*, ignoring delimiters inside quoted strings.
+
+    RFC 9110 auth-param values may be quoted strings containing commas, so a naive
+    ``str.split(",")`` would corrupt them.
+
+    Args:
+        value: The string to split.
+        delimiter: Single character to split on.
+
+    Returns:
+        List of parts with surrounding whitespace stripped. Empty parts are dropped.
+    """
+    parts: List[str] = []
+    current: List[str] = []
+    in_quotes = False
+    escaped = False
+
+    for char in value:
+        if escaped:
+            current.append(char)
+            escaped = False
+            continue
+        if char == "\\" and in_quotes:
+            current.append(char)
+            escaped = True
+            continue
+        if char == '"':
+            in_quotes = not in_quotes
+            current.append(char)
+            continue
+        if char == delimiter and not in_quotes:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+
+    parts.append("".join(current).strip())
+    return [p for p in parts if p]
+
+
+def _unquote(value: str) -> str:
+    """Remove surrounding double quotes from an auth-param value and unescape it."""
+    value = value.strip()
+    if len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+        inner = value[1:-1]
+        return inner.replace('\\"', '"').replace("\\\\", "\\")
+    return value
+
+
+def _parse_auth_param(part: str) -> Optional[tuple]:
+    """Parse a single ``key=value`` auth-param.
+
+    Args:
+        part: The auth-param text, e.g. ``id="aB3cDeF4"``.
+
+    Returns:
+        ``(lowercased_key, unquoted_value)``, or None if *part* is not a ``key=value`` pair.
+    """
+    if "=" not in part:
+        return None
+    key, _, raw_value = part.partition("=")
+    key = key.strip().lower()
+    if not key:
+        return None
+    return key, _unquote(raw_value)
+
+
+def _starts_new_auth_scheme(part: str) -> bool:
+    """Check whether *part* begins a new (non-Payment) auth-scheme.
+
+    A ``WWW-Authenticate`` field may list several challenges across different schemes,
+    separated by the same commas that separate auth-params. Per RFC 9110 a challenge
+    opens with a bare scheme token, optionally followed by its first auth-param —
+    ``Bearer`` or ``Bearer realm="x"`` — whereas an auth-param belonging to the current
+    challenge is just ``key=value``. The distinguishing feature is whitespace before
+    the ``=``: a scheme token precedes its first param, so the text left of ``=``
+    contains a space.
+
+    Args:
+        part: One comma-separated segment of the header value.
+
+    Returns:
+        True if *part* opens a scheme other than ``Payment``.
+    """
+    stripped = part.strip()
+    if not stripped:
+        return False
+
+    head = stripped.partition("=")[0]
+    # `key=value` -> no whitespace in the key. `Scheme key=value` -> whitespace.
+    # A bare token with no `=` at all is also a scheme (e.g. a valueless `Negotiate`).
+    if "=" in stripped and not head.strip().count(" "):
+        return False
+
+    token = stripped.split()[0]
+    return token.lower() != MPP_AUTH_SCHEME.lower()
+
+
+def parse_www_authenticate(header_value: str) -> List[Dict[str, Any]]:
+    """Parse ``WWW-Authenticate`` header value(s) into MPP challenges.
+
+    A single header field value may advertise more than one challenge, and servers
+    commonly emit one ``WWW-Authenticate`` line per payment option. Both forms are
+    handled: the value is split on the ``Payment`` auth-scheme token, and each
+    resulting group is parsed into auth-params.
+
+    Non-``Payment`` schemes (e.g. ``Bearer``) are ignored.
+
+    Args:
+        header_value: Raw header value, possibly containing several challenges.
+
+    Returns:
+        List of challenge dicts. Each contains the parsed auth-params (``id``,
+        ``realm``, ``method``, ``intent``, ``request``, ``expires``, ``opaque``, plus
+        any unknown params) and a ``raw`` key holding the verbatim single-challenge
+        header value to forward to ProcessPayment.
+    """
+    if not header_value or not isinstance(header_value, str):
+        return []
+
+    challenges: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    current_parts: List[str] = []
+    scheme_prefix = MPP_AUTH_SCHEME.lower() + " "
+
+    def _flush() -> None:
+        if current is not None and current_parts:
+            current["raw"] = f"{MPP_AUTH_SCHEME} " + ", ".join(current_parts)
+            challenges.append(current)
+
+    for part in _split_outside_quotes(header_value):
+        lowered = part.lower()
+        # A part that begins with the scheme name starts a new challenge.
+        if lowered.startswith(scheme_prefix) or lowered == MPP_AUTH_SCHEME.lower():
+            _flush()
+            current = {}
+            current_parts = []
+            remainder = part[len(MPP_AUTH_SCHEME) :].strip()
+            if remainder:
+                parsed = _parse_auth_param(remainder)
+                if parsed:
+                    current[parsed[0]] = parsed[1]
+                    current_parts.append(remainder)
+            continue
+
+        # A part that opens some other auth-scheme (e.g. `Bearer realm="x"`) ends the
+        # current challenge. Without this, that scheme's auth-params would be absorbed
+        # into the MPP challenge — and into its `raw` value, corrupting the exact bytes
+        # the challenge HMAC binds to.
+        if _starts_new_auth_scheme(part):
+            _flush()
+            current = None
+            current_parts = []
+            continue
+
+        if current is None:
+            # Auth-params belonging to a non-Payment scheme, or a malformed value.
+            continue
+
+        parsed = _parse_auth_param(part)
+        if parsed:
+            current[parsed[0]] = parsed[1]
+            current_parts.append(part)
+
+    _flush()
+    return challenges
+
+
+def extract_challenges(payment_required_request: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Collect all MPP challenges from a 402 payment required request.
+
+    Scans headers case-insensitively for ``WWW-Authenticate``. A header value may be a
+    single string or a list of strings (some HTTP clients expose repeated headers as a
+    list); both are supported.
+
+    Args:
+        payment_required_request: Dict with ``statusCode``, ``headers`` and ``body``.
+
+    Returns:
+        List of parsed challenge dicts, in the order advertised by the server.
+    """
+    headers = payment_required_request.get("headers") or {}
+    if not isinstance(headers, dict):
+        return []
+
+    challenges: List[Dict[str, Any]] = []
+    for key, value in headers.items():
+        if not isinstance(key, str) or key.lower() != _WWW_AUTHENTICATE:
+            continue
+        values = value if isinstance(value, (list, tuple)) else [value]
+        for entry in values:
+            challenges.extend(parse_www_authenticate(entry))
+
+    return challenges
+
+
+def is_mpp_payment_required(payment_required_request: Dict[str, Any]) -> bool:
+    """Check whether a 402 response advertises at least one MPP ``Payment`` challenge.
+
+    Used to route a 402 to the MPP code path instead of the x402 one.
+
+    Args:
+        payment_required_request: Dict with ``statusCode``, ``headers`` and ``body``.
+
+    Returns:
+        True if a parseable ``WWW-Authenticate: Payment`` challenge is present.
+    """
+    if not isinstance(payment_required_request, dict):
+        return False
+    return bool(extract_challenges(payment_required_request))
+
+
+def decode_challenge_request(challenge: Dict[str, Any]) -> Dict[str, Any]:
+    """Decode a challenge's ``request`` auth-param into its JSON object.
+
+    The ``request`` param is JCS-canonicalized JSON, base64url-encoded without padding.
+
+    Args:
+        challenge: A parsed challenge dict.
+
+    Returns:
+        The decoded request object, or an empty dict if absent or undecodable.
+        Decoding never raises — selection treats an undecodable request as an
+        unusable challenge rather than failing the whole call.
+    """
+    encoded = challenge.get("request")
+    if not encoded or not isinstance(encoded, str):
+        return {}
+
+    # base64url without padding — restore padding before decoding.
+    padded = encoded + "=" * (-len(encoded) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii"))
+        request = json.loads(decoded)
+    except (binascii.Error, ValueError, json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.debug("MPP: failed to decode challenge request for id=%s: %s", challenge.get("id"), e)
+        return {}
+
+    if not isinstance(request, dict):
+        logger.debug("MPP: challenge request for id=%s decoded to a non-object", challenge.get("id"))
+        return {}
+    return request
+
+
+def challenge_network(challenge: Dict[str, Any]) -> Optional[str]:
+    """Derive the network identifier for a challenge, for preference ordering.
+
+    EVM-family challenges carry ``methodDetails.chainId``, which maps to the CAIP-2
+    style ``eip155:<chainId>`` identifiers used in ``NETWORK_PREFERENCES``. Solana
+    challenges carry an optional ``methodDetails.network`` (mainnet/devnet/localnet),
+    defaulting to mainnet.
+
+    Args:
+        challenge: A parsed challenge dict.
+
+    Returns:
+        Lowercased network identifier, or None if it cannot be determined.
+    """
+    method = (challenge.get("method") or "").lower()
+    request = decode_challenge_request(challenge)
+    method_details = request.get("methodDetails")
+    if not isinstance(method_details, dict):
+        method_details = {}
+
+    if MPP_METHOD_BLOCKCHAIN.get(method) == "ETHEREUM":
+        chain_id = method_details.get("chainId")
+        if isinstance(chain_id, bool) or chain_id is None:
+            return None
+        try:
+            return f"eip155:{int(chain_id)}"
+        except (TypeError, ValueError):
+            return None
+
+    if MPP_METHOD_BLOCKCHAIN.get(method) == "SOLANA":
+        network = method_details.get("network")
+        if not isinstance(network, str) or not network.strip():
+            network = MPP_SOLANA_DEFAULT_NETWORK
+        return MPP_SOLANA_NETWORK_ALIASES.get(network.strip().lower())
+
+    return None
+
+
+def _parse_expires(value: Any) -> Optional[datetime]:
+    """Parse an RFC 3339 ``expires`` auth-param into a timezone-aware datetime."""
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    # datetime.fromisoformat on Python 3.10 does not accept a trailing "Z".
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        logger.debug("MPP: unparseable expires value %r", value)
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def is_expired(challenge: Dict[str, Any], now: Optional[datetime] = None) -> bool:
+    """Check whether a challenge's ``expires`` auth-param is in the past.
+
+    A challenge with no ``expires`` param, or an unparseable one, is treated as not
+    expired — the service is the authority on validity, and discarding a challenge we
+    merely failed to parse would be worse than attempting it.
+
+    Args:
+        challenge: A parsed challenge dict.
+        now: Reference time. Defaults to the current UTC time.
+
+    Returns:
+        True if the challenge has definitively expired.
+    """
+    expires = _parse_expires(challenge.get("expires"))
+    if expires is None:
+        return False
+    reference = now or datetime.now(timezone.utc)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=timezone.utc)
+    return expires <= reference
+
+
+def select_challenge(
+    challenges: List[Dict[str, Any]],
+    instrument_network: str,
+    network_preferences: Optional[List[str]] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Select the one challenge to pay from those the server advertised.
+
+    Selection process (mirrors x402 accept selection):
+
+    1. Drop challenges whose ``intent`` is not ``charge`` — only charge is implemented.
+    2. Drop challenges that have definitively expired.
+    3. Keep only challenges whose ``method`` the instrument's blockchain can satisfy
+       (``evm``/``tempo`` require an ETHEREUM instrument, ``solana`` a SOLANA one).
+    4. Order the survivors by ``network_preferences`` (default ``NETWORK_PREFERENCES``),
+       deriving each challenge's network from its decoded ``request``.
+    5. Tiebreak on the soonest expiry, then on server order.
+
+    Args:
+        challenges: Parsed challenges, in the order the server advertised them.
+        instrument_network: The instrument's network (``ETHEREUM`` or ``SOLANA``).
+        network_preferences: Optional network identifiers, most preferred first.
+            Defaults to ``NETWORK_PREFERENCES``.
+        now: Reference time for expiry checks. Defaults to the current UTC time.
+
+    Returns:
+        The selected challenge dict.
+
+    Raises:
+        MppChallengeSelectionError: If no advertised challenge can be satisfied.
+    """
+    if not challenges:
+        raise MppChallengeSelectionError(
+            "MPP Challenge Selection: No challenges - the 402 response contained no "
+            "parseable 'WWW-Authenticate: Payment' challenge."
+        )
+
+    blockchain = (instrument_network or "").strip().upper()
+    if blockchain not in {"ETHEREUM", "SOLANA"}:
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: Unsupported instrument network '{instrument_network}'. "
+            f"Supported networks are ETHEREUM and SOLANA."
+        )
+
+    # Step 1 & 2: intent and expiry filters.
+    reference = now or datetime.now(timezone.utc)
+    candidates = []
+    skipped_intents: List[str] = []
+    expired_count = 0
+    for challenge in challenges:
+        intent = (challenge.get("intent") or "").strip().lower()
+        # Per draft-*-charge-00 the intent MUST be lowercase; an absent intent is
+        # treated as charge since charge is the only intent this SDK implements.
+        if intent and intent != MPP_SUPPORTED_INTENT:
+            skipped_intents.append(intent)
+            continue
+        if is_expired(challenge, reference):
+            expired_count += 1
+            continue
+        candidates.append(challenge)
+
+    if not candidates:
+        intent_detail = f": {', '.join(sorted(set(skipped_intents)))}" if skipped_intents else ""
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: No usable challenge - all {len(challenges)} advertised "
+            f"challenge(s) were rejected ({expired_count} expired, "
+            f"{len(skipped_intents)} with unsupported intent{intent_detail}). "
+            f"Only the '{MPP_SUPPORTED_INTENT}' intent is supported."
+        )
+
+    # Step 3: keep only methods the instrument can satisfy.
+    supported = []
+    seen_methods: List[str] = []
+    for challenge in candidates:
+        method = (challenge.get("method") or "").strip().lower()
+        if method:
+            seen_methods.append(method)
+        if MPP_METHOD_BLOCKCHAIN.get(method) == blockchain:
+            supported.append(challenge)
+
+    if not supported:
+        raise MppChallengeSelectionError(
+            f"MPP Challenge Selection: No matching challenge - no advertised payment method "
+            f"can be satisfied by an instrument on network '{blockchain}'. "
+            f"Advertised methods: {', '.join(sorted(set(seen_methods))) or 'none'}. "
+            f"Supported methods: {', '.join(sorted(MPP_METHOD_BLOCKCHAIN))}."
+        )
+
+    # Step 4: order by network preference.
+    preferences = network_preferences if network_preferences is not None else NETWORK_PREFERENCES
+    normalized_preferences = [p.lower() for p in preferences]
+
+    def sort_key(indexed):
+        index, challenge = indexed
+        network = challenge_network(challenge)
+        try:
+            rank = normalized_preferences.index(network) if network else len(normalized_preferences)
+        except ValueError:
+            rank = len(normalized_preferences)
+        # Step 5: soonest expiry first, then server order. Challenges without an
+        # expiry sort last among equals so bounded offers are taken first.
+        expires = _parse_expires(challenge.get("expires"))
+        has_expiry = 0 if expires is not None else 1
+        expiry_ts = expires.timestamp() if expires is not None else 0.0
+        return (rank, has_expiry, expiry_ts, index)
+
+    selected = min(enumerate(supported), key=sort_key)[1]
+    logger.debug(
+        "MPP: selected challenge id=%s method=%s network=%s from %d candidate(s)",
+        selected.get("id"),
+        selected.get("method"),
+        challenge_network(selected),
+        len(supported),
+    )
+    return selected

--- a/tests/bedrock_agentcore/payments/integrations/langgraph/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/integrations/langgraph/test_mpp.py
@@ -1,0 +1,262 @@
+"""Tests for MPP (Machine Payments Protocol) support in the LangGraph middleware."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain.messages import ToolMessage
+
+from bedrock_agentcore.payments.integrations.langgraph import AgentCorePaymentsConfig
+from bedrock_agentcore.payments.integrations.langgraph.middleware import AgentCorePaymentsMiddleware
+from bedrock_agentcore.payments.manager import PaymentError
+
+CHALLENGE = (
+    'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+)
+MPP_CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+
+def _make_config(**overrides):
+    defaults = {
+        "payment_manager_arn": "arn:aws:bedrock-agentcore:us-east-1:123456789012:payment-manager/pm-1",
+        "user_id": "user-1",
+        "payment_instrument_id": "instr-1",
+        "payment_session_id": "sess-1",
+        "post_payment_retry_delay_seconds": 0,
+    }
+    defaults.update(overrides)
+    return AgentCorePaymentsConfig(**defaults)
+
+
+def _make_request(tool_name="http_request", tool_args=None, tool_id="tc-1"):
+    req = MagicMock()
+    req.tool_call = {
+        "name": tool_name,
+        "args": tool_args if tool_args is not None else {"url": "http://x.com", "headers": {}},
+        "id": tool_id,
+    }
+    return req
+
+
+def _mpp_402_content(challenge=CHALLENGE):
+    """A spec-compliant PAYMENT_REQUIRED marker carrying an MPP challenge."""
+    payload = json.dumps(
+        {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge, "content-type": "application/json"},
+            "body": {},
+        }
+    )
+    return f"PAYMENT_REQUIRED: {payload}"
+
+
+def _mpp_402_raw_content(challenge=CHALLENGE):
+    """A raw JSON 402 with no marker — exercises fallback detection."""
+    return json.dumps({"responseHeaders": {"WWW-Authenticate": challenge}, "structuredContent": {}})
+
+
+def _200_content():
+    return json.dumps({"statusCode": 200, "body": {"data": "paid content"}})
+
+
+class TestMppFallbackDetection:
+    """A header-only MPP 402 must be detected without an explicit status code."""
+
+    def test_detects_mpp_challenge_in_response_headers(self):
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(_mpp_402_raw_content())
+
+        assert detected is not None
+        assert detected["statusCode"] == 402
+        assert detected["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_detects_mpp_challenge_under_headers_key(self):
+        content = json.dumps({"headers": {"WWW-Authenticate": CHALLENGE}})
+
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(content)
+
+        assert detected is not None
+        assert detected["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_ignores_bearer_challenge(self):
+        content = json.dumps({"responseHeaders": {"WWW-Authenticate": 'Bearer realm="x"'}})
+
+        assert AgentCorePaymentsMiddleware._fallback_detect_402(content) is None
+
+    def test_x402_detection_still_takes_precedence(self):
+        content = json.dumps({"x402Version": 1, "accepts": [{"network": "base-sepolia"}]})
+
+        detected = AgentCorePaymentsMiddleware._fallback_detect_402(content)
+
+        assert detected["body"]["x402Version"] == 1
+
+    def test_non_payment_response_is_not_detected(self):
+        assert AgentCorePaymentsMiddleware._fallback_detect_402(json.dumps({"statusCode": 200})) is None
+
+
+class TestMppSyncFlow:
+    """The sync path must settle MPP 402s and retry with the Authorization header."""
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_402_then_200_on_retry(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        success = ToolMessage(content=_200_content(), tool_call_id="tc-1")
+
+        calls = [0]
+
+        def handler(req):
+            calls[0] += 1
+            if calls[0] == 1:
+                return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+            return success
+
+        result = mw.wrap_tool_call(request, handler)
+
+        assert result is success
+        assert calls[0] == 2
+        mock_pm.generate_payment_header.assert_called_once()
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_authorization_header_injected_into_tool_args(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request(tool_args={"url": "http://x.com", "headers": {}})
+
+        mw.wrap_tool_call(
+            request,
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert request.tool_call["args"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_challenge_reaches_payment_manager(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        request_arg = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request_arg["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_selection_failure_returns_error_tool_message(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP Challenge Selection: No matching challenge")
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        result = mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(return_value=ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")),
+        )
+
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == "tc-1"
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_auto_payment_disabled_skips_mpp(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mw = AgentCorePaymentsMiddleware(_make_config(auto_payment=False))
+        msg = ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+
+        result = mw.wrap_tool_call(_make_request(), MagicMock(return_value=msg))
+
+        assert result is msg
+        mock_pm.generate_payment_header.assert_not_called()
+
+    @pytest.mark.parametrize("configured", [True, False, None])
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_buyer_pays_gas_fees_is_forwarded_from_config(self, mock_pm_cls, configured):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config(buyer_pays_gas_fees=configured))
+
+        mw.wrap_tool_call(
+            _make_request(),
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is configured
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_x402_flow_is_unaffected(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "sig"}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        x402 = f"PAYMENT_REQUIRED: {json.dumps({'statusCode': 402, 'headers': {}, 'body': {'x402Version': 1}})}"
+
+        mw.wrap_tool_call(
+            request,
+            MagicMock(
+                side_effect=[
+                    ToolMessage(content=x402, tool_call_id="tc-1"),
+                    ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+                ]
+            ),
+        )
+
+        assert request.tool_call["args"]["headers"]["X-PAYMENT"] == "sig"
+
+
+class TestMppAsyncFlow:
+    """The async path must behave identically to the sync path."""
+
+    @pytest.mark.asyncio
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    async def test_async_402_then_200_on_retry(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        mw = AgentCorePaymentsMiddleware(_make_config())
+        request = _make_request()
+        success = ToolMessage(content=_200_content(), tool_call_id="tc-1")
+
+        calls = [0]
+
+        async def handler(req):
+            calls[0] += 1
+            if calls[0] == 1:
+                return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+            return success
+
+        result = await mw.awrap_tool_call(request, handler)
+
+        assert result is success
+        assert calls[0] == 2
+        assert request.tool_call["args"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    @pytest.mark.asyncio
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    async def test_async_selection_failure_returns_error_message(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP Challenge Selection: No matching challenge")
+        mw = AgentCorePaymentsMiddleware(_make_config())
+
+        async def handler(req):
+            return ToolMessage(content=_mpp_402_content(), tool_call_id="tc-1")
+
+        result = await mw.awrap_tool_call(_make_request(), handler)
+
+        assert isinstance(result, ToolMessage)

--- a/tests/bedrock_agentcore/payments/integrations/langgraph/test_stage7.py
+++ b/tests/bedrock_agentcore/payments/integrations/langgraph/test_stage7.py
@@ -152,6 +152,27 @@ class TestRetryLoop:
     """Callback can retry multiple times up to max_error_retries."""
 
     @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_paid_request_retry_reuses_generated_payment(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "sig"}
+        config = _make_config(on_payment_error=lambda ctx: ErrorResolution.RETRY, max_error_retries=1)
+        middleware = AgentCorePaymentsMiddleware(config)
+        request = _make_request(tool_args={"url": "http://x.com", "headers": {}})
+        handler = MagicMock(
+            side_effect=[
+                ToolMessage(content=_402_content(), tool_call_id="tc-1"),
+                TimeoutError("ambiguous paid request failure"),
+                ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+            ]
+        )
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        assert json.loads(result.content)["statusCode"] == 200
+        mock_pm.generate_payment_header.assert_called_once()
+        assert request.tool_call["args"]["headers"]["X-PAYMENT"] == "sig"
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
     def test_max_retries_exhausted(self, mock_pm_cls):
         """Callback always retries but PM always fails → exhausts max retries."""
         mock_pm_cls.return_value.generate_payment_header.side_effect = PaymentError("always fails")
@@ -254,6 +275,27 @@ class TestContextPopulated:
 
 class TestAsyncErrorHandler:
     """Async callbacks are awaited correctly."""
+
+    @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
+    def test_paid_request_retry_reuses_generated_payment(self, mock_pm_cls):
+        mock_pm = mock_pm_cls.return_value
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "sig"}
+        config = _make_config(on_payment_error=lambda ctx: ErrorResolution.RETRY, max_error_retries=1)
+        middleware = AgentCorePaymentsMiddleware(config)
+        request = _make_request(tool_args={"url": "http://x.com", "headers": {}})
+        handler = AsyncMock(
+            side_effect=[
+                ToolMessage(content=_402_content(), tool_call_id="tc-1"),
+                TimeoutError("ambiguous paid request failure"),
+                ToolMessage(content=_200_content(), tool_call_id="tc-1"),
+            ]
+        )
+
+        result = asyncio.run(middleware.awrap_tool_call(request, handler))
+
+        assert json.loads(result.content)["statusCode"] == 200
+        mock_pm.generate_payment_header.assert_called_once()
+        assert request.tool_call["args"]["headers"]["X-PAYMENT"] == "sig"
 
     @patch("bedrock_agentcore.payments.integrations.langgraph.middleware.PaymentManager")
     def test_async_callback_awaited(self, mock_pm_cls):

--- a/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
+++ b/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
@@ -612,10 +612,13 @@ class TestAgentCorePaymentsPluginConfigPermit2AllowanceLimit:
         )
         assert config.permit2_allowance_limit == uint256_max
 
-    @pytest.mark.parametrize("bad_value", ["0", "-1", "1.5", "abc", "", "  "])
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["0", "-1", "1.5", "abc", "", "  ", "１２３", "²", "9" * 79],
+    )
     def test_non_positive_integer_string_raises(self, bad_value):
         """Non-positive-integer strings raise ValueError."""
-        with pytest.raises(ValueError, match="permit2_allowance_limit must be a positive integer string"):
+        with pytest.raises(ValueError, match="permit2_allowance_limit must be a positive ASCII integer"):
             AgentCorePaymentsPluginConfig(payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=bad_value)
 
     def test_non_string_raises(self):

--- a/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
+++ b/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
@@ -585,3 +585,44 @@ class TestAgentCorePaymentsPluginConfigWhitespaceUserId:
                 payment_manager_arn="arn:aws:payment:us-east-1:123456789012:payment-manager/test",
                 user_id="\t\t",
             )
+
+
+class TestAgentCorePaymentsPluginConfigPermit2AllowanceLimit:
+    """Test permit2_allowance_limit validation."""
+
+    _ARN = "arn:aws:payment:us-east-1:123456789012:payment-manager/test"
+
+    def test_none_default_is_valid(self):
+        """Default (None) is valid — the exact-scheme flow is unaffected."""
+        config = AgentCorePaymentsPluginConfig(payment_manager_arn=self._ARN, user_id="u")
+        assert config.permit2_allowance_limit is None
+
+    def test_positive_integer_string_is_valid(self):
+        """A positive integer string in the asset's smallest denomination is accepted."""
+        config = AgentCorePaymentsPluginConfig(
+            payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit="1000000"
+        )
+        assert config.permit2_allowance_limit == "1000000"
+
+    def test_uint256_max_string_is_valid(self):
+        """The uint256 max (unlimited allowance) is accepted."""
+        uint256_max = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+        config = AgentCorePaymentsPluginConfig(
+            payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=uint256_max
+        )
+        assert config.permit2_allowance_limit == uint256_max
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "1.5", "abc", "", "  "])
+    def test_non_positive_integer_string_raises(self, bad_value):
+        """Non-positive-integer strings raise ValueError."""
+        with pytest.raises(ValueError, match="permit2_allowance_limit must be a positive integer string"):
+            AgentCorePaymentsPluginConfig(
+                payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=bad_value
+            )
+
+    def test_non_string_raises(self):
+        """A non-string value raises ValueError."""
+        with pytest.raises(ValueError, match="permit2_allowance_limit must be a string"):
+            AgentCorePaymentsPluginConfig(
+                payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=1000000
+            )

--- a/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
+++ b/tests/bedrock_agentcore/payments/integrations/strands/test_config.py
@@ -616,13 +616,9 @@ class TestAgentCorePaymentsPluginConfigPermit2AllowanceLimit:
     def test_non_positive_integer_string_raises(self, bad_value):
         """Non-positive-integer strings raise ValueError."""
         with pytest.raises(ValueError, match="permit2_allowance_limit must be a positive integer string"):
-            AgentCorePaymentsPluginConfig(
-                payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=bad_value
-            )
+            AgentCorePaymentsPluginConfig(payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=bad_value)
 
     def test_non_string_raises(self):
         """A non-string value raises ValueError."""
         with pytest.raises(ValueError, match="permit2_allowance_limit must be a string"):
-            AgentCorePaymentsPluginConfig(
-                payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=1000000
-            )
+            AgentCorePaymentsPluginConfig(payment_manager_arn=self._ARN, user_id="u", permit2_allowance_limit=1000000)

--- a/tests/bedrock_agentcore/payments/integrations/strands/test_mpp_plugin.py
+++ b/tests/bedrock_agentcore/payments/integrations/strands/test_mpp_plugin.py
@@ -1,0 +1,321 @@
+"""Unit tests for MPP support in the Strands payments plugin."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bedrock_agentcore.payments.integrations.config import AgentCorePaymentsPluginConfig
+from bedrock_agentcore.payments.integrations.strands.plugin import AgentCorePaymentsPlugin
+from bedrock_agentcore.payments.manager import PaymentError
+
+PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/test"
+
+CHALLENGE = (
+    'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+)
+MPP_CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+
+def _create_mock_agent():
+    """Create a mock agent with a dict-backed state object."""
+    agent = MagicMock()
+    state_store = {}
+
+    def state_get(key=None):
+        if key is None:
+            return dict(state_store)
+        return state_store.get(key)
+
+    agent.state.get = MagicMock(side_effect=state_get)
+    agent.state.set = MagicMock(side_effect=lambda k, v: state_store.__setitem__(k, v))
+    agent.state.delete = MagicMock(side_effect=lambda k: state_store.pop(k, None))
+    agent._state_store = state_store
+    return agent
+
+
+def _create_event(result, tool_input=None, agent=None, invocation_state=None):
+    """Create a mock AfterToolCallEvent carrying *result*.
+
+    Pass the same *invocation_state* dict across events to simulate consecutive
+    attempts on one tool use — the plugin tracks signing and failure state there,
+    not on agent.state.
+    """
+    event = MagicMock()
+    event.agent = agent or _create_mock_agent()
+    event.result = result
+    event.tool_use = {
+        "name": "http_request",
+        "toolUseId": "tool-123",
+        "input": tool_input if tool_input is not None else {"headers": {}},
+    }
+    event.invocation_state = invocation_state if invocation_state is not None else {}
+    event.retry = False
+    return event
+
+
+def _config(**overrides):
+    kwargs = {
+        "payment_manager_arn": PAYMENT_MANAGER_ARN,
+        "user_id": "test-user",
+        "payment_instrument_id": "payment-instrument-123",
+        "payment_session_id": "payment-session-456",
+        "post_payment_retry_delay_seconds": 0,
+    }
+    kwargs.update(overrides)
+    return AgentCorePaymentsPluginConfig(**kwargs)
+
+
+def _mpp_402_result(challenge=CHALLENGE):
+    """Build an http_request tool result carrying an MPP 402."""
+    payload = {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": challenge, "content-type": "application/json"},
+        "body": {},
+    }
+    return [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]
+
+
+def _plugin_with_manager(mock_pm, config=None):
+    plugin = AgentCorePaymentsPlugin(config=config or _config())
+    plugin.payment_manager = mock_pm
+    return plugin
+
+
+class TestStrandsPluginMppFlow:
+    """The plugin must settle MPP 402s and retry with the Authorization header."""
+
+    def test_mpp_402_triggers_payment_and_retry(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        mock_pm.generate_payment_header.assert_called_once()
+
+    def test_authorization_header_is_applied_to_tool_input(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.tool_use["input"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    def test_www_authenticate_challenge_reaches_payment_manager(self):
+        """The plugin must forward the challenge header so selection can run."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        request = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request["statusCode"] == 402
+        assert request["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_existing_request_headers_are_preserved(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result(), tool_input={"headers": {"Accept": "application/json"}})
+
+        plugin.after_tool_call(event)
+
+        headers = event.tool_use["input"]["headers"]
+        assert headers["Accept"] == "application/json"
+        assert headers["Authorization"] == MPP_CREDENTIAL
+
+    def test_headers_dict_is_created_when_absent(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result(), tool_input={"url": "https://api.example.com/resource"})
+
+        plugin.after_tool_call(event)
+
+        assert event.tool_use["input"]["headers"]["Authorization"] == MPP_CREDENTIAL
+
+    def test_network_preferences_are_passed_through(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm, _config(network_preferences_config=["eip155:1"]))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["network_preferences"] == ["eip155:1"]
+
+    @pytest.mark.parametrize("configured", [True, False])
+    def test_buyer_pays_gas_fees_is_forwarded_from_config(self, configured):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm, _config(buyer_pays_gas_fees=configured))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is configured
+
+    def test_buyer_pays_gas_fees_defaults_to_none(self):
+        """Unset config must not assert a gas-fee choice on the caller's behalf."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert mock_pm.generate_payment_header.call_args.kwargs["buyer_pays_gas_fees"] is None
+
+    def test_non_boolean_buyer_pays_gas_fees_is_rejected_by_config(self):
+        with pytest.raises(ValueError, match="buyer_pays_gas_fees must be a boolean"):
+            _config(buyer_pays_gas_fees="yes")
+
+    def test_x402_flow_is_unaffected(self):
+        """Adding MPP must not change the existing x402 behavior."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"X-PAYMENT": "base64-encoded"}
+        plugin = _plugin_with_manager(mock_pm)
+        payload = {
+            "statusCode": 402,
+            "headers": {},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+        event = _create_event([{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}])
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        assert event.tool_use["input"]["headers"]["X-PAYMENT"] == "base64-encoded"
+
+
+class TestStrandsPluginMppErrors:
+    """Failures on the MPP path must surface like any other payment failure."""
+
+    def test_unsatisfiable_challenge_does_not_retry(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError(
+            "MPP Challenge Selection: No matching challenge - no advertised payment method"
+        )
+        plugin = _plugin_with_manager(mock_pm)
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is False
+        assert "Authorization" not in event.tool_use["input"].get("headers", {})
+
+    def test_payment_failure_state_is_recorded(self):
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError("MPP selection failed")
+        plugin = _plugin_with_manager(mock_pm)
+        invocation_state = {}
+        event = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+
+        plugin.after_tool_call(event)
+
+        failure = invocation_state.get("payment_failure_tool-123")
+        assert failure is not None, f"Expected payment failure state, got {invocation_state}"
+        assert "MPP selection failed" in str(failure)
+
+    def test_second_402_after_signing_is_not_retried(self):
+        """A 402 after a successful signing means server-side rejection."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": MPP_CREDENTIAL}
+        plugin = _plugin_with_manager(mock_pm)
+        # invocation_state is shared across attempts on the same tool use.
+        invocation_state = {}
+
+        first = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+        plugin.after_tool_call(first)
+        assert first.retry is True
+
+        second = _create_event(_mpp_402_result(), invocation_state=invocation_state)
+        plugin.after_tool_call(second)
+
+        assert second.retry is False
+        assert mock_pm.generate_payment_header.call_count == 1
+        assert "payment_failure_tool-123" in invocation_state
+
+    def test_auto_payment_disabled_skips_mpp(self):
+        mock_pm = MagicMock()
+        plugin = _plugin_with_manager(mock_pm, _config(auto_payment=False))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        mock_pm.generate_payment_header.assert_not_called()
+
+    def test_tool_not_in_allowlist_skips_mpp(self):
+        mock_pm = MagicMock()
+        plugin = _plugin_with_manager(mock_pm, _config(payment_tool_allowlist=["other_tool"]))
+        event = _create_event(_mpp_402_result())
+
+        plugin.after_tool_call(event)
+
+        mock_pm.generate_payment_header.assert_not_called()
+
+    def test_missing_instrument_id_raises_configuration_error(self):
+        """The setup hint must not be x402-specific now that MPP shares this path."""
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config(payment_instrument_id=None))
+        plugin.payment_manager = MagicMock()
+
+        with pytest.raises(Exception) as exc_info:
+            plugin._process_payment_required_request(
+                {"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}}
+            )
+
+        assert "payment_instrument_id is required" in str(exc_info.value)
+
+
+class TestStrandsHttpRequestToolPreservesChallenges:
+    """The built-in http_request tool must not strip WWW-Authenticate."""
+
+    def test_402_response_headers_are_forwarded_verbatim(self):
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.headers = {"WWW-Authenticate": CHALLENGE, "content-type": "application/json"}
+        mock_response.json.return_value = {}
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+            result = plugin.http_request(url="https://api.example.com/resource")
+
+        text = result["content"][0]["text"]
+        assert text.startswith("PAYMENT_REQUIRED: ")
+        payload = json.loads(text[len("PAYMENT_REQUIRED: ") :])
+        assert payload["statusCode"] == 402
+        assert payload["headers"]["WWW-Authenticate"] == CHALLENGE
+
+    def test_round_trip_challenge_survives_json_encoding(self):
+        """Base64url request bytes must be byte-identical after the tool's JSON hop."""
+        request_bytes = base64.urlsafe_b64encode(b'{"amount":"1000"}').decode().rstrip("=")
+        challenge = f'Payment id="x", method="evm", intent="charge", request="{request_bytes}"'
+
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager"):
+            plugin = AgentCorePaymentsPlugin(config=_config())
+
+        mock_response = MagicMock()
+        mock_response.status_code = 402
+        mock_response.headers = {"WWW-Authenticate": challenge}
+        mock_response.json.return_value = {}
+
+        with patch("httpx.Client") as mock_client:
+            mock_client.return_value.__enter__.return_value.request.return_value = mock_response
+            result = plugin.http_request(url="https://api.example.com/resource")
+
+        text = result["content"][0]["text"]
+        payload = json.loads(text[len("PAYMENT_REQUIRED: ") :])
+        assert payload["headers"]["WWW-Authenticate"] == challenge
+        assert request_bytes in payload["headers"]["WWW-Authenticate"]

--- a/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
+++ b/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
@@ -1,0 +1,202 @@
+"""Unit tests for MPP detection in the integration payment handlers."""
+
+import json
+
+import pytest
+
+from bedrock_agentcore.payments.integrations.handlers import (
+    GenericPaymentHandler,
+    HttpRequestPaymentHandler,
+    MCPRequestPaymentHandler,
+    has_mpp_challenge,
+)
+
+CHALLENGE = 'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhIjoxfQ"'
+
+
+class TestHasMppChallenge:
+    """Tests for the header-level MPP challenge probe."""
+
+    def test_detects_canonical_header(self):
+        assert has_mpp_challenge({"WWW-Authenticate": CHALLENGE}) is True
+
+    @pytest.mark.parametrize("name", ["www-authenticate", "WWW-Authenticate", "Www-Authenticate"])
+    def test_header_name_is_case_insensitive(self, name):
+        assert has_mpp_challenge({name: CHALLENGE}) is True
+
+    def test_detects_in_list_valued_header(self):
+        assert has_mpp_challenge({"www-authenticate": ['Bearer realm="x"', CHALLENGE]}) is True
+
+    def test_scheme_name_is_case_insensitive(self):
+        assert has_mpp_challenge({"www-authenticate": 'payment id="x"'}) is True
+
+    def test_rejects_bearer_scheme(self):
+        assert has_mpp_challenge({"WWW-Authenticate": 'Bearer realm="x"'}) is False
+
+    def test_detects_payment_challenge_following_another_scheme(self):
+        """A server may offer Bearer and Payment; the Payment option must still be found."""
+        header = f'Bearer realm="api", error="invalid_token", {CHALLENGE}'
+
+        assert has_mpp_challenge({"WWW-Authenticate": header}) is True
+
+    def test_rejects_scheme_merely_prefixed_with_payment(self):
+        """`PaymentXYZ` is a different scheme, not MPP."""
+        assert has_mpp_challenge({"WWW-Authenticate": 'PaymentXYZ realm="x"'}) is False
+
+    def test_rejects_bare_payment_token_with_no_auth_params(self):
+        """Nothing to fulfill, so this must not be reported as a payment requirement."""
+        assert has_mpp_challenge({"WWW-Authenticate": "Payment"}) is False
+
+    @pytest.mark.parametrize(
+        "header_value",
+        [
+            CHALLENGE,
+            f'Bearer realm="api", {CHALLENGE}',
+            'PaymentXYZ realm="x"',
+            "Payment",
+            'Bearer realm="x"',
+            "",
+        ],
+    )
+    def test_agrees_with_the_mpp_parser(self, header_value):
+        """Detection must never disagree with the parser that does the real work."""
+        from bedrock_agentcore.payments.mpp import is_mpp_payment_required
+
+        headers = {"WWW-Authenticate": header_value}
+
+        assert has_mpp_challenge(headers) == is_mpp_payment_required({"headers": headers})
+
+    def test_rejects_missing_header(self):
+        assert has_mpp_challenge({"content-type": "application/json"}) is False
+
+    @pytest.mark.parametrize("headers", [None, "string", 42, [], {"www-authenticate": 42}])
+    def test_malformed_input_is_false(self, headers):
+        assert has_mpp_challenge(headers) is False
+
+
+class TestGenericHandlerForwardsMppHeaders:
+    """The generic handler must surface WWW-Authenticate so MPP reaches PaymentManager."""
+
+    def _result(self, payload):
+        return {"content": [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]}
+
+    def test_extracts_402_status(self):
+        handler = GenericPaymentHandler()
+        result = self._result({"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}})
+
+        assert handler.extract_status_code(result) == 402
+
+    def test_forwards_www_authenticate_header_intact(self):
+        handler = GenericPaymentHandler()
+        result = self._result({"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}})
+
+        headers = handler.extract_headers(result)
+
+        assert headers["WWW-Authenticate"] == CHALLENGE
+
+    def test_applies_authorization_header_to_tool_input(self):
+        handler = GenericPaymentHandler()
+        tool_input = {"url": "https://api.example.com/resource"}
+
+        applied = handler.apply_payment_header(tool_input, {"Authorization": "Payment eyJhIjoxfQ"})
+
+        assert applied is True
+        assert tool_input["headers"]["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_authorization_header_merges_with_existing_headers(self):
+        handler = GenericPaymentHandler()
+        tool_input = {"url": "https://x", "headers": {"Accept": "application/json"}}
+
+        handler.apply_payment_header(tool_input, {"Authorization": "Payment tok"})
+
+        assert tool_input["headers"] == {"Accept": "application/json", "Authorization": "Payment tok"}
+
+
+class TestHttpRequestHandlerForwardsMppHeaders:
+    """The http_request handler's legacy text format must also carry MPP challenges."""
+
+    def test_legacy_headers_block_python_repr(self):
+        handler = HttpRequestPaymentHandler()
+        result = {
+            "content": [
+                {"text": "Status Code: 402"},
+                {"text": "Headers: " + repr({"WWW-Authenticate": CHALLENGE})},
+            ]
+        }
+
+        assert handler.extract_status_code(result) == 402
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+    def test_spec_compliant_marker_takes_precedence(self):
+        handler = HttpRequestPaymentHandler()
+        payload = {"statusCode": 402, "headers": {"WWW-Authenticate": CHALLENGE}, "body": {}}
+        result = {"content": [{"text": f"PAYMENT_REQUIRED: {json.dumps(payload)}"}]}
+
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+
+class TestMcpHandlerMppDetection:
+    """MCP Gateway returns 200 with the requirement embedded; MPP lives in headers."""
+
+    def test_infers_402_from_mpp_challenge_in_response_headers(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": CHALLENGE}, "structuredContent": {}}
+
+        assert handler.extract_status_code(result) == 402
+
+    def test_forwards_response_headers_for_mpp(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": CHALLENGE}, "structuredContent": {}}
+
+        assert handler.extract_headers(result)["WWW-Authenticate"] == CHALLENGE
+
+    def test_surfaces_structured_content_as_body_for_mpp(self):
+        handler = MCPRequestPaymentHandler()
+        result = {
+            "responseHeaders": {"WWW-Authenticate": CHALLENGE},
+            "structuredContent": {"error": "payment required"},
+        }
+
+        assert handler.extract_body(result) == {"error": "payment required"}
+
+    def test_x402_detection_is_unchanged(self):
+        handler = MCPRequestPaymentHandler()
+        x402 = {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]}
+        result = {"structuredContent": x402}
+
+        assert handler.extract_status_code(result) == 402
+        assert handler.extract_body(result) == x402
+        # No upstream headers present, so the synthetic content-type is used.
+        assert handler.extract_headers(result) == {"content-type": "application/json"}
+
+    def test_x402_prefers_real_response_headers_when_present(self):
+        handler = MCPRequestPaymentHandler()
+        result = {
+            "responseHeaders": {"content-type": "application/json", "x-request-id": "abc"},
+            "structuredContent": {"x402Version": 1, "accepts": []},
+        }
+
+        assert handler.extract_headers(result)["x-request-id"] == "abc"
+
+    def test_no_payment_requirement_returns_none(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"content-type": "application/json"}, "structuredContent": {"ok": True}}
+
+        assert handler.extract_status_code(result) is None
+        assert handler.extract_headers(result) is None
+        assert handler.extract_body(result) is None
+
+    def test_bearer_challenge_is_not_a_payment_requirement(self):
+        handler = MCPRequestPaymentHandler()
+        result = {"responseHeaders": {"WWW-Authenticate": 'Bearer realm="x"'}, "structuredContent": {}}
+
+        assert handler.extract_status_code(result) is None
+
+    def test_applies_authorization_header_inside_parameters(self):
+        handler = MCPRequestPaymentHandler()
+        tool_input = {"toolName": "fetch", "parameters": {"url": "https://x"}}
+
+        applied = handler.apply_payment_header(tool_input, {"Authorization": "Payment tok"})
+
+        assert applied is True
+        assert tool_input["parameters"]["headers"]["Authorization"] == "Payment tok"

--- a/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
+++ b/tests/bedrock_agentcore/payments/integrations/test_mpp_handlers.py
@@ -10,6 +10,7 @@ from bedrock_agentcore.payments.integrations.handlers import (
     MCPRequestPaymentHandler,
     has_mpp_challenge,
 )
+from bedrock_agentcore.payments.mpp import is_mpp_payment_required
 
 CHALLENGE = 'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhIjoxfQ"'
 
@@ -28,7 +29,7 @@ class TestHasMppChallenge:
         assert has_mpp_challenge({"www-authenticate": ['Bearer realm="x"', CHALLENGE]}) is True
 
     def test_scheme_name_is_case_insensitive(self):
-        assert has_mpp_challenge({"www-authenticate": 'payment id="x"'}) is True
+        assert has_mpp_challenge({"www-authenticate": CHALLENGE.replace("Payment ", "payment ", 1)}) is True
 
     def test_rejects_bearer_scheme(self):
         assert has_mpp_challenge({"WWW-Authenticate": 'Bearer realm="x"'}) is False
@@ -60,8 +61,6 @@ class TestHasMppChallenge:
     )
     def test_agrees_with_the_mpp_parser(self, header_value):
         """Detection must never disagree with the parser that does the real work."""
-        from bedrock_agentcore.payments.mpp import is_mpp_payment_required
-
         headers = {"WWW-Authenticate": header_value}
 
         assert has_mpp_challenge(headers) == is_mpp_payment_required({"headers": headers})

--- a/tests/bedrock_agentcore/payments/test_client.py
+++ b/tests/bedrock_agentcore/payments/test_client.py
@@ -275,7 +275,10 @@ class TestPaymentConnectorOperations:
     @patch("bedrock_agentcore.payments.client.boto3.client")
     @patch("bedrock_agentcore.payments.client.boto3.Session")
     def test_create_payment_connector_manual_omits_provision_mode(self, mock_session, mock_boto3_client):
-        """When provision_mode is not supplied, provisionMode is absent from the request (service defaults to MANUAL)."""
+        """Omit provisionMode when provision_mode is not supplied.
+
+        The service defaults the omitted field to MANUAL.
+        """
         mock_session.return_value.region_name = "us-west-2"
         mock_cp_client = MagicMock()
         mock_boto3_client.return_value = mock_cp_client

--- a/tests/bedrock_agentcore/payments/test_client.py
+++ b/tests/bedrock_agentcore/payments/test_client.py
@@ -241,6 +241,67 @@ class TestPaymentConnectorOperations:
 
     @patch("bedrock_agentcore.payments.client.boto3.client")
     @patch("bedrock_agentcore.payments.client.boto3.Session")
+    def test_create_payment_connector_quick_create(self, mock_session, mock_boto3_client):
+        """QUICK_CREATE passes provisionMode through and returns the authorizationUrl."""
+        mock_session.return_value.region_name = "us-west-2"
+        mock_cp_client = MagicMock()
+        mock_boto3_client.return_value = mock_cp_client
+
+        mock_cp_client.create_payment_connector.return_value = {
+            "paymentConnectorId": "pc-qc-1",
+            "status": "PENDING_AUTHENTICATION",
+            "authorizationUrl": "https://bedrock-agentcore.us-west-2.amazonaws.com/identities/oauth2/authorize?request_uri=urn:x",
+        }
+
+        client = PaymentClient(region_name="us-west-2")
+        result = client.create_payment_connector(
+            payment_manager_id="pm-123",
+            name="test-connector",
+            connector_type="CoinbaseCDP",
+            credential_provider_configurations=[],
+            provision_mode="QUICK_CREATE",
+        )
+
+        # provisionMode is threaded into the outgoing request.
+        call_kwargs = mock_cp_client.create_payment_connector.call_args[1]
+        assert call_kwargs["provisionMode"] == "QUICK_CREATE"
+        assert call_kwargs["credentialProviderConfigurations"] == []
+
+        # authorizationUrl is surfaced for a PENDING_AUTHENTICATION connector.
+        assert result["paymentConnectorId"] == "pc-qc-1"
+        assert result["status"] == "PENDING_AUTHENTICATION"
+        assert result["authorizationUrl"].startswith("https://")
+
+    @patch("bedrock_agentcore.payments.client.boto3.client")
+    @patch("bedrock_agentcore.payments.client.boto3.Session")
+    def test_create_payment_connector_manual_omits_provision_mode(self, mock_session, mock_boto3_client):
+        """When provision_mode is not supplied, provisionMode is absent from the request (service defaults to MANUAL)."""
+        mock_session.return_value.region_name = "us-west-2"
+        mock_cp_client = MagicMock()
+        mock_boto3_client.return_value = mock_cp_client
+
+        mock_cp_client.create_payment_connector.return_value = {
+            "paymentConnectorId": "pc-123",
+            "status": "READY",
+        }
+
+        client = PaymentClient(region_name="us-west-2")
+        result = client.create_payment_connector(
+            payment_manager_id="pm-123",
+            name="test-connector",
+            connector_type="CoinbaseCDP",
+            credential_provider_configurations=[
+                {"coinbaseCDP": {"credentialProviderArn": "arn:aws:secretsmanager:us-west-2:123456789012:secret:test"}}
+            ],
+        )
+
+        call_kwargs = mock_cp_client.create_payment_connector.call_args[1]
+        assert "provisionMode" not in call_kwargs
+        # No authorizationUrl in the response -> not present in the result.
+        assert "authorizationUrl" not in result
+
+    @patch("bedrock_agentcore.payments.client.boto3.client")
+    @patch("bedrock_agentcore.payments.client.boto3.Session")
     def test_get_payment_connector_success(self, mock_session, mock_boto3_client):
         """Test successful payment connector retrieval."""
         mock_session.return_value.region_name = "us-west-2"

--- a/tests/bedrock_agentcore/payments/test_client.py
+++ b/tests/bedrock_agentcore/payments/test_client.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
-from bedrock_agentcore.payments import PaymentClient
+from bedrock_agentcore.payments import PaymentClient, PaymentConnectorProvisionMode
 from bedrock_agentcore.payments.client import PaymentConnectorConfig
 
 # Get role ARN from environment variable, with fallback for testing
@@ -259,7 +259,7 @@ class TestPaymentConnectorOperations:
             name="test-connector",
             connector_type="CoinbaseCDP",
             credential_provider_configurations=[],
-            provision_mode="QUICK_CREATE",
+            provision_mode=PaymentConnectorProvisionMode.QUICK_CREATE,
         )
 
         # provisionMode is threaded into the outgoing request.
@@ -271,6 +271,26 @@ class TestPaymentConnectorOperations:
         assert result["paymentConnectorId"] == "pc-qc-1"
         assert result["status"] == "PENDING_AUTHENTICATION"
         assert result["authorizationUrl"].startswith("https://")
+
+    @patch("bedrock_agentcore.payments.client.boto3.client")
+    @patch("bedrock_agentcore.payments.client.boto3.Session")
+    def test_quick_create_rejects_wait_for_ready_before_create(self, mock_session, mock_boto3_client):
+        mock_session.return_value.region_name = "us-west-2"
+        mock_cp_client = MagicMock()
+        mock_boto3_client.return_value = mock_cp_client
+        client = PaymentClient(region_name="us-west-2")
+
+        with pytest.raises(ValueError, match="wait_for_ready cannot be used with QUICK_CREATE"):
+            client.create_payment_connector(
+                payment_manager_id="pm-123",
+                name="test-connector",
+                connector_type="CoinbaseCDP",
+                credential_provider_configurations=[],
+                provision_mode=PaymentConnectorProvisionMode.QUICK_CREATE,
+                wait_for_ready=True,
+            )
+
+        mock_cp_client.create_payment_connector.assert_not_called()
 
     @patch("bedrock_agentcore.payments.client.boto3.client")
     @patch("bedrock_agentcore.payments.client.boto3.Session")
@@ -327,6 +347,36 @@ class TestPaymentConnectorOperations:
 
         assert result["paymentConnectorId"] == "pc-123"
         assert result["name"] == "test-connector"
+
+    @pytest.mark.parametrize(
+        ("status", "includes_authorization_url"),
+        [("PENDING_AUTHENTICATION", True), ("READY", False)],
+    )
+    @patch("bedrock_agentcore.payments.client.boto3.client")
+    @patch("bedrock_agentcore.payments.client.boto3.Session")
+    def test_get_payment_connector_only_returns_live_authorization_url(
+        self,
+        mock_session,
+        mock_boto3_client,
+        status,
+        includes_authorization_url,
+    ):
+        mock_session.return_value.region_name = "us-west-2"
+        mock_cp_client = MagicMock()
+        mock_boto3_client.return_value = mock_cp_client
+        mock_cp_client.get_payment_connector.return_value = {
+            "paymentConnectorId": "pc-qc-1",
+            "paymentManagerId": "pm-123",
+            "name": "test-connector",
+            "type": "CoinbaseCDP",
+            "status": status,
+            "authorizationUrl": "https://example.com/authorize",
+        }
+
+        client = PaymentClient(region_name="us-west-2")
+        result = client.get_payment_connector("pm-123", "pc-qc-1")
+
+        assert ("authorizationUrl" in result) is includes_authorization_url
 
     @patch("bedrock_agentcore.payments.client.boto3.client")
     @patch("bedrock_agentcore.payments.client.boto3.Session")

--- a/tests/bedrock_agentcore/payments/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/test_mpp.py
@@ -163,7 +163,7 @@ class TestParseWwwAuthenticate:
 
     def test_quoted_value_containing_spaces_is_not_mistaken_for_a_scheme(self):
         """`description="fast access now"` is an auth-param, not a new scheme."""
-        header = 'Payment id="x", method="evm", description="fast access now"'
+        header = challenge_header("x", "evm", evm_request()) + ', description="fast access now"'
 
         challenges = parse_www_authenticate(header)
 
@@ -171,19 +171,25 @@ class TestParseWwwAuthenticate:
         assert challenges[0]["description"] == "fast access now"
 
     def test_scheme_name_is_case_insensitive(self):
-        challenges = parse_www_authenticate('payment id="x", method="evm", intent="charge"')
+        header = challenge_header("x", "evm", evm_request()).replace("Payment ", "payment ", 1)
+        challenges = parse_www_authenticate(header)
 
         assert len(challenges) == 1
         assert challenges[0]["id"] == "x"
 
     def test_auth_param_keys_are_lowercased(self):
-        challenges = parse_www_authenticate('Payment ID="x", Method="evm"')
+        header = (
+            challenge_header("x", "evm", evm_request())
+            .replace('id="x"', 'ID="x"')
+            .replace('method="evm"', 'Method="evm"')
+        )
+        challenges = parse_www_authenticate(header)
 
         assert challenges[0]["id"] == "x"
         assert challenges[0]["method"] == "evm"
 
     def test_commas_inside_quoted_values_are_not_split(self):
-        header = 'Payment id="x", method="evm", description="Premium, fast access"'
+        header = challenge_header("x", "evm", evm_request()) + ', description="Premium, fast access"'
 
         challenges = parse_www_authenticate(header)
 
@@ -191,7 +197,7 @@ class TestParseWwwAuthenticate:
         assert challenges[0]["description"] == "Premium, fast access"
 
     def test_escaped_quote_inside_quoted_value(self):
-        header = 'Payment id="x", method="evm", description="a \\"quoted\\" word"'
+        header = challenge_header("x", "evm", evm_request()) + ', description="a \\"quoted\\" word"'
 
         challenges = parse_www_authenticate(header)
 
@@ -199,7 +205,7 @@ class TestParseWwwAuthenticate:
 
     def test_unknown_auth_params_are_retained_not_rejected(self):
         """The spec requires clients to ignore unknown params, not fail on them."""
-        header = 'Payment id="x", method="evm", intent="charge", futureParam="v", opaque="o"'
+        header = challenge_header("x", "evm", evm_request()) + ', futureParam="v", opaque="o"'
 
         challenges = parse_www_authenticate(header)
 
@@ -208,7 +214,9 @@ class TestParseWwwAuthenticate:
         assert challenges[0]["opaque"] == "o"
 
     def test_unquoted_values_are_accepted(self):
-        challenges = parse_www_authenticate("Payment id=abc, method=evm, intent=charge")
+        challenges = parse_www_authenticate(
+            f"Payment id=abc, realm=api.example.com, method=evm, intent=charge, request={b64url(evm_request())}"
+        )
 
         assert challenges[0]["id"] == "abc"
         assert challenges[0]["method"] == "evm"
@@ -219,6 +227,35 @@ class TestParseWwwAuthenticate:
 
     def test_bare_payment_scheme_without_params_is_dropped(self):
         assert parse_www_authenticate("Payment") == []
+
+    @pytest.mark.parametrize("missing_field", ["id", "realm", "method", "intent", "request"])
+    def test_missing_required_field_is_rejected(self, missing_field):
+        values = {
+            "id": "x",
+            "realm": "api.example.com",
+            "method": "evm",
+            "intent": "charge",
+            "request": b64url(evm_request()),
+        }
+        del values[missing_field]
+        header = "Payment " + ", ".join(f'{name}="{value}"' for name, value in values.items())
+
+        assert parse_www_authenticate(header) == []
+
+    @pytest.mark.parametrize(
+        "encoded_request",
+        ["!!!not-base64!!!", b64url("not json"), b64url(["not", "object"])],
+    )
+    def test_invalid_request_is_rejected(self, encoded_request):
+        header = f'Payment id="x", realm="api.example.com", method="evm", intent="charge", request="{encoded_request}"'
+
+        assert parse_www_authenticate(header) == []
+
+    def test_invalid_sibling_does_not_suppress_valid_challenge(self):
+        invalid = 'Payment method="evm"'
+        valid = challenge_header("valid", "evm", evm_request())
+
+        assert [challenge["id"] for challenge in parse_www_authenticate(f"{invalid}, {valid}")] == ["valid"]
 
 
 class TestExtractChallenges:
@@ -326,29 +363,23 @@ class TestDecodeChallengeRequest:
         encoded = b64url(payload)
         assert not encoded.endswith("=")
 
-        challenge = parse_www_authenticate(f'Payment id="x", method="solana", request="{encoded}"')[0]
+        challenge = parse_www_authenticate(challenge_header("x", "solana", payload))[0]
 
         assert decode_challenge_request(challenge) == payload
 
-    @pytest.mark.parametrize(
-        "bad_request",
-        ['request="!!!not-base64!!!"', 'request="' + base64.urlsafe_b64encode(b"not json").decode() + '"'],
-    )
+    @pytest.mark.parametrize("bad_request", ["!!!not-base64!!!", base64.urlsafe_b64encode(b"not json").decode()])
     def test_undecodable_request_returns_empty_dict(self, bad_request):
-        challenge = parse_www_authenticate(f'Payment id="x", method="evm", {bad_request}')[0]
+        challenge = {"id": "x", "request": bad_request}
 
         assert decode_challenge_request(challenge) == {}
 
     def test_missing_request_returns_empty_dict(self):
-        challenge = parse_www_authenticate('Payment id="x", method="evm"')[0]
-
-        assert decode_challenge_request(challenge) == {}
+        assert decode_challenge_request({"id": "x"}) == {}
 
     def test_non_object_json_returns_empty_dict(self):
         encoded = base64.urlsafe_b64encode(b'["a","list"]').decode().rstrip("=")
-        challenge = parse_www_authenticate(f'Payment id="x", method="evm", request="{encoded}"')[0]
 
-        assert decode_challenge_request(challenge) == {}
+        assert decode_challenge_request({"id": "x", "request": encoded}) == {}
 
 
 class TestChallengeNetwork:
@@ -566,10 +597,10 @@ class TestSelectChallenge:
         with pytest.raises(MppChallengeSelectionError, match="charge"):
             select_challenge(challenges, instrument_network="ETHEREUM")
 
-    def test_absent_intent_is_treated_as_charge(self):
-        challenges = parse_www_authenticate(f'Payment id="x", method="evm", request="{b64url(evm_request())}"')
+    def test_absent_intent_is_rejected(self):
+        header = f'Payment id="x", realm="api.example.com", method="evm", request="{b64url(evm_request())}"'
 
-        assert select_challenge(challenges, instrument_network="ETHEREUM")["id"] == "x"
+        assert parse_www_authenticate(header) == []
 
     def test_expired_challenge_is_filtered_out(self):
         challenges = self._parse(

--- a/tests/bedrock_agentcore/payments/test_mpp.py
+++ b/tests/bedrock_agentcore/payments/test_mpp.py
@@ -1,0 +1,670 @@
+"""Unit tests for MPP (Machine Payments Protocol) challenge parsing and selection."""
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from bedrock_agentcore.payments.mpp import (
+    MppChallengeSelectionError,
+    challenge_network,
+    decode_challenge_request,
+    extract_challenges,
+    is_expired,
+    is_mpp_payment_required,
+    parse_www_authenticate,
+    select_challenge,
+)
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding, as MPP requires."""
+    raw = json.dumps(obj, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def evm_request(chain_id=84532, amount="1000000"):
+    """Build an evm-charge request object per draft-evm-charge-00."""
+    return {
+        "amount": amount,
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+
+
+def solana_request(network="devnet", amount="1000000"):
+    """Build a solana-charge request object per draft-solana-charge-00."""
+    details = {}
+    if network is not None:
+        details["network"] = network
+    return {
+        "amount": amount,
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": details,
+    }
+
+
+def challenge_header(challenge_id, method, request_obj, intent="charge", expires=None, realm="api.example.com"):
+    """Build a single 'Payment ...' WWW-Authenticate challenge value."""
+    parts = [
+        f'id="{challenge_id}"',
+        f'realm="{realm}"',
+        f'method="{method}"',
+        f'intent="{intent}"',
+        f'request="{b64url(request_obj)}"',
+    ]
+    if expires:
+        parts.append(f'expires="{expires}"')
+    return "Payment " + ", ".join(parts)
+
+
+FUTURE = "2099-04-01T12:05:00Z"
+PAST = "2020-04-01T12:05:00Z"
+
+
+class TestParseWwwAuthenticate:
+    """Tests for parsing WWW-Authenticate header values into challenges."""
+
+    def test_parses_single_challenge_auth_params(self):
+        header = challenge_header("aB3cDeF4gHiJkLmN", "evm", evm_request(), expires=FUTURE)
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        c = challenges[0]
+        assert c["id"] == "aB3cDeF4gHiJkLmN"
+        assert c["realm"] == "api.example.com"
+        assert c["method"] == "evm"
+        assert c["intent"] == "charge"
+        assert c["expires"] == FUTURE
+        assert c["request"]
+
+    def test_parses_multiple_challenges_in_one_header_value(self):
+        header = ", ".join(
+            [
+                challenge_header("evm-1", "evm", evm_request()),
+                challenge_header("sol-1", "solana", solana_request()),
+            ]
+        )
+
+        challenges = parse_www_authenticate(header)
+
+        assert [c["id"] for c in challenges] == ["evm-1", "sol-1"]
+        assert [c["method"] for c in challenges] == ["evm", "solana"]
+
+    def test_preserves_raw_header_verbatim_per_challenge(self):
+        """The raw value must round-trip so the challenge HMAC stays valid."""
+        first = challenge_header("evm-1", "evm", evm_request())
+        second = challenge_header("sol-1", "solana", solana_request())
+
+        challenges = parse_www_authenticate(f"{first}, {second}")
+
+        # Each challenge's raw value contains only its own auth-params.
+        assert "evm-1" in challenges[0]["raw"]
+        assert "sol-1" not in challenges[0]["raw"]
+        assert "sol-1" in challenges[1]["raw"]
+        assert "evm-1" not in challenges[1]["raw"]
+        # The base64url request bytes survive unchanged.
+        assert b64url(evm_request()) in challenges[0]["raw"]
+
+    def test_ignores_non_payment_schemes(self):
+        header = 'Bearer realm="example", ' + challenge_header("evm-1", "evm", evm_request())
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["id"] == "evm-1"
+
+    def test_bearer_only_yields_no_challenges(self):
+        assert parse_www_authenticate('Bearer realm="example", error="invalid_token"') == []
+
+    def test_scheme_after_payment_does_not_leak_into_challenge(self):
+        """A trailing scheme's params must not be absorbed into the MPP challenge.
+
+        Leaking them would also corrupt the ``raw`` value forwarded to the service,
+        breaking the challenge HMAC.
+        """
+        header = challenge_header("evm-1", "evm", evm_request()) + ', Bearer realm="api", error="invalid_token"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert "realm" in challenges[0]  # the challenge's own realm, not Bearer's
+        assert challenges[0]["realm"] == "api.example.com"
+        assert "error" not in challenges[0]
+        assert "Bearer" not in challenges[0]["raw"]
+        assert "invalid_token" not in challenges[0]["raw"]
+
+    @pytest.mark.parametrize("other_scheme", ['Bearer realm="api"', 'Basic realm="corp"', "Negotiate"])
+    def test_trailing_schemes_are_excluded_from_raw(self, other_scheme):
+        header = f"{challenge_header('evm-1', 'evm', evm_request())}, {other_scheme}"
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["raw"] == challenge_header("evm-1", "evm", evm_request())
+
+    def test_foreign_scheme_between_two_payment_challenges(self):
+        header = ", ".join(
+            [
+                challenge_header("evm-1", "evm", evm_request()),
+                'Bearer realm="api"',
+                challenge_header("sol-1", "solana", solana_request()),
+            ]
+        )
+
+        challenges = parse_www_authenticate(header)
+
+        assert [c["id"] for c in challenges] == ["evm-1", "sol-1"]
+        assert all("Bearer" not in c["raw"] for c in challenges)
+
+    def test_quoted_value_containing_spaces_is_not_mistaken_for_a_scheme(self):
+        """`description="fast access now"` is an auth-param, not a new scheme."""
+        header = 'Payment id="x", method="evm", description="fast access now"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["description"] == "fast access now"
+
+    def test_scheme_name_is_case_insensitive(self):
+        challenges = parse_www_authenticate('payment id="x", method="evm", intent="charge"')
+
+        assert len(challenges) == 1
+        assert challenges[0]["id"] == "x"
+
+    def test_auth_param_keys_are_lowercased(self):
+        challenges = parse_www_authenticate('Payment ID="x", Method="evm"')
+
+        assert challenges[0]["id"] == "x"
+        assert challenges[0]["method"] == "evm"
+
+    def test_commas_inside_quoted_values_are_not_split(self):
+        header = 'Payment id="x", method="evm", description="Premium, fast access"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["description"] == "Premium, fast access"
+
+    def test_escaped_quote_inside_quoted_value(self):
+        header = 'Payment id="x", method="evm", description="a \\"quoted\\" word"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert challenges[0]["description"] == 'a "quoted" word'
+
+    def test_unknown_auth_params_are_retained_not_rejected(self):
+        """The spec requires clients to ignore unknown params, not fail on them."""
+        header = 'Payment id="x", method="evm", intent="charge", futureParam="v", opaque="o"'
+
+        challenges = parse_www_authenticate(header)
+
+        assert len(challenges) == 1
+        assert challenges[0]["futureparam"] == "v"
+        assert challenges[0]["opaque"] == "o"
+
+    def test_unquoted_values_are_accepted(self):
+        challenges = parse_www_authenticate("Payment id=abc, method=evm, intent=charge")
+
+        assert challenges[0]["id"] == "abc"
+        assert challenges[0]["method"] == "evm"
+
+    @pytest.mark.parametrize("value", ["", None, 123, [], {}])
+    def test_invalid_input_returns_empty_list(self, value):
+        assert parse_www_authenticate(value) == []
+
+    def test_bare_payment_scheme_without_params_is_dropped(self):
+        assert parse_www_authenticate("Payment") == []
+
+
+class TestExtractChallenges:
+    """Tests for pulling challenges out of a 402 payment required request."""
+
+    def test_extracts_from_canonical_header_name(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert [c["id"] for c in extract_challenges(req)] == ["evm-1"]
+
+    @pytest.mark.parametrize("header_name", ["www-authenticate", "WWW-Authenticate", "Www-Authenticate"])
+    def test_header_lookup_is_case_insensitive(self, header_name):
+        req = {
+            "statusCode": 402,
+            "headers": {header_name: challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert len(extract_challenges(req)) == 1
+
+    def test_extracts_from_list_valued_header(self):
+        """Some HTTP clients expose repeated headers as a list."""
+        req = {
+            "statusCode": 402,
+            "headers": {
+                "www-authenticate": [
+                    challenge_header("evm-1", "evm", evm_request()),
+                    challenge_header("sol-1", "solana", solana_request()),
+                ]
+            },
+            "body": {},
+        }
+
+        assert [c["id"] for c in extract_challenges(req)] == ["evm-1", "sol-1"]
+
+    def test_no_www_authenticate_header_yields_nothing(self):
+        req = {"statusCode": 402, "headers": {"content-type": "application/json"}, "body": {}}
+
+        assert extract_challenges(req) == []
+
+    @pytest.mark.parametrize("headers", [None, "not-a-dict", 42, []])
+    def test_malformed_headers_yield_nothing(self, headers):
+        assert extract_challenges({"statusCode": 402, "headers": headers, "body": {}}) == []
+
+
+class TestIsMppPaymentRequired:
+    """Tests for protocol detection used to route 402s to the MPP path."""
+
+    def test_true_for_mpp_challenge(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge_header("evm-1", "evm", evm_request())},
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(req) is True
+
+    def test_false_for_x402_body_payload(self):
+        """An x402 402 must not be misrouted to MPP."""
+        req = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+
+        assert is_mpp_payment_required(req) is False
+
+    def test_false_for_x402_v2_payment_required_header(self):
+        req = {
+            "statusCode": 402,
+            "headers": {"payment-required": "eyJ4NDAyVmVyc2lvbiI6Mn0="},
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(req) is False
+
+    def test_false_for_bearer_challenge(self):
+        req = {"statusCode": 402, "headers": {"WWW-Authenticate": 'Bearer realm="x"'}, "body": {}}
+
+        assert is_mpp_payment_required(req) is False
+
+    @pytest.mark.parametrize("value", [None, "string", 42, []])
+    def test_non_dict_input_is_false(self, value):
+        assert is_mpp_payment_required(value) is False
+
+
+class TestDecodeChallengeRequest:
+    """Tests for decoding the base64url JCS-JSON request auth-param."""
+
+    def test_decodes_evm_request(self):
+        challenge = parse_www_authenticate(challenge_header("evm-1", "evm", evm_request(chain_id=8453)))[0]
+
+        request = decode_challenge_request(challenge)
+
+        assert request["amount"] == "1000000"
+        assert request["methodDetails"]["chainId"] == 8453
+
+    def test_decodes_unpadded_base64url(self):
+        """MPP encodes base64url without padding; decoding must restore it."""
+        payload = {"amount": "1", "currency": "sol", "recipient": "r"}
+        encoded = b64url(payload)
+        assert not encoded.endswith("=")
+
+        challenge = parse_www_authenticate(f'Payment id="x", method="solana", request="{encoded}"')[0]
+
+        assert decode_challenge_request(challenge) == payload
+
+    @pytest.mark.parametrize(
+        "bad_request",
+        ['request="!!!not-base64!!!"', 'request="' + base64.urlsafe_b64encode(b"not json").decode() + '"'],
+    )
+    def test_undecodable_request_returns_empty_dict(self, bad_request):
+        challenge = parse_www_authenticate(f'Payment id="x", method="evm", {bad_request}')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+    def test_missing_request_returns_empty_dict(self):
+        challenge = parse_www_authenticate('Payment id="x", method="evm"')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+    def test_non_object_json_returns_empty_dict(self):
+        encoded = base64.urlsafe_b64encode(b'["a","list"]').decode().rstrip("=")
+        challenge = parse_www_authenticate(f'Payment id="x", method="evm", request="{encoded}"')[0]
+
+        assert decode_challenge_request(challenge) == {}
+
+
+class TestChallengeNetwork:
+    """Tests for deriving a preference-orderable network identifier."""
+
+    @pytest.mark.parametrize(
+        "chain_id,expected",
+        [(8453, "eip155:8453"), (1, "eip155:1"), (84532, "eip155:84532"), (4326, "eip155:4326")],
+    )
+    def test_evm_chain_id_maps_to_eip155(self, chain_id, expected):
+        challenge = parse_www_authenticate(challenge_header("x", "evm", evm_request(chain_id=chain_id)))[0]
+
+        assert challenge_network(challenge) == expected
+
+    def test_tempo_uses_evm_chain_id_mapping(self):
+        challenge = parse_www_authenticate(challenge_header("x", "tempo", evm_request(chain_id=4326)))[0]
+
+        assert challenge_network(challenge) == "eip155:4326"
+
+    def test_evm_string_chain_id_is_coerced(self):
+        request = evm_request()
+        request["methodDetails"]["chainId"] = "8453"
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) == "eip155:8453"
+
+    @pytest.mark.parametrize(
+        "network,expected",
+        [
+            ("mainnet", "solana-mainnet"),
+            ("devnet", "solana-devnet"),
+            ("testnet", "solana-testnet"),
+            ("MAINNET", "solana-mainnet"),
+        ],
+    )
+    def test_solana_network_maps_to_identifier(self, network, expected):
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network=network)))[0]
+
+        assert challenge_network(challenge) == expected
+
+    def test_localnet_is_not_aliased_to_a_public_network(self):
+        """localnet is a local RPC/Surfpool environment, not Solana testnet.
+
+        Aliasing it would let a local-only challenge satisfy a solana-testnet preference.
+        """
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network="localnet")))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_payable_devnet_challenge_outranks_localnet(self):
+        """The regression this guards: a local-only challenge must not beat a payable one."""
+        header = ", ".join(
+            [
+                challenge_header("local-1", "solana", solana_request(network="localnet")),
+                challenge_header("dev-1", "solana", solana_request(network="devnet")),
+            ]
+        )
+        challenges = parse_www_authenticate(header)
+
+        selected = select_challenge(challenges, instrument_network="SOLANA")
+
+        assert selected["id"] == "dev-1"
+
+    def test_localnet_remains_selectable_when_it_is_the_only_option(self):
+        """Unranked, not unusable — a local-only challenge is still payable if alone."""
+        challenges = parse_www_authenticate(challenge_header("local-1", "solana", solana_request(network="localnet")))
+
+        assert select_challenge(challenges, instrument_network="SOLANA")["id"] == "local-1"
+
+    def test_solana_defaults_to_mainnet_when_network_absent(self):
+        """Per draft-solana-charge-00, methodDetails.network is optional."""
+        challenge = parse_www_authenticate(challenge_header("x", "solana", solana_request(network=None)))[0]
+
+        assert challenge_network(challenge) == "solana-mainnet"
+
+    def test_missing_chain_id_returns_none(self):
+        request = evm_request()
+        del request["methodDetails"]["chainId"]
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_boolean_chain_id_returns_none(self):
+        """bool is an int subclass; chainId=True must not become eip155:1."""
+        request = evm_request()
+        request["methodDetails"]["chainId"] = True
+        challenge = parse_www_authenticate(challenge_header("x", "evm", request))[0]
+
+        assert challenge_network(challenge) is None
+
+    def test_unknown_method_returns_none(self):
+        challenge = parse_www_authenticate(challenge_header("x", "bitcoin", evm_request()))[0]
+
+        assert challenge_network(challenge) is None
+
+
+class TestIsExpired:
+    """Tests for challenge expiry evaluation."""
+
+    def test_past_expires_is_expired(self):
+        challenge = {"id": "x", "expires": PAST}
+
+        assert is_expired(challenge) is True
+
+    def test_future_expires_is_not_expired(self):
+        challenge = {"id": "x", "expires": FUTURE}
+
+        assert is_expired(challenge) is False
+
+    def test_missing_expires_is_not_expired(self):
+        assert is_expired({"id": "x"}) is False
+
+    def test_unparseable_expires_is_not_expired(self):
+        """Prefer attempting a challenge over discarding one we failed to parse."""
+        assert is_expired({"id": "x", "expires": "not-a-date"}) is False
+
+    def test_expiry_exactly_now_is_expired(self):
+        now = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        assert is_expired({"expires": "2026-04-01T12:00:00Z"}, now=now) is True
+
+    def test_offset_timezone_is_honoured(self):
+        now = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        # 13:30+02:00 == 11:30Z, already past.
+        assert is_expired({"expires": "2026-04-01T13:30:00+02:00"}, now=now) is True
+        # 15:30+02:00 == 13:30Z, still ahead.
+        assert is_expired({"expires": "2026-04-01T15:30:00+02:00"}, now=now) is False
+
+    def test_naive_datetime_reference_is_treated_as_utc(self):
+        naive_now = datetime(2026, 4, 1, 12, 0, 0)
+
+        assert is_expired({"expires": "2026-04-01T11:00:00Z"}, now=naive_now) is True
+
+
+class TestSelectChallenge:
+    """Tests for the challenge selection algorithm."""
+
+    def _parse(self, *headers):
+        return parse_www_authenticate(", ".join(headers))
+
+    def test_selects_solana_challenge_for_solana_instrument(self):
+        challenges = self._parse(
+            challenge_header("evm-1", "evm", evm_request()),
+            challenge_header("sol-1", "solana", solana_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="SOLANA")
+
+        assert selected["id"] == "sol-1"
+
+    def test_selects_evm_challenge_for_ethereum_instrument(self):
+        challenges = self._parse(
+            challenge_header("sol-1", "solana", solana_request()),
+            challenge_header("evm-1", "evm", evm_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "evm-1"
+
+    def test_tempo_is_satisfied_by_ethereum_instrument(self):
+        challenges = self._parse(challenge_header("tempo-1", "tempo", evm_request(chain_id=4326)))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "tempo-1"
+
+    def test_instrument_network_is_case_insensitive(self):
+        challenges = self._parse(challenge_header("sol-1", "solana", solana_request()))
+
+        assert select_challenge(challenges, instrument_network="solana")["id"] == "sol-1"
+
+    def test_network_preference_order_decides_among_same_family(self):
+        """Base mainnet (eip155:8453) outranks Ethereum mainnet in NETWORK_PREFERENCES."""
+        challenges = self._parse(
+            challenge_header("eth-mainnet", "evm", evm_request(chain_id=1)),
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "base"
+
+    def test_explicit_network_preferences_override_default(self):
+        challenges = self._parse(
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+            challenge_header("eth-mainnet", "evm", evm_request(chain_id=1)),
+        )
+
+        selected = select_challenge(
+            challenges,
+            instrument_network="ETHEREUM",
+            network_preferences=["eip155:1", "eip155:8453"],
+        )
+
+        assert selected["id"] == "eth-mainnet"
+
+    def test_unsupported_intent_is_filtered_out(self):
+        challenges = self._parse(
+            challenge_header("sub-1", "evm", evm_request(), intent="subscription"),
+            challenge_header("charge-1", "evm", evm_request()),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "charge-1"
+
+    def test_all_non_charge_intents_raises(self):
+        challenges = self._parse(
+            challenge_header("s-1", "evm", evm_request(), intent="session"),
+            challenge_header("s-2", "evm", evm_request(), intent="subscription"),
+        )
+
+        with pytest.raises(MppChallengeSelectionError, match="charge"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_absent_intent_is_treated_as_charge(self):
+        challenges = parse_www_authenticate(f'Payment id="x", method="evm", request="{b64url(evm_request())}"')
+
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["id"] == "x"
+
+    def test_expired_challenge_is_filtered_out(self):
+        challenges = self._parse(
+            challenge_header("old", "evm", evm_request(), expires=PAST),
+            challenge_header("fresh", "evm", evm_request(), expires=FUTURE),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "fresh"
+
+    def test_all_expired_raises(self):
+        challenges = self._parse(challenge_header("old", "evm", evm_request(), expires=PAST))
+
+        with pytest.raises(MppChallengeSelectionError, match="expired"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_soonest_expiry_wins_when_network_rank_ties(self):
+        soon = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        later = (datetime.now(timezone.utc) + timedelta(hours=5)).isoformat().replace("+00:00", "Z")
+        challenges = self._parse(
+            challenge_header("later", "evm", evm_request(chain_id=8453), expires=later),
+            challenge_header("soon", "evm", evm_request(chain_id=8453), expires=soon),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "soon"
+
+    def test_bounded_offer_preferred_over_unbounded_on_tie(self):
+        soon = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+        challenges = self._parse(
+            challenge_header("no-expiry", "evm", evm_request(chain_id=8453)),
+            challenge_header("bounded", "evm", evm_request(chain_id=8453), expires=soon),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "bounded"
+
+    def test_server_order_breaks_full_tie(self):
+        challenges = self._parse(
+            challenge_header("first", "evm", evm_request(chain_id=8453)),
+            challenge_header("second", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "first"
+
+    def test_unknown_network_still_selectable_when_it_is_the_only_option(self):
+        """A challenge on an unranked chain must not be silently unusable."""
+        challenges = self._parse(challenge_header("exotic", "evm", evm_request(chain_id=999999)))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "exotic"
+
+    def test_ranked_network_beats_unranked(self):
+        challenges = self._parse(
+            challenge_header("exotic", "evm", evm_request(chain_id=999999)),
+            challenge_header("base", "evm", evm_request(chain_id=8453)),
+        )
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["id"] == "base"
+
+    def test_no_matching_method_raises_with_advertised_methods(self):
+        challenges = self._parse(challenge_header("sol-1", "solana", solana_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="solana"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_unknown_method_is_not_satisfiable(self):
+        challenges = self._parse(challenge_header("btc-1", "bitcoin", evm_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="No matching challenge"):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+    def test_empty_challenge_list_raises(self):
+        with pytest.raises(MppChallengeSelectionError, match="No challenges"):
+            select_challenge([], instrument_network="ETHEREUM")
+
+    @pytest.mark.parametrize("network", ["BITCOIN", "", None, "  "])
+    def test_unsupported_instrument_network_raises(self, network):
+        challenges = self._parse(challenge_header("evm-1", "evm", evm_request()))
+
+        with pytest.raises(MppChallengeSelectionError, match="[Uu]nsupported instrument network"):
+            select_challenge(challenges, instrument_network=network)
+
+    def test_selected_challenge_retains_raw_header(self):
+        challenges = self._parse(challenge_header("evm-1", "evm", evm_request()))
+
+        selected = select_challenge(challenges, instrument_network="ETHEREUM")
+
+        assert selected["raw"].startswith("Payment ")
+        assert 'id="evm-1"' in selected["raw"]

--- a/tests/bedrock_agentcore/payments/test_mpp_manager.py
+++ b/tests/bedrock_agentcore/payments/test_mpp_manager.py
@@ -1,0 +1,634 @@
+"""Unit tests for the MPP payment path on PaymentManager."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bedrock_agentcore.payments.manager import InsufficientBudget, PaymentError, PaymentManager
+
+PAYMENT_MANAGER_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-abc123"
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding."""
+    return base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode()).decode().rstrip("=")
+
+
+def evm_request(chain_id=84532):
+    return {
+        "amount": "1000000",
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+
+
+def solana_request(network="devnet"):
+    return {
+        "amount": "1000000",
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": {"network": network},
+    }
+
+
+def challenge_header(challenge_id, method, request_obj, intent="charge"):
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="{method}", '
+        f'intent="{intent}", request="{b64url(request_obj)}"'
+    )
+
+
+def mpp_402(*headers):
+    """Build a 402 payment required request advertising the given challenges."""
+    return {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": ", ".join(headers)},
+        "body": {},
+    }
+
+
+@pytest.fixture
+def manager():
+    """A PaymentManager with a mocked data-plane client."""
+    with patch("boto3.Session") as mock_session:
+        mock_session.return_value.region_name = "us-west-2"
+        mgr = PaymentManager(payment_manager_arn=PAYMENT_MANAGER_ARN, region_name="us-west-2")
+    mgr._payment_client = MagicMock()
+    return mgr
+
+
+def set_instrument_network(manager, network):
+    manager._payment_client.get_payment_instrument.return_value = {
+        "paymentInstrument": {
+            "paymentInstrumentId": "pi-1",
+            "paymentInstrumentDetails": {"embeddedCryptoWallet": {"network": network}},
+        }
+    }
+
+
+def set_mpp_result(manager, selected_payment_id="evm-1", credential="eyJjaGFsbGVuZ2UiOnt9fQ", version="1"):
+    manager._payment_client.process_payment.return_value = {
+        "processPayment": {
+            "processPaymentId": "pp-1",
+            "status": "PROOF_GENERATED",
+            "paymentOutput": {
+                "mpp": {
+                    "version": version,
+                    "selectedPaymentId": selected_payment_id,
+                    "paymentCredential": credential,
+                }
+            },
+        }
+    }
+
+
+class TestMppRouting:
+    """generate_payment_header must route by detected protocol."""
+
+    def test_mpp_402_returns_authorization_header(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header == {"Authorization": "Payment eyJhIjoxfQ"}
+
+    def test_mpp_sends_payment_type_mpp(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        kwargs = manager._payment_client.process_payment.call_args.kwargs
+        assert kwargs["paymentType"] == "MPP"
+        assert "cryptoX402" not in kwargs["paymentInput"]
+
+    def test_raw_challenge_header_is_forwarded_verbatim(self, manager):
+        """The challenge HMAC binds to the exact request bytes, so no re-encoding."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+        raw = challenge_header("evm-1", "evm", evm_request())
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(raw),
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert sent["wwwAuthenticateHeaders"] == [raw]
+        assert b64url(evm_request()) in sent["wwwAuthenticateHeaders"][0]
+
+    def test_exactly_one_challenge_is_sent(self, manager):
+        """The service model constrains wwwAuthenticateHeaders to a single entry."""
+        set_instrument_network(manager, "SOLANA")
+        set_mpp_result(manager, selected_payment_id="sol-1")
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(
+                challenge_header("evm-1", "evm", evm_request()),
+                challenge_header("sol-1", "solana", solana_request()),
+            ),
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert len(sent["wwwAuthenticateHeaders"]) == 1
+        assert 'id="sol-1"' in sent["wwwAuthenticateHeaders"][0]
+
+    def test_mpp_version_is_numeric_string(self, manager):
+        """The model constrains version to ^[0-9]+$."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        version = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]["version"]
+        assert version.isdigit()
+
+    def test_x402_402_still_uses_crypto_x402_path(self, manager):
+        """MPP detection must not regress the existing x402 flow."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+        x402_request = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {
+                "x402Version": 1,
+                "accepts": [{"scheme": "exact", "network": "base-sepolia", "maxAmountRequired": "1000"}],
+            },
+        }
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=x402_request,
+        )
+
+        assert "X-PAYMENT" in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "CRYPTO_X402"
+
+    def test_client_token_is_forwarded(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            client_token="my-token-123",
+        )
+
+        assert manager._payment_client.process_payment.call_args.kwargs["clientToken"] == "my-token-123"
+
+    def _mpp_input(self, manager):
+        return manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+
+    def _process_mpp(self, manager, **kwargs):
+        return manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            **kwargs,
+        )
+
+    def test_buyer_pays_gas_fees_omitted_when_not_specified(self, manager):
+        """Omitting the field must leave the service-side protocol default in place."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager)
+
+        assert "buyerPaysGasFees" not in self._mpp_input(manager)
+
+    def test_buyer_pays_gas_fees_true_is_forwarded(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=True)
+
+        assert self._mpp_input(manager)["buyerPaysGasFees"] is True
+
+    def test_buyer_pays_gas_fees_false_is_forwarded_explicitly(self, manager):
+        """False is a deliberate refusal and must be sent, not treated as unset."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=False)
+
+        assert self._mpp_input(manager)["buyerPaysGasFees"] is False
+
+    @pytest.mark.parametrize("value", ["false", "true", "no", 1, 0, [], {"a": 1}])
+    def test_non_boolean_buyer_pays_gas_fees_is_rejected_not_coerced(self, manager, value):
+        """Coercion would let the string "false" authorize wallet charges.
+
+        Every non-empty string is truthy, so bool("false") is True. Authorizing network
+        fees must be unambiguous, so non-bool values are rejected rather than coerced.
+        """
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        with pytest.raises(PaymentError, match="buyer_pays_gas_fees must be a boolean or None"):
+            self._process_mpp(manager, buyer_pays_gas_fees=value)
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_string_false_never_authorizes_gas_fees(self, manager):
+        """Regression guard for the specific money-moving misread."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        with pytest.raises(PaymentError):
+            self._process_mpp(manager, buyer_pays_gas_fees="false")
+
+        # Nothing was sent at all, so nothing could have been authorized.
+        manager._payment_client.process_payment.assert_not_called()
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_values_are_forwarded_unchanged(self, manager, value):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager)
+
+        self._process_mpp(manager, buyer_pays_gas_fees=value)
+
+        forwarded = self._mpp_input(manager)["buyerPaysGasFees"]
+        assert forwarded is value
+        assert isinstance(forwarded, bool)
+
+    def test_buyer_pays_gas_fees_not_sent_on_x402_path(self, manager):
+        """The field is MPP-only and must never appear in a cryptoX402 input."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request={
+                "statusCode": 402,
+                "headers": {"content-type": "application/json"},
+                "body": {"x402Version": 1, "accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+            },
+            buyer_pays_gas_fees=True,
+        )
+
+        payment_input = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]
+        assert "mpp" not in payment_input
+        assert "buyerPaysGasFees" not in payment_input["cryptoX402"]
+
+    def test_network_preferences_are_applied(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="eth-1")
+
+        manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(
+                challenge_header("base-1", "evm", evm_request(chain_id=8453)),
+                challenge_header("eth-1", "evm", evm_request(chain_id=1)),
+            ),
+            network_preferences=["eip155:1", "eip155:8453"],
+        )
+
+        sent = manager._payment_client.process_payment.call_args.kwargs["paymentInput"]["mpp"]
+        assert 'id="eth-1"' in sent["wwwAuthenticateHeaders"][0]
+
+    def test_non_402_status_code_is_rejected(self, manager):
+        request = mpp_402(challenge_header("evm-1", "evm", evm_request()))
+        request["statusCode"] = 200
+
+        with pytest.raises(PaymentError, match="Expected statusCode 402"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=request,
+            )
+
+
+class TestMppCredentialHandling:
+    """Tests for turning the service's output into an Authorization header."""
+
+    def test_scheme_prefix_is_added_when_absent(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_existing_scheme_prefix_is_not_duplicated(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, credential="Payment eyJhIjoxfQ")
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+    def test_missing_mpp_output_raises(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {}}}}
+        }
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    @pytest.mark.parametrize(
+        "payment_output",
+        [
+            None,
+            {"mpp": None},
+            {"mpp": "not-a-dict"},
+            {"mpp": {}},
+            {"mpp": []},
+        ],
+    )
+    def test_malformed_payment_output_raises_actionable_error(self, manager, payment_output):
+        """A null or non-object member must name the field, not leak an AttributeError."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {"processPayment": {"paymentOutput": payment_output}}
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    @pytest.mark.parametrize("credential", [None, "", "   ", 123])
+    def test_missing_credential_raises(self, manager, credential):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {
+                "paymentOutput": {
+                    "mpp": {
+                        "version": "1",
+                        "selectedPaymentId": "evm-1",
+                        "paymentCredential": credential,
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(PaymentError, match="Missing paymentCredential"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_challenge_id_mismatch_raises(self, manager):
+        """Attaching a credential for a challenge we did not select would fail upstream."""
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="some-other-id")
+
+        with pytest.raises(PaymentError, match="Challenge mismatch"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_absent_selected_payment_id_is_tolerated(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"mpp": {"version": "1", "paymentCredential": "eyJhIjoxfQ"}}}
+        }
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert header["Authorization"] == "Payment eyJhIjoxfQ"
+
+
+class TestDualProtocolFallback:
+    """A 402 may advertise both MPP and x402; an unsatisfiable MPP option must not fail it."""
+
+    X402_BODY = {
+        "x402Version": 1,
+        "accepts": [{"scheme": "exact", "network": "base-sepolia", "maxAmountRequired": "1000"}],
+    }
+
+    def _dual_402(self, challenge, body=None):
+        return {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": challenge},
+            "body": body if body is not None else self.X402_BODY,
+        }
+
+    def _set_x402_result(self, manager):
+        manager._payment_client.process_payment.return_value = {
+            "processPayment": {"paymentOutput": {"cryptoX402": {"payload": {"signature": "0xsig"}}}}
+        }
+
+    def _generate(self, manager, challenge, body=None):
+        return manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request=self._dual_402(challenge, body),
+        )
+
+    def test_mpp_is_preferred_when_satisfiable(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+        set_mpp_result(manager, selected_payment_id="evm-1")
+
+        header = self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        assert "Authorization" in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "MPP"
+
+    def test_falls_back_to_x402_when_mpp_is_unsatisfiable(self, manager):
+        """A SOLANA-only MPP challenge with an ETHEREUM instrument must use the x402 option."""
+        set_instrument_network(manager, "ETHEREUM")
+        self._set_x402_result(manager)
+
+        header = self._generate(manager, challenge_header("sol-1", "solana", solana_request()))
+
+        assert "X-PAYMENT" in header
+        assert "Authorization" not in header
+        assert manager._payment_client.process_payment.call_args.kwargs["paymentType"] == "CRYPTO_X402"
+
+    def test_raises_when_mpp_unsatisfiable_and_no_x402_present(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError, match="No matching challenge"):
+            self._generate(manager, challenge_header("sol-1", "solana", solana_request()), body={})
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"x402Version": 1, "accepts": []},
+            {"x402Version": 1},
+            {"accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+        ],
+    )
+    def test_no_fallback_without_a_usable_x402_option(self, manager, body):
+        """An absent, empty or malformed x402 payload is not a fallback target."""
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError):
+            self._generate(manager, challenge_header("sol-1", "solana", solana_request()), body=body)
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_post_submission_failure_does_not_fall_back(self, manager):
+        """Falling back after a submitted payment could charge the buyer twice."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.side_effect = InsufficientBudget("Insufficient budget")
+
+        with pytest.raises(PaymentError):
+            self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        attempts = [c.kwargs["paymentType"] for c in manager._payment_client.process_payment.call_args_list]
+        assert attempts == ["MPP"], f"Expected exactly one submission, got {attempts}"
+
+    def test_missing_mpp_output_does_not_fall_back(self, manager):
+        """A malformed MPP response is post-submission, so it must not retry as x402."""
+        set_instrument_network(manager, "ETHEREUM")
+        manager._payment_client.process_payment.return_value = {"processPayment": {"paymentOutput": {}}}
+
+        with pytest.raises(PaymentError, match="Missing mpp in payment output"):
+            self._generate(manager, challenge_header("evm-1", "evm", evm_request()))
+
+        attempts = [c.kwargs["paymentType"] for c in manager._payment_client.process_payment.call_args_list]
+        assert attempts == ["MPP"]
+
+    def test_x402_only_402_is_unaffected(self, manager):
+        """No MPP challenge present — the x402 path must behave exactly as before."""
+        set_instrument_network(manager, "ETHEREUM")
+        self._set_x402_result(manager)
+
+        header = manager.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            user_id="user-1",
+            payment_required_request={
+                "statusCode": 402,
+                "headers": {"content-type": "application/json"},
+                "body": self.X402_BODY,
+            },
+        )
+
+        assert "X-PAYMENT" in header
+
+
+class TestMppSelectionErrors:
+    """Selection failures must surface as PaymentError, not leak internal types."""
+
+    def test_no_satisfiable_method_raises_payment_error(self, manager):
+        set_instrument_network(manager, "ETHEREUM")
+
+        with pytest.raises(PaymentError, match="No matching challenge"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("sol-1", "solana", solana_request())),
+            )
+
+        manager._payment_client.process_payment.assert_not_called()
+
+    def test_unsupported_instrument_network_raises_payment_error(self, manager):
+        set_instrument_network(manager, "BITCOIN")
+
+        with pytest.raises(PaymentError, match="[Uu]nsupported instrument network"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+    def test_instrument_without_network_raises(self, manager):
+        manager._payment_client.get_payment_instrument.return_value = {
+            "paymentInstrument": {"paymentInstrumentId": "pi-1", "paymentInstrumentDetails": {}}
+        }
+
+        with pytest.raises(PaymentError, match="Missing network information"):
+            manager.generate_payment_header(
+                payment_instrument_id="pi-1",
+                payment_session_id="ps-1",
+                user_id="user-1",
+                payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+            )
+
+
+class TestMppBearerAuth:
+    """MPP must work under CUSTOM_JWT bearer auth, where userId is omitted."""
+
+    def test_bearer_auth_omits_user_id(self):
+        with patch("boto3.Session") as mock_session:
+            mock_session.return_value.region_name = "us-west-2"
+            mgr = PaymentManager(
+                payment_manager_arn=PAYMENT_MANAGER_ARN,
+                region_name="us-west-2",
+                bearer_token="jwt-token",
+            )
+        mgr._payment_client = MagicMock()
+        set_instrument_network(mgr, "ETHEREUM")
+        set_mpp_result(mgr)
+
+        header = mgr.generate_payment_header(
+            payment_instrument_id="pi-1",
+            payment_session_id="ps-1",
+            payment_required_request=mpp_402(challenge_header("evm-1", "evm", evm_request())),
+        )
+
+        assert "Authorization" in header
+        assert "userId" not in mgr._payment_client.process_payment.call_args.kwargs

--- a/tests/bedrock_agentcore/payments/test_payment_manager.py
+++ b/tests/bedrock_agentcore/payments/test_payment_manager.py
@@ -1627,6 +1627,75 @@ class TestGeneratePaymentHeaderX402Extraction:
         assert "Missing required fields" in str(exc_info.value)
 
 
+class TestGeneratePaymentHeaderPermit2AllowanceLimit:
+    """Tests for the optional permit2_allowance_limit injection into cryptoX402."""
+
+    @staticmethod
+    def _setup_manager(mock_session_class):
+        arn = "arn:aws:bedrock-agentcore:us-east-1:123456789012:payment-manager/pm-123"
+        mock_session = MagicMock()
+        mock_session.region_name = "us-east-1"
+        mock_client = MagicMock()
+        mock_session.client.return_value = mock_client
+        mock_session_class.return_value = mock_session
+
+        mock_client.get_payment_instrument.return_value = {
+            "paymentInstrument": {
+                "paymentInstrumentId": "instrument-123",
+                "paymentInstrumentType": "EMBEDDED_CRYPTO_WALLET",
+                "paymentInstrumentDetails": {"embeddedCryptoWallet": {"network": "ethereum"}},
+                "status": "active",
+            }
+        }
+        mock_client.process_payment.return_value = {
+            "paymentOutput": {"cryptoX402": {"payload": "payment-proof"}}
+        }
+        manager = PaymentManager(payment_manager_arn=arn, region_name="us-east-1")
+        return manager, mock_client
+
+    _V1_PAYLOAD = {
+        "x402Version": 1,
+        "scheme": "upto",
+        "network": "ethereum",
+        "accepts": [{"network": "ethereum", "value": "100"}],
+        "payload": "proof-data",
+    }
+
+    @patch("bedrock_agentcore.payments.manager.boto3.Session")
+    def test_permit2_allowance_limit_forwarded_onto_crypto_x402(self, mock_session_class):
+        """When set, permit2AllowanceLimit is injected at the cryptoX402 level."""
+        manager, mock_client = self._setup_manager(mock_session_class)
+
+        manager.generate_payment_header(
+            user_id="user-123",
+            payment_instrument_id="instrument-123",
+            payment_session_id="session-123",
+            payment_required_request={"statusCode": 402, "headers": {}, "body": self._V1_PAYLOAD},
+            permit2_allowance_limit="1000000",
+        )
+
+        payment_input = mock_client.process_payment.call_args.kwargs["paymentInput"]
+        crypto_x402 = payment_input["cryptoX402"]
+        assert crypto_x402["permit2AllowanceLimit"] == "1000000"
+        # Sibling of version/payload, not nested inside payload.
+        assert "permit2AllowanceLimit" not in crypto_x402["payload"]
+
+    @patch("bedrock_agentcore.payments.manager.boto3.Session")
+    def test_permit2_allowance_limit_omitted_when_not_set(self, mock_session_class):
+        """When unset (default), the exact flow is unaffected — no key added."""
+        manager, mock_client = self._setup_manager(mock_session_class)
+
+        manager.generate_payment_header(
+            user_id="user-123",
+            payment_instrument_id="instrument-123",
+            payment_session_id="session-123",
+            payment_required_request={"statusCode": 402, "headers": {}, "body": self._V1_PAYLOAD},
+        )
+
+        payment_input = mock_client.process_payment.call_args.kwargs["paymentInput"]
+        assert "permit2AllowanceLimit" not in payment_input["cryptoX402"]
+
+
 class TestGeneratePaymentHeaderNetworkDetection:
     """Tests for network detection and accept selection."""
 

--- a/tests/bedrock_agentcore/payments/test_payment_manager.py
+++ b/tests/bedrock_agentcore/payments/test_payment_manager.py
@@ -1647,9 +1647,7 @@ class TestGeneratePaymentHeaderPermit2AllowanceLimit:
                 "status": "active",
             }
         }
-        mock_client.process_payment.return_value = {
-            "paymentOutput": {"cryptoX402": {"payload": "payment-proof"}}
-        }
+        mock_client.process_payment.return_value = {"paymentOutput": {"cryptoX402": {"payload": "payment-proof"}}}
         manager = PaymentManager(payment_manager_arn=arn, region_name="us-east-1")
         return manager, mock_client
 

--- a/tests/bedrock_agentcore/payments/test_payment_manager.py
+++ b/tests/bedrock_agentcore/payments/test_payment_manager.py
@@ -1655,7 +1655,7 @@ class TestGeneratePaymentHeaderPermit2AllowanceLimit:
         "x402Version": 1,
         "scheme": "upto",
         "network": "ethereum",
-        "accepts": [{"network": "ethereum", "value": "100"}],
+        "accepts": [{"scheme": "upto", "network": "ethereum", "value": "100"}],
         "payload": "proof-data",
     }
 
@@ -1692,6 +1692,41 @@ class TestGeneratePaymentHeaderPermit2AllowanceLimit:
 
         payment_input = mock_client.process_payment.call_args.kwargs["paymentInput"]
         assert "permit2AllowanceLimit" not in payment_input["cryptoX402"]
+
+    @patch("bedrock_agentcore.payments.manager.boto3.Session")
+    def test_permit2_allowance_limit_omitted_for_exact_scheme(self, mock_session_class):
+        manager, mock_client = self._setup_manager(mock_session_class)
+        payload = {
+            **self._V1_PAYLOAD,
+            "scheme": "exact",
+            "accepts": [{"scheme": "exact", "network": "ethereum", "value": "100"}],
+        }
+
+        manager.generate_payment_header(
+            user_id="user-123",
+            payment_instrument_id="instrument-123",
+            payment_session_id="session-123",
+            payment_required_request={"statusCode": 402, "headers": {}, "body": payload},
+            permit2_allowance_limit="1000000",
+        )
+
+        payment_input = mock_client.process_payment.call_args.kwargs["paymentInput"]
+        assert "permit2AllowanceLimit" not in payment_input["cryptoX402"]
+
+    @patch("bedrock_agentcore.payments.manager.boto3.Session")
+    def test_invalid_permit2_allowance_is_rejected_for_upto(self, mock_session_class):
+        manager, mock_client = self._setup_manager(mock_session_class)
+
+        with pytest.raises(PaymentError, match="positive ASCII integer"):
+            manager.generate_payment_header(
+                user_id="user-123",
+                payment_instrument_id="instrument-123",
+                payment_session_id="session-123",
+                payment_required_request={"statusCode": 402, "headers": {}, "body": self._V1_PAYLOAD},
+                permit2_allowance_limit="9" * 79,
+            )
+
+        mock_client.process_payment.assert_not_called()
 
 
 class TestGeneratePaymentHeaderNetworkDetection:

--- a/tests_integ/payments/integrations/strands/test_plugin_integration.py
+++ b/tests_integ/payments/integrations/strands/test_plugin_integration.py
@@ -10,11 +10,13 @@ import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from strands import Agent
 from strands_tools import http_request
 
 from bedrock_agentcore.payments.integrations.config import AgentCorePaymentsPluginConfig
+from bedrock_agentcore.payments.integrations.handlers import get_payment_handler
 from bedrock_agentcore.payments.integrations.strands.plugin import AgentCorePaymentsPlugin
 from bedrock_agentcore.payments.manager import (
     PaymentError,
@@ -23,6 +25,7 @@ from bedrock_agentcore.payments.manager import (
     PaymentSessionConfigurationRequired,
     PaymentSessionNotFound,
 )
+from bedrock_agentcore.payments.mpp import extract_challenges, is_mpp_payment_required
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -280,8 +283,6 @@ class TestAgentCorePaymentsPluginMpp:
 
     def _fetch_live_402(self):
         """Fetch a real MPP 402 and return it as a payment_required_request dict."""
-        import httpx
-
         with httpx.Client(timeout=30.0, follow_redirects=True) as client:
             response = client.get(self.mpp_url)
 
@@ -296,8 +297,6 @@ class TestAgentCorePaymentsPluginMpp:
 
         Needs no AWS credentials — it validates only detection and parsing.
         """
-        from bedrock_agentcore.payments.mpp import extract_challenges, is_mpp_payment_required
-
         payment_required_request = self._fetch_live_402()
 
         assert is_mpp_payment_required(payment_required_request), (
@@ -324,8 +323,6 @@ class TestAgentCorePaymentsPluginMpp:
         MPP challenges travel in headers, so a tool that drops or rewrites response
         headers would silently break auto-payment. Needs no AWS credentials.
         """
-        from bedrock_agentcore.payments.integrations.handlers import get_payment_handler
-
         config = self._make_config(
             payment_manager_arn=os.environ.get(
                 "TEST_PAYMENT_MANAGER_ARN",

--- a/tests_integ/payments/integrations/strands/test_plugin_integration.py
+++ b/tests_integ/payments/integrations/strands/test_plugin_integration.py
@@ -226,6 +226,357 @@ class TestAgentCorePaymentsPlugin:
 
 
 @pytest.mark.integration
+class TestAgentCorePaymentsPluginMpp:
+    """Integration tests for MPP (Machine Payments Protocol) handling in the plugin.
+
+    MPP servers advertise payment options as ``WWW-Authenticate: Payment`` challenges on
+    a 402 response, rather than in the body like x402. These tests exercise that path
+    against the live MPP reference endpoint.
+
+    To run the live tests:
+        export BEDROCK_TEST_REGION="us-west-2"
+        export TEST_PAYMENT_MANAGER_ARN="arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/pm-123"
+        export TEST_PAYMENT_INSTRUMENT_ID="payment-instrument-xxx"
+        export TEST_PAYMENT_SESSION_ID="payment-session-xxx"
+        export TEST_USER_ID="test-user"
+        export TEST_MPP_RESOURCE_URL="https://mpp.dev/api/ping/paid"
+        pytest tests_integ/payments/integrations/strands/test_plugin_integration.py::\
+            TestAgentCorePaymentsPluginMpp -v -s
+    """
+
+    DEFAULT_MPP_URL = "https://mpp.dev/api/ping/paid"
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test environment."""
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.mpp_url = os.environ.get("TEST_MPP_RESOURCE_URL", cls.DEFAULT_MPP_URL)
+
+    def _make_config(self, **overrides):
+        """Build a plugin config from the configured test resources."""
+        kwargs = {
+            "payment_manager_arn": os.environ.get("TEST_PAYMENT_MANAGER_ARN"),
+            "user_id": self.user_id,
+            "payment_instrument_id": os.environ.get("TEST_PAYMENT_INSTRUMENT_ID"),
+            "payment_session_id": os.environ.get("TEST_PAYMENT_SESSION_ID"),
+            "region": self.region,
+            # No chain-advance wait needed: these tests assert on signing, not settlement.
+            "post_payment_retry_delay_seconds": 0,
+        }
+        kwargs.update(overrides)
+        return AgentCorePaymentsPluginConfig(**kwargs)
+
+    @staticmethod
+    def _require_payment_resources():
+        """Skip unless a payment manager, instrument and session are all configured."""
+        missing = [
+            name
+            for name in ("TEST_PAYMENT_MANAGER_ARN", "TEST_PAYMENT_INSTRUMENT_ID", "TEST_PAYMENT_SESSION_ID")
+            if not os.environ.get(name)
+        ]
+        if missing:
+            pytest.skip(f"Not configured: {', '.join(missing)}")
+
+    def _fetch_live_402(self):
+        """Fetch a real MPP 402 and return it as a payment_required_request dict."""
+        import httpx
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            response = client.get(self.mpp_url)
+
+        assert response.status_code == 402, (
+            f"Expected 402 from {self.mpp_url}, got {response.status_code}. "
+            "The MPP reference endpoint may have changed."
+        )
+        return {"statusCode": 402, "headers": dict(response.headers), "body": {}}
+
+    def test_live_mpp_endpoint_advertises_payment_challenge(self):
+        """The live MPP endpoint must return a 402 the SDK recognizes as MPP.
+
+        Needs no AWS credentials — it validates only detection and parsing.
+        """
+        from bedrock_agentcore.payments.mpp import extract_challenges, is_mpp_payment_required
+
+        payment_required_request = self._fetch_live_402()
+
+        assert is_mpp_payment_required(payment_required_request), (
+            f"No MPP challenge found in headers: {payment_required_request['headers']}"
+        )
+
+        challenges = extract_challenges(payment_required_request)
+        assert challenges, "At least one challenge must be parsed"
+        for challenge in challenges:
+            assert challenge.get("id"), f"Challenge missing id: {challenge}"
+            assert challenge.get("method"), f"Challenge missing method: {challenge}"
+            assert challenge["raw"].startswith("Payment ")
+            logger.info(
+                "Live challenge: id=%s method=%s intent=%s expires=%s",
+                challenge.get("id"),
+                challenge.get("method"),
+                challenge.get("intent"),
+                challenge.get("expires"),
+            )
+
+    def test_plugin_http_request_preserves_live_challenge(self):
+        """The plugin's http_request tool must surface the challenge for detection.
+
+        MPP challenges travel in headers, so a tool that drops or rewrites response
+        headers would silently break auto-payment. Needs no AWS credentials.
+        """
+        from bedrock_agentcore.payments.integrations.handlers import get_payment_handler
+
+        config = self._make_config(
+            payment_manager_arn=os.environ.get(
+                "TEST_PAYMENT_MANAGER_ARN",
+                "arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/mypaymentmanager-cyrc25gr4c",
+            )
+        )
+        plugin = AgentCorePaymentsPlugin(config=config)
+
+        result = plugin.http_request(url=self.mpp_url)
+
+        handler = get_payment_handler("http_request", {"url": self.mpp_url, "headers": {}})
+        assert handler.extract_status_code(result["content"]) == 402
+        headers = handler.extract_headers(result["content"])
+        assert headers is not None
+
+        challenge = next((v for k, v in headers.items() if k.lower() == "www-authenticate"), None)
+        assert challenge is not None, f"WWW-Authenticate not preserved by http_request: {headers}"
+        assert challenge.strip().lower().startswith("payment")
+        logger.info("http_request preserved the MPP challenge: %s...", challenge[:80])
+
+    def test_plugin_settles_live_mpp_402(self):
+        """Plugin signs a real MPP challenge and applies the Authorization header.
+
+        Requires AWS credentials and MPP entitlement on the account. When the account
+        is not yet enabled for MPP, the service returns AccessDeniedException; the test
+        skips in that case rather than reporting a false failure, but still asserts the
+        request shape was accepted.
+        """
+        self._require_payment_resources()
+
+        plugin = AgentCorePaymentsPlugin(config=self._make_config())
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager") as mock_cls:
+            mock_cls.return_value = PaymentManager(
+                payment_manager_arn=plugin.config.payment_manager_arn,
+                region_name=self.region,
+            )
+            plugin.init_agent(MagicMock())
+
+        payment_required_request = self._fetch_live_402()
+
+        try:
+            header = plugin._process_payment_required_request(payment_required_request)
+        except PaymentError as e:
+            message = str(e)
+            lowered = message.lower()
+            for shape_hint in ("unknown parameter", "validationexception"):
+                assert shape_hint not in lowered, f"MPP request shape was rejected: {message}"
+            pytest.skip(f"MPP payment not completed (expected without account entitlement): {message}")
+
+        assert set(header) == {"Authorization"}, f"MPP must yield only an Authorization header, got {list(header)}"
+        assert header["Authorization"].startswith("Payment ")
+        assert "X-PAYMENT" not in header
+        logger.info("Plugin settled the live MPP challenge and produced an Authorization header")
+
+    def test_agent_pays_live_mpp_endpoint(self):
+        """End-to-end: a Strands agent fetches an MPP-gated resource via the plugin.
+
+        The plugin intercepts the 402, settles the challenge, attaches the
+        Authorization header, and Strands retries the tool.
+        """
+        self._require_payment_resources()
+
+        plugin = AgentCorePaymentsPlugin(config=self._make_config())
+        agent = Agent(
+            system_prompt=(
+                "You are a helpful assistant. Use the http_request tool to fetch URLs. "
+                "Report the final response you receive."
+            ),
+            plugins=[plugin],
+        )
+
+        result = self.invoke_agent_with_payment_handling(
+            agent,
+            f"Please fetch {self.mpp_url} and tell me what it returned.",
+            plugin=plugin,
+        )
+
+        logger.info("Agent stop_reason: %s", result.stop_reason)
+        logger.info("MPP agent flow completed")
+
+    def invoke_agent_with_payment_handling(self, agent, prompt, plugin=None, max_iterations=10):
+        """Reuse the x402 interrupt-handling wrapper for the MPP flow."""
+        return TestAgentCorePaymentsPlugin.invoke_agent_with_payment_handling(
+            self, agent, prompt, plugin=plugin, max_iterations=max_iterations
+        )
+
+
+@pytest.mark.integration
+class TestMppPostPaymentFailureFlow:
+    """Hook-flow scenarios for MPP payments.
+
+    Mock-driven: these fully mock PaymentManager, do not hit AWS, and require no
+    credentials. They cover the plugin's after_tool_call hook end to end for MPP.
+    """
+
+    CHALLENGE = (
+        'Payment id="evm-1", realm="api.example.com", method="evm", intent="charge", request="eyJhbW91bnQiOiIxMDAwIn0"'
+    )
+    CREDENTIAL = "Payment eyJjaGFsbGVuZ2UiOnt9fQ"
+
+    @classmethod
+    def setup_class(cls):
+        """Set up test environment."""
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+
+    def _make_mpp_402_event(self, tool_use_id, invocation_state=None, tool_input=None, body=None):
+        """Create a mock AfterToolCallEvent carrying an MPP 402 (challenge in headers)."""
+        payment_required = {
+            "statusCode": 402,
+            "headers": {"WWW-Authenticate": self.CHALLENGE, "content-type": "application/problem+json"},
+            "body": body if body is not None else {},
+        }
+
+        event = MagicMock()
+        event.tool_use = {
+            "name": "http_request",
+            "toolUseId": tool_use_id,
+            "input": tool_input if tool_input is not None else {"url": "https://mpp.dev/api/ping/paid", "headers": {}},
+        }
+        event.result = [{"text": f"PAYMENT_REQUIRED: {json.dumps(payment_required)}"}]
+        event.invocation_state = invocation_state if invocation_state is not None else {}
+        event.retry = False
+        event.agent = MagicMock()
+        event.agent.state.get = MagicMock(return_value=None)
+        event.agent.state.set = MagicMock()
+        event.agent.state.delete = MagicMock()
+        return event
+
+    def _make_plugin(self, mock_pm):
+        config = AgentCorePaymentsPluginConfig(
+            payment_manager_arn="arn:aws:bedrock-agentcore:us-west-2:123456789012:payment-manager/test",
+            user_id=self.user_id,
+            payment_instrument_id="payment-instrument-123",
+            payment_session_id="payment-session-456",
+            region=self.region,
+            post_payment_retry_delay_seconds=0,
+        )
+        plugin = AgentCorePaymentsPlugin(config=config)
+        with patch("bedrock_agentcore.payments.integrations.strands.plugin.PaymentManager", return_value=mock_pm):
+            plugin.init_agent(MagicMock())
+        plugin.payment_manager = mock_pm
+        return plugin
+
+    def test_mpp_402_signs_and_retries_with_authorization(self):
+        """A 402 carrying a Payment challenge is signed and retried."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": self.CREDENTIAL}
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        event = self._make_mpp_402_event("tool-mpp", invocation_state=invocation_state, tool_input=tool_input)
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is True
+        assert tool_input["headers"]["Authorization"] == self.CREDENTIAL
+        assert invocation_state.get("payment_signed_tool-mpp") is True
+
+        # The challenge must reach PaymentManager so selection can run.
+        request_arg = mock_pm.generate_payment_header.call_args.kwargs["payment_required_request"]
+        assert request_arg["headers"]["WWW-Authenticate"] == self.CHALLENGE
+        logger.info("MPP 402 signed, Authorization header applied, retry requested")
+
+    def test_mpp_402_after_signing_stops(self):
+        """A second MPP 402 after signing is a server rejection, not a retry case."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.return_value = {"Authorization": self.CREDENTIAL}
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+
+        first = self._make_mpp_402_event("tool-mpp2", invocation_state=invocation_state, tool_input=tool_input)
+        plugin.after_tool_call(first)
+        assert first.retry is True
+
+        second = self._make_mpp_402_event(
+            "tool-mpp2",
+            invocation_state=invocation_state,
+            tool_input=tool_input,
+            body={"error": "verification-failed"},
+        )
+        plugin.after_tool_call(second)
+
+        assert second.retry is False
+        assert mock_pm.generate_payment_header.call_count == 1
+        assert "payment_failure_tool-mpp2" in invocation_state
+        logger.info("Second MPP 402 after signing stopped and stored failure state")
+
+    def test_mpp_selection_failure_does_not_retry(self):
+        """An unsatisfiable challenge must not retry or leave a payment header."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = PaymentError(
+            "MPP Challenge Selection: No matching challenge - no advertised payment method can be satisfied"
+        )
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+        tool_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        event = self._make_mpp_402_event("tool-mpp3", invocation_state=invocation_state, tool_input=tool_input)
+
+        plugin.after_tool_call(event)
+
+        assert event.retry is False
+        assert "Authorization" not in tool_input["headers"]
+        assert "payment_failure_tool-mpp3" in invocation_state
+        logger.info("MPP selection failure stopped cleanly with no header applied")
+
+    def test_x402_and_mpp_use_independent_state(self):
+        """An x402 tool use and an MPP tool use must not share signing state."""
+        mock_pm = MagicMock()
+        mock_pm.generate_payment_header.side_effect = [
+            {"X-PAYMENT": "x402-proof"},
+            {"Authorization": self.CREDENTIAL},
+        ]
+        plugin = self._make_plugin(mock_pm)
+
+        invocation_state = {}
+
+        x402_input = {"url": "https://nickeljoke.vercel.app/api/joke", "headers": {}}
+        x402_payload = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"scheme": "exact", "network": "base-sepolia"}]},
+        }
+        x402_event = MagicMock()
+        x402_event.tool_use = {"name": "http_request", "toolUseId": "tool-x402", "input": x402_input}
+        x402_event.result = [{"text": f"PAYMENT_REQUIRED: {json.dumps(x402_payload)}"}]
+        x402_event.invocation_state = invocation_state
+        x402_event.retry = False
+        x402_event.agent = MagicMock()
+        x402_event.agent.state.get = MagicMock(return_value=None)
+
+        plugin.after_tool_call(x402_event)
+        assert x402_event.retry is True
+        assert x402_input["headers"]["X-PAYMENT"] == "x402-proof"
+
+        mpp_input = {"url": "https://mpp.dev/api/ping/paid", "headers": {}}
+        mpp_event = self._make_mpp_402_event("tool-mpp4", invocation_state=invocation_state, tool_input=mpp_input)
+        plugin.after_tool_call(mpp_event)
+
+        assert mpp_event.retry is True
+        assert mpp_input["headers"]["Authorization"] == self.CREDENTIAL
+        assert "X-PAYMENT" not in mpp_input["headers"]
+        assert mock_pm.generate_payment_header.call_count == 2
+        logger.info("x402 and MPP tool uses tracked independently with protocol-correct headers")
+
+
+@pytest.mark.integration
 class TestPaymentHandlerExtraction:
     """Integration tests for payment handler extraction with real handler instances."""
 

--- a/tests_integ/payments/test_mpp_payment.py
+++ b/tests_integ/payments/test_mpp_payment.py
@@ -50,6 +50,8 @@ import json
 import os
 import uuid
 
+import botocore
+import httpx
 import pytest
 
 from bedrock_agentcore.payments.manager import PaymentError, PaymentManager
@@ -143,8 +145,6 @@ class TestMppModelSupport:
 
     def test_botocore_models_mpp_payment_input(self):
         """Skips (rather than fails) when the installed botocore predates MPP."""
-        import botocore
-
         manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
         shapes = self._shape_map(manager)
 
@@ -377,8 +377,6 @@ class TestMppLiveResource:
     )
     def test_live_402_challenge_is_parseable(self):
         """A real server's 402 must produce at least one usable challenge."""
-        import httpx
-
         with httpx.Client(timeout=30.0, follow_redirects=True) as client:
             response = client.get(self.resource_url)
 
@@ -414,8 +412,6 @@ class TestMppLiveResource:
     )
     def test_end_to_end_pay_and_retry(self):
         """Full loop: 402 → select → pay → retry with Authorization → 200."""
-        import httpx
-
         manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
 
         with httpx.Client(timeout=30.0, follow_redirects=True) as client:

--- a/tests_integ/payments/test_mpp_payment.py
+++ b/tests_integ/payments/test_mpp_payment.py
@@ -1,0 +1,440 @@
+"""Integration tests for MPP (Machine Payments Protocol) payment processing.
+
+These tests exercise the MPP path end to end against the real ProcessPayment API:
+challenge selection, ``paymentType="MPP"`` submission, and credential minting.
+
+SETUP INSTRUCTIONS:
+===================
+
+1. Set the following environment variables before running tests:
+
+   # Required: AWS region
+   export BEDROCK_TEST_REGION="us-west-2"
+
+   # Required: Payment manager ARN (created via control plane)
+   export TEST_PAYMENT_MANAGER_ARN="arn:aws:bedrock:us-west-2:123456789012:payment-manager/pm-123"
+
+   # Required: Payment connector ID (created via control plane)
+   export TEST_PAYMENT_CONNECTOR_ID="pc-123"
+
+   # Required for live payment tests: a funded instrument and an open session.
+   # Without these, only the offline selection/detection tests run.
+   export TEST_PAYMENT_INSTRUMENT_ID="payment-instrument-..."
+   export TEST_PAYMENT_SESSION_ID="payment-session-..."
+
+   # Optional: User ID for testing (default: generated)
+   export TEST_USER_ID="test-user"
+
+   # Optional: an MPP-enabled resource that answers 402 with a
+   # 'WWW-Authenticate: Payment' challenge. When set, test_live_402_challenge
+   # fetches a real challenge instead of using a synthetic one.
+   export TEST_MPP_RESOURCE_URL="https://api.example.com/api/paid"
+
+2. Ensure AWS credentials are configured (see tests_integ/payments/README.md).
+
+3. Run the tests:
+   pytest tests_integ/payments/test_mpp_payment.py -v
+
+SERVICE SIDE VERIFICATION:
+==========================
+
+Monitor service logs to verify:
+- ProcessPayment invoked with paymentType=MPP
+- The wwwAuthenticateHeaders value matches the challenge byte-for-byte
+- MppPaymentOutput.selectedPaymentId echoes the submitted challenge id
+- The minted credential is not written to logs (it is @sensitive)
+"""
+
+import base64
+import json
+import os
+import uuid
+
+import pytest
+
+from bedrock_agentcore.payments.manager import PaymentError, PaymentManager
+from bedrock_agentcore.payments.mpp import (
+    MppChallengeSelectionError,
+    extract_challenges,
+    is_mpp_payment_required,
+    select_challenge,
+)
+
+REQUIRES_MANAGER = pytest.mark.skipif(
+    not os.environ.get("TEST_PAYMENT_MANAGER_ARN"),
+    reason="TEST_PAYMENT_MANAGER_ARN environment variable not set",
+)
+
+REQUIRES_LIVE_PAYMENT = pytest.mark.skipif(
+    not (
+        os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        and os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        and os.environ.get("TEST_PAYMENT_SESSION_ID")
+    ),
+    reason="TEST_PAYMENT_MANAGER_ARN, TEST_PAYMENT_INSTRUMENT_ID and TEST_PAYMENT_SESSION_ID must be set",
+)
+
+
+def b64url(obj) -> str:
+    """Encode a dict as base64url JSON without padding, as MPP requires."""
+    return base64.urlsafe_b64encode(json.dumps(obj, separators=(",", ":")).encode()).decode().rstrip("=")
+
+
+def evm_challenge(challenge_id="evm-1", chain_id=84532, amount="1000"):
+    """Build an evm-charge challenge per draft-evm-charge-00."""
+    request = {
+        "amount": amount,
+        "currency": "0x036CbD53842c5426634e7929541eC2318f3dCF71",
+        "recipient": "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE00",
+        "methodDetails": {"chainId": chain_id},
+    }
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="evm", '
+        f'intent="charge", request="{b64url(request)}"'
+    )
+
+
+def solana_challenge(challenge_id="sol-1", network="devnet", amount="1000"):
+    """Build a solana-charge challenge per draft-solana-charge-00."""
+    request = {
+        "amount": amount,
+        "currency": "sol",
+        "recipient": "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+        "methodDetails": {"network": network},
+    }
+    return (
+        f'Payment id="{challenge_id}", realm="api.example.com", method="solana", '
+        f'intent="charge", request="{b64url(request)}"'
+    )
+
+
+def mpp_402(*challenges):
+    """Build a 402 payment required request advertising the given challenges."""
+    return {
+        "statusCode": 402,
+        "headers": {"WWW-Authenticate": ", ".join(challenges)},
+        "body": {},
+    }
+
+
+@pytest.mark.integration
+class TestMppModelSupport:
+    """Submitting MPP requires botocore to model the MPP ProcessPayment shapes.
+
+    The SDK does not patch the service model, so MPP payments depend on the installed
+    botocore release exposing ``paymentInput.mpp``. On an older release, botocore rejects
+    the request client-side with::
+
+        Unknown parameter in paymentInput: "mpp", must be one of: cryptoX402
+
+    These tests surface that dependency explicitly, so a missing-shape failure is
+    diagnosed as an out-of-date botocore rather than an SDK bug.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        default_arn = "arn:aws:bedrock:us-west-2:123456789012:payment-manager/pm-test"
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN", default_arn)
+
+    @staticmethod
+    def _shape_map(manager):
+        return manager._payment_client.meta.service_model._shape_resolver._shape_map
+
+    def test_botocore_models_mpp_payment_input(self):
+        """Skips (rather than fails) when the installed botocore predates MPP."""
+        import botocore
+
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+        shapes = self._shape_map(manager)
+
+        if "mpp" not in shapes["PaymentInput"]["members"]:
+            pytest.skip(
+                f"Installed botocore {botocore.__version__} does not model paymentInput.mpp. "
+                "MPP payments require a botocore release that includes the MPP ProcessPayment shapes."
+            )
+
+        assert "mpp" in shapes["PaymentOutput"]["members"]
+        assert "MPP" in shapes["PaymentType"]["enum"]
+
+    def test_crypto_x402_support_is_retained(self):
+        """The x402 contract must remain intact regardless of MPP shape availability."""
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+
+        shapes = self._shape_map(manager)
+
+        assert "cryptoX402" in shapes["PaymentInput"]["members"]
+        assert "CRYPTO_X402" in shapes["PaymentType"]["enum"]
+
+
+@pytest.mark.integration
+class TestMppChallengeSelection:
+    """Selection is pure logic, so it is verified without calling the service."""
+
+    def test_detects_mpp_402(self):
+        assert is_mpp_payment_required(mpp_402(evm_challenge())) is True
+
+    def test_does_not_claim_x402_402(self):
+        x402 = {
+            "statusCode": 402,
+            "headers": {"content-type": "application/json"},
+            "body": {"x402Version": 1, "accepts": [{"network": "base-sepolia"}]},
+        }
+
+        assert is_mpp_payment_required(x402) is False
+
+    def test_selects_challenge_matching_instrument_blockchain(self):
+        challenges = extract_challenges(mpp_402(evm_challenge(), solana_challenge()))
+
+        assert select_challenge(challenges, instrument_network="SOLANA")["id"] == "sol-1"
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["id"] == "evm-1"
+
+    def test_selected_raw_header_round_trips_byte_for_byte(self):
+        """The challenge HMAC binds to these exact bytes."""
+        raw = evm_challenge()
+        challenges = extract_challenges(mpp_402(raw))
+
+        assert select_challenge(challenges, instrument_network="ETHEREUM")["raw"] == raw
+
+    def test_unsatisfiable_challenge_raises(self):
+        challenges = extract_challenges(mpp_402(solana_challenge()))
+
+        with pytest.raises(MppChallengeSelectionError):
+            select_challenge(challenges, instrument_network="ETHEREUM")
+
+
+@pytest.mark.integration
+class TestMppProcessPayment:
+    """Tests that call the real ProcessPayment API with paymentType=MPP."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.instrument_id = os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        cls.session_id = os.environ.get("TEST_PAYMENT_SESSION_ID")
+
+        if cls.payment_manager_arn:
+            cls.manager = PaymentManager(
+                payment_manager_arn=cls.payment_manager_arn,
+                region_name=cls.region,
+            )
+        else:
+            cls.manager = None
+
+    def _instrument_network(self):
+        """Read the configured instrument's blockchain so tests pick a payable challenge."""
+        instrument = self.manager.get_payment_instrument(
+            payment_instrument_id=self.instrument_id,
+            user_id=self.user_id,
+        )
+        return instrument["paymentInstrumentDetails"]["embeddedCryptoWallet"]["network"]
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_process_payment_accepts_mpp_payment_type(self):
+        """ProcessPayment must accept paymentType=MPP and an MppPaymentInput."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        payment_input = {
+            "mpp": {
+                "version": "1",
+                "wwwAuthenticateHeaders": [challenge],
+            }
+        }
+
+        # The synthetic challenge is not signed by a real merchant, so the service is
+        # expected to reject it on verification. What this test proves is that the
+        # request shape itself is accepted: a ValidationException naming 'mpp',
+        # 'paymentType' or 'paymentInput' would mean the contract is wrong.
+        try:
+            response = self.manager.process_payment(
+                user_id=self.user_id,
+                payment_session_id=self.session_id,
+                payment_instrument_id=self.instrument_id,
+                payment_type="MPP",
+                payment_input=payment_input,
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            message = str(e).lower()
+            for shape_hint in ("unknown parameter", "paymenttype", "paymentinput"):
+                assert shape_hint not in message, f"MPP request shape was rejected: {e}"
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+        else:
+            assert isinstance(response, dict)
+            assert "mpp" in response.get("paymentOutput", {})
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_generate_payment_header_routes_mpp_402_to_authorization(self):
+        """An MPP 402 must yield an Authorization header, not an x402 one."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        try:
+            header = self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request=mpp_402(challenge),
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+
+        assert set(header) == {"Authorization"}
+        assert header["Authorization"].startswith("Payment ")
+        assert "X-PAYMENT" not in header
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_buyer_pays_gas_fees_is_accepted_by_the_service(self):
+        """ProcessPayment must accept the optional buyerPaysGasFees flag."""
+        network = self._instrument_network()
+        challenge = solana_challenge() if network.upper() == "SOLANA" else evm_challenge()
+
+        try:
+            self.manager.process_payment(
+                user_id=self.user_id,
+                payment_session_id=self.session_id,
+                payment_instrument_id=self.instrument_id,
+                payment_type="MPP",
+                payment_input={
+                    "mpp": {
+                        "version": "1",
+                        "wwwAuthenticateHeaders": [challenge],
+                        "buyerPaysGasFees": True,
+                    }
+                },
+                client_token=str(uuid.uuid4()),
+            )
+        except PaymentError as e:
+            message = str(e).lower()
+            assert "buyerpaysgasfees" not in message, f"buyerPaysGasFees was rejected: {e}"
+            assert "unknown parameter" not in message, f"MPP request shape was rejected: {e}"
+            pytest.skip(f"Service rejected the synthetic challenge (expected without a live merchant): {e}")
+
+    @REQUIRES_MANAGER
+    def test_unsatisfiable_challenge_fails_before_calling_service(self):
+        """Selection failures must not burn a ProcessPayment call or session budget."""
+        instrument_id = self.instrument_id or "payment-instrument-unused"
+
+        with pytest.raises(PaymentError, match="No matching challenge|Missing network information"):
+            self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=instrument_id,
+                payment_session_id=self.session_id or "payment-session-unused",
+                # Only a bitcoin challenge is advertised; no instrument can satisfy it.
+                payment_required_request=mpp_402(
+                    'Payment id="btc-1", realm="api.example.com", method="bitcoin", intent="charge"'
+                ),
+                client_token=str(uuid.uuid4()),
+            )
+
+    @REQUIRES_LIVE_PAYMENT
+    def test_expired_challenge_is_rejected_locally(self):
+        """An expired challenge must be filtered out before the service is called."""
+        expired_request = b64url(
+            {
+                "amount": "1",
+                "currency": "0xUSDC",
+                "recipient": "0xabc",
+                "methodDetails": {"chainId": 84532},
+            }
+        )
+        expired = (
+            'Payment id="old-1", realm="api.example.com", method="evm", '
+            'intent="charge", expires="2020-01-01T00:00:00Z", '
+            f'request="{expired_request}"'
+        )
+
+        with pytest.raises(PaymentError, match="expired|No usable challenge"):
+            self.manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request=mpp_402(expired),
+                client_token=str(uuid.uuid4()),
+            )
+
+
+@pytest.mark.integration
+class TestMppLiveResource:
+    """Tests against a real MPP-enabled endpoint, when one is configured."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.region = os.environ.get("BEDROCK_TEST_REGION", "us-west-2")
+        cls.resource_url = os.environ.get("TEST_MPP_RESOURCE_URL")
+        cls.payment_manager_arn = os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+        cls.user_id = os.environ.get("TEST_USER_ID", f"test-user-{uuid.uuid4().hex[:8]}")
+        cls.instrument_id = os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+        cls.session_id = os.environ.get("TEST_PAYMENT_SESSION_ID")
+
+    @pytest.mark.skipif(
+        not os.environ.get("TEST_MPP_RESOURCE_URL"),
+        reason="TEST_MPP_RESOURCE_URL environment variable not set",
+    )
+    def test_live_402_challenge_is_parseable(self):
+        """A real server's 402 must produce at least one usable challenge."""
+        import httpx
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            response = client.get(self.resource_url)
+
+        assert response.status_code == 402, f"Expected 402, got {response.status_code}"
+
+        payment_required_request = {
+            "statusCode": response.status_code,
+            "headers": dict(response.headers),
+            "body": {},
+        }
+
+        assert is_mpp_payment_required(payment_required_request), (
+            f"No MPP challenge in response headers: {dict(response.headers)}"
+        )
+
+        challenges = extract_challenges(payment_required_request)
+        assert challenges
+        # Every challenge must carry the auth-params selection depends on.
+        for challenge in challenges:
+            assert challenge.get("id"), f"Challenge missing id: {challenge}"
+            assert challenge.get("method"), f"Challenge missing method: {challenge}"
+            assert challenge["raw"].startswith("Payment ")
+
+    @pytest.mark.skipif(
+        not (
+            os.environ.get("TEST_MPP_RESOURCE_URL")
+            and os.environ.get("TEST_PAYMENT_MANAGER_ARN")
+            and os.environ.get("TEST_PAYMENT_INSTRUMENT_ID")
+            and os.environ.get("TEST_PAYMENT_SESSION_ID")
+        ),
+        reason="TEST_MPP_RESOURCE_URL, TEST_PAYMENT_MANAGER_ARN, TEST_PAYMENT_INSTRUMENT_ID "
+        "and TEST_PAYMENT_SESSION_ID must be set",
+    )
+    def test_end_to_end_pay_and_retry(self):
+        """Full loop: 402 → select → pay → retry with Authorization → 200."""
+        import httpx
+
+        manager = PaymentManager(payment_manager_arn=self.payment_manager_arn, region_name=self.region)
+
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            first = client.get(self.resource_url)
+            assert first.status_code == 402
+
+            header = manager.generate_payment_header(
+                user_id=self.user_id,
+                payment_instrument_id=self.instrument_id,
+                payment_session_id=self.session_id,
+                payment_required_request={
+                    "statusCode": first.status_code,
+                    "headers": dict(first.headers),
+                    "body": {},
+                },
+                client_token=str(uuid.uuid4()),
+            )
+            assert "Authorization" in header
+
+            retry = client.get(self.resource_url, headers=header)
+
+        assert retry.status_code == 200, f"Retry after payment failed: {retry.status_code} {retry.text[:300]}"

--- a/uv.lock
+++ b/uv.lock
@@ -368,43 +368,41 @@ wheels = [
 
 [[package]]
 name = "awscrt"
-version = "0.32.2"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/cb/980fe60c4209af71d036276217f8b9f372f958e290c15d2849a3de4dcd23/awscrt-0.32.2.tar.gz", hash = "sha256:a4f48805e8a66237923f03b7b692d213994cff42d1ff08125d1d60c74fcaf872", size = 36862073, upload-time = "2026-04-24T22:59:55.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/7d/fd87588cffbef8fbdb8436f14fa673ee3735cf8600a1a2a36ef78718cfd6/awscrt-0.36.0.tar.gz", hash = "sha256:ad2198461f3b2a2851f37891d75dcb9173bfe2474d8550ad6260bf9970b4064a", size = 37058473, upload-time = "2026-07-16T19:36:20.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/93/08c8dde6e10c2aa5e50c08730e7913fd68cc861536260115bdf109f20bb8/awscrt-0.32.2-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:a9ed98e20ca6fcad8ef32e3c6779aaa3526a5ff3f0aa99d59e0deeff59640375", size = 3405893, upload-time = "2026-04-24T22:58:34.276Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/d8/f838299003df9c77b9d582411f009bf2e5bc07fc68566685b434de249755/awscrt-0.32.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acb707df280079d21d20ad1735b38a80d4939133cbaecfc2e4927dd8fc0190bc", size = 3946562, upload-time = "2026-04-24T22:58:37.467Z" },
-    { url = "https://files.pythonhosted.org/packages/34/95/a9d9ff694e15550a1fa2f83ac9b3b50cc5f809d66dacc57af4d84cc01c7f/awscrt-0.32.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ab06479bcdcb42b2956f59c0e4138049e5b44c885b7584ea05e39cc4d71b1f99", size = 4236332, upload-time = "2026-04-24T22:58:38.789Z" },
-    { url = "https://files.pythonhosted.org/packages/24/bd/92fcf514966e7a139b146282396608493b99e25f745b332075ebe18e129b/awscrt-0.32.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2792fc2877335673058d0b4e8249ef73dc36b22689fda939506aea6eceb42054", size = 3883087, upload-time = "2026-04-24T22:58:40.292Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/7d/cf7ec60d4997ee966ca003a3c7bfc556ee34db10f230f03e5608edf022ca/awscrt-0.32.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0d2e8a13063a3d9b61eee0e2885d133a75b38de3600f6b62437d8559f7d664e3", size = 4118974, upload-time = "2026-04-24T22:58:41.913Z" },
-    { url = "https://files.pythonhosted.org/packages/65/bb/769f8923d7d7986e762898fa98a9d16130681a47da2ff668e6fb07bae0b4/awscrt-0.32.2-cp310-cp310-win32.whl", hash = "sha256:4e975223f3af4faa581c733f0fdd316514b987c42ce85ef3bcd6d9c02eb48f77", size = 4067395, upload-time = "2026-04-24T22:58:43.308Z" },
-    { url = "https://files.pythonhosted.org/packages/83/42/17ab1d701f2628adf7b1b993cae9993111ed760aaf08f5772c2bf37c6b7a/awscrt-0.32.2-cp310-cp310-win_amd64.whl", hash = "sha256:a13c0a555bd930c829c72e6b2b2df70442b3b414037fd488984495b5beff5ddc", size = 4224532, upload-time = "2026-04-24T22:58:45.039Z" },
-    { url = "https://files.pythonhosted.org/packages/03/99/a6c712a2f638c766b0879da0eacd9fe5695c64deb89c0357bcc4f1f4df9b/awscrt-0.32.2-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:32785f54d0786e07b6491b51f9c2f75ea9e17decd39bb6b66fdc60cd871a49ef", size = 3406247, upload-time = "2026-04-24T22:58:46.268Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/03/665c81f3b9d3c56fcdfb8f353c22501bc538d192c431cfaaf307f867d404/awscrt-0.32.2-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f8a586c52f41ff14c2f1b8afeb764e231ad3d66acfd42a6b9fb6c8afd8da8fe2", size = 3906890, upload-time = "2026-04-24T22:58:47.96Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ad/5db0691a0c72d55a17c03c47149cf15d4602b83b470355c322c9a7f115e8/awscrt-0.32.2-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3ef1664588d35dcad2115377120667e689cd7a517da52a481373c9536811ed96", size = 4196631, upload-time = "2026-04-24T22:58:49.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/66/63a4654b2996158f33e88d74d79178a5812d94a7e0d6c94ec475115dff18/awscrt-0.32.2-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7ed7c209136650fe25659436bb4150e5af6eb43d71a0bf294f0bf414428736ee", size = 3818090, upload-time = "2026-04-24T22:58:50.657Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/26/b8fee227918465830a0bbba48f54ebf0a5029c3a7d11d4fa973838a79262/awscrt-0.32.2-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cfd437122d5a2ec7eb9fffaf2cd8b96543d4a0d7e906b9515b79672005a1607a", size = 4056453, upload-time = "2026-04-24T22:58:52.373Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/26/f5b9e9677bf90d1840d4db1513ba92e73601ef82e61a16e747a83493d35c/awscrt-0.32.2-cp311-abi3-win32.whl", hash = "sha256:5197d1e4e780d755632f79f8d32a09a30a9101cccb51ca1694fe25c711b2e801", size = 4066027, upload-time = "2026-04-24T22:58:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0b/fd1798551ecdc8a28d61ecdeda248f99faa3457f83aefa10ab797f466889/awscrt-0.32.2-cp311-abi3-win_amd64.whl", hash = "sha256:80420aa19c074a4c0335f2bd0e4aee3381fa452328d937795a1e0c779f0c052d", size = 4221984, upload-time = "2026-04-24T22:58:55.115Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a3/075e29b39945f398adfb5d5ee4d533e00d37c0f5c68d79b250a1bdb087ba/awscrt-0.32.2-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:d2f7aee3bce261ab1ceba1fac404de4d496aa866237161d4257cef92bff9d828", size = 3404901, upload-time = "2026-04-24T22:58:56.492Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/41/1c4783b32bf4ec7383156787570ea1221c95c037c2c0f11cbc9e9529ba48/awscrt-0.32.2-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff0fff9c2b613d7fabc298b0fd81f0d7056353f3d20271a852a719c5b2f7ccf4", size = 3897627, upload-time = "2026-04-24T22:58:58.144Z" },
-    { url = "https://files.pythonhosted.org/packages/af/2d/5736128847ff4a877d50720ea7a48d7e50a56b78741919e4b6ffabffb1ad/awscrt-0.32.2-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:79bb11d5d1dfdcfd867aac4a026bee11afbd2154279e12b66588442d8c14bdf7", size = 4189579, upload-time = "2026-04-24T22:58:59.56Z" },
-    { url = "https://files.pythonhosted.org/packages/90/f5/064b23d4c927e9b63725ee60c88edb75a1e8f5fd1e97d56d4d6a63fe954b/awscrt-0.32.2-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:47330f421948207a122092042f235cf82d48fa145c446ff4db12cc8cd3a418b6", size = 3809647, upload-time = "2026-04-24T22:59:00.884Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/36/f14ea531cccb6ff85c4d50c9e79e61030675520a393b4af23685d24ea018/awscrt-0.32.2-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5ec4d8200eb0158b60e35fbb65faa96ef1eb7763f6ce1192827886ee24c6df99", size = 4051532, upload-time = "2026-04-24T22:59:02.593Z" },
-    { url = "https://files.pythonhosted.org/packages/64/aa/b12e721c8148a1bbc58a22cbd204d88d0a6263331049d40c057f9dcd3e11/awscrt-0.32.2-cp313-abi3-win32.whl", hash = "sha256:a81f30a501d2eb6ba52c769cd6ecb3f7005512fba4a533211dc717e1115b0d94", size = 4062484, upload-time = "2026-04-24T22:59:04.251Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/26/9f5f23647465a4fe1b28afce334e54a4264e23b69365024c28955f0c4119/awscrt-0.32.2-cp313-abi3-win_amd64.whl", hash = "sha256:8d731edda20dce5afc15a04731d91136a31779a244672d1f0a292a8b04aa0fd3", size = 4220425, upload-time = "2026-04-24T22:59:05.627Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/76/18077410c1d7b524a7a7486550bc969218f6575288f66e285157dc78e143/awscrt-0.32.2-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:f2a085d0dd4eef974f2ae5467ae3717d2fc08dd8cd508c4fd7a5acb658c68616", size = 3414715, upload-time = "2026-04-24T22:59:07.01Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/12/465d72ea6afffc7829f7f48f408a707d4dab9e3f2b694f4e0e63e011478a/awscrt-0.32.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d8a4e52f7312e5e435461119aa903f6424e9996d93a040101fb1eb7b9c4e58dc", size = 4028634, upload-time = "2026-04-24T22:59:08.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ee/2e9d3716cf6a24f30b85af24691d473c913c119dc996bcd8c9b2b3fe2c17/awscrt-0.32.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6cb3c858e96ba023de691a3b6478bed9fb59085433042dff78c42e59eed19cf2", size = 4311846, upload-time = "2026-04-24T22:59:10.02Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/ce/aa08aad92e48929cfe243ed7da5cf039fbb137c391e84af79e88c848a37a/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:7f92b8f40a104a2a87ea5f428b3799220666ec1450b3a90665867d3715749e91", size = 3952242, upload-time = "2026-04-24T22:59:11.632Z" },
-    { url = "https://files.pythonhosted.org/packages/42/e3/09ad98aa7dae9cd3ad578c7721b64e9da03f9a5ed444e518c63e82db05a9/awscrt-0.32.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:9fd2dbca02f4e22fb5c02d1505327e6e6e9320dbe8ca80fc033cbbb29ed8631a", size = 4187982, upload-time = "2026-04-24T22:59:14.477Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/897b1ad519d83a837d721f4e8a87d98e6f36e5b985fa697f3ffed512a8eb/awscrt-0.32.2-cp313-cp313t-win32.whl", hash = "sha256:023a2f4595804a0f1d61ab49b64dda5612be9bfbe9b13759331e8e31658dda3f", size = 4111958, upload-time = "2026-04-24T22:59:15.857Z" },
-    { url = "https://files.pythonhosted.org/packages/71/54/6cca298e8acb6769c8078b39bedbc507f17a3f7fe6ea768d8256d584d4ed/awscrt-0.32.2-cp313-cp313t-win_amd64.whl", hash = "sha256:a2f513f0fb3aafdf7cdf29d7f6f0c46bf4cc7880380c86e88635b7818565e76d", size = 4271679, upload-time = "2026-04-24T22:59:17.425Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/09/51fca333d42b53ddb04881f53e3cc0f4462872ac81426fbb34f5d0b1d1fb/awscrt-0.32.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:7404cb551046bbe7cd454ea75f88b4a1b26f018d1b9bea83dbe46c174789d835", size = 3414716, upload-time = "2026-04-24T22:59:18.918Z" },
-    { url = "https://files.pythonhosted.org/packages/39/3a/0ae52a8dfb0e3c37f0129232d79307c65e6ee1ea13a3cbdcf301aaad0a6a/awscrt-0.32.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:51d6132e9d70de40da07dfad5f17780a652dd4b351c35ca97c79d0fa0186d645", size = 4028980, upload-time = "2026-04-24T22:59:20.316Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/7f/7f52020bfcf29122cad77e936d82abaa1f6857a5a70453e8cc734119f0e2/awscrt-0.32.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:193cc3ecf03a1dd6f989853b6c21549a0a9750c855520fedc8c3c8fbcd32e1bc", size = 4312564, upload-time = "2026-04-24T22:59:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/25/86/2c9b5479e08b8198459d2a781df5524e45d4d0f9c6329bad26979a4d1e85/awscrt-0.32.2-cp314-cp314t-win32.whl", hash = "sha256:25c7e7e6535cb2d2a4d22fd6264f621672d3903491318364dbc59066b63c7186", size = 4195784, upload-time = "2026-04-24T22:59:23.769Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/85/a12515514de8969b9e7fa40bb782501a336a8a985cc3093309120a80b627/awscrt-0.32.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a6782c19a00f354c7b232b675f09cde94d1ca37bcf29009b8779b3f6395b27b4", size = 4366435, upload-time = "2026-04-24T22:59:25.53Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f4/f1fc56f0a48154e14428ed4dada897fbea8d1d5c94127575af3041cbdf2e/awscrt-0.36.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:698c0af9c376d8103c03b8b45ef80bdd100c6a91d26538fa8baa1f22c0a848be", size = 5148286, upload-time = "2026-07-16T19:35:07.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/aa/94174564e1b1e54307e7564c4c97bd4563f77c41b1b35e79b1d4475b050a/awscrt-0.36.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d901f73c9cf722d76f5947c87dfb10de3cea324646c29ecc053fef63b79ef466", size = 4012383, upload-time = "2026-07-16T19:35:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/9d/65cb2e5b6b96acfb3d98a21414293584d4457e28827bf754a377aed39585/awscrt-0.36.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf326cf5248835df4828ddd2ee74ad9e7fa2a294de0d8301e04af2bcd7af3e2a", size = 4303769, upload-time = "2026-07-16T19:35:10.172Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c1/a7addb874a662fff63586e2857c54b1ce72775f02fd8a6b2113370d49e35/awscrt-0.36.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9950a556b5a2d6b3dc5d5aab1755639cc357c0b7fde6f5a4d8bafc3c333f433b", size = 3945220, upload-time = "2026-07-16T19:35:11.693Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ad/ddeaba1a318d1448a7fa522d0acc2ce919f397d75fa63ed0b4f97ad4b7f1/awscrt-0.36.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:48b2622ecf02dcb7092a3b7b7ec92f71b9d7cd234e0bdb72cc9a2faecb4d058a", size = 4186776, upload-time = "2026-07-16T19:35:13.008Z" },
+    { url = "https://files.pythonhosted.org/packages/60/77/adeed08e1cbb207685199ade997f4b523236343914bb7b34af0e276654aa/awscrt-0.36.0-cp310-cp310-win32.whl", hash = "sha256:642ed998d7c794ad3844c23281a68f67adc57c9756eb0c65b0b4f76649d59239", size = 4166268, upload-time = "2026-07-16T19:35:14.541Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/91/b66dd9f28e5d1a38888a3839b4f29eea3e49d05af9bd7fc7dd8ca7defa88/awscrt-0.36.0-cp310-cp310-win_amd64.whl", hash = "sha256:e40a43780a1ea080a8dc9d313be76694b6609bbced7193d182a51bf6662febba", size = 4336657, upload-time = "2026-07-16T19:35:16.022Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/1dd6a63dc5325bdb36f082490fd770aec1fd6565d1aaacb3ff9fd9c2bad7/awscrt-0.36.0-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:1f6dbe7fd755d981c6492f6ad08775060e86e9ccb7d84f6725e4444cee14bf5c", size = 5148128, upload-time = "2026-07-16T19:35:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e6/3ecfa5ad2023bc7e897ccd9f09e6d30d34448c9fddbdb2f7549f7964784e/awscrt-0.36.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:900eb2cf518a3f1c7e9c4ebc320f5a3fac891208992b9428da76e3f0fb0300a5", size = 3972156, upload-time = "2026-07-16T19:35:19.025Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/94/a5fc3f83e4178f20f4e75fbecfaefc1c8d5a1d848eeba100c46226bf966e/awscrt-0.36.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf8bafef584f9d5fead3a88f3b86e0aea957c85ecab5243d0c47858ea3d9b39a", size = 4264588, upload-time = "2026-07-16T19:35:20.437Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8d/0c3d1ea026a20be02a0586dd31c41018a98ec7e52701b1ff68c408e79d09/awscrt-0.36.0-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:1608b45260678aeb4aabdf5f0c69799cb801304b50d065891f96a474e053f908", size = 3880158, upload-time = "2026-07-16T19:35:21.971Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/58/870c1a5adc6d0675e8a4cbb39ea7070ec2860a82b4fa71416bc18cc2f805/awscrt-0.36.0-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:a950c3b4082a687f7e76accc01f937113c6febe13a790856381314323e6a8d03", size = 4121252, upload-time = "2026-07-16T19:35:23.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/a06708ee6caf8d0281a9a7c5f73ec36d5471dda37ccd0b630933c869fa4e/awscrt-0.36.0-cp311-abi3-win32.whl", hash = "sha256:b195103c3b87f02a2c2f278281a64e35dfe57d03d92017097adeb31332731459", size = 4167298, upload-time = "2026-07-16T19:35:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/0a/3fa90ed5283aba9c41f3ea657a4bc71addf6eda0fe85d05aff338f159a53/awscrt-0.36.0-cp311-abi3-win_amd64.whl", hash = "sha256:d4b391736d15f44d452bef0372997c418af44c83d0a11953d0e18a5fd937ba0f", size = 4337077, upload-time = "2026-07-16T19:35:26.236Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/355a9c06805f14ac4e1ac1bdf81c8e50d1308dd8c1ea73ae8b3ff35a09ac/awscrt-0.36.0-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:0ef852c7bd977402f2c82959d9b6c68e39c74bca885d4578cec86e6a3b60c864", size = 5146650, upload-time = "2026-07-16T19:35:27.565Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fb/982bb2798550c469e1fe8ff3b368dbc458f82187a82c38ce6b61456a7a94/awscrt-0.36.0-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01a55a4de4d3d915714590bd50cd3cc430e8f5bce78a4c6b6308c6a7f513ca12", size = 3962528, upload-time = "2026-07-16T19:35:29.166Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/a607e1c70a56bc33008b4a2829334e1b319cf9056419784aaed24dbad9c9/awscrt-0.36.0-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6dba4e0ec0aeec18ecf534081c02357794b89d8a7e12d83f6c970f9d90b1ff0a", size = 4258010, upload-time = "2026-07-16T19:35:30.606Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/57655a46f64a7a5d384248a16ad624d2aac076b8a0e759f3e820a30543d0/awscrt-0.36.0-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:63b726ee7165c5f13ffdd8c57402538a59d01dbc1eeec4eaef75790dbb4ce4d9", size = 3872506, upload-time = "2026-07-16T19:35:32.017Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c7/7963d182695a1a13597d8c1df36364595475eaba26af176a5d892e8199a6/awscrt-0.36.0-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:74e8419f3ab6770082a5a7af267508c72af10b7352bae17b284800ba8e6ec13b", size = 4116622, upload-time = "2026-07-16T19:35:33.477Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/2f/dbefbf49c797a4fc0698f9f5ef51ec6725cc46755e8ce8ecadad07efe64a/awscrt-0.36.0-cp313-abi3-win32.whl", hash = "sha256:ef8e655ffaf245a2d4a5c6ca9a1da12fe72cf43c70457dd07f6e0b162ffed164", size = 4163785, upload-time = "2026-07-16T19:35:35.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b4/710ec9200b10bb3a39eb3308723fb7ee86622e57a2a8b18532e37c191b7a/awscrt-0.36.0-cp313-abi3-win_amd64.whl", hash = "sha256:e1329d9e6b4e1051bf094130fc40d9790cd6986b529bbe8a8bf65ae4fb559d30", size = 4333718, upload-time = "2026-07-16T19:35:36.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/15/d4754f15a54206ea2fe4bb8b2343dc86cf1ae163a413aeb23280feffe129/awscrt-0.36.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:6f0044e3fdc3acb7287dc8285fb0710370b94ffd5d69ee1e01a0f161b5ea0376", size = 5155749, upload-time = "2026-07-16T19:35:37.904Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/64590179bc367832edb16a56ff88d86a73f8bfe070311325851c404331c1/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:93ece6a57527cb6124cda94345adc797bee99ae34bb013c7edcd4bbe09493778", size = 4013555, upload-time = "2026-07-16T19:35:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5f/eba58de79c2e63758805de1d355cbe68a17053cd460f1040c98f7baa9211/awscrt-0.36.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:6231b3940c261ac3c6e2128d9ea3fcaabdeec6f5737c19e4310f98b1c5ea2b8d", size = 4254426, upload-time = "2026-07-16T19:35:41.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a9/49839240e66c8373fe266c9d16218cbce06f31c6e706939e53976c197631/awscrt-0.36.0-cp313-cp313t-win32.whl", hash = "sha256:62d8938540dfa84e754621bcbf9dfdab19a39a4ae2d3a6f350f3d615b1ff4767", size = 4219945, upload-time = "2026-07-16T19:35:42.604Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c6/926f66a4f17d874d60fc60578fe6be58f5a91e64cd8836a94f87d1803bf7/awscrt-0.36.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3c822bb7c98c306484c70564d798400110928a0ea5c9c1b2091b74a5026b4561", size = 4380060, upload-time = "2026-07-16T19:35:44.211Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/43/98fa9bd741ce4e46e9701ee2247635aa5ccfb9fbcf0e5922ab14ff91306d/awscrt-0.36.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4c1a10d5f33a6c3fb1e39474242c6761b9f607c048e688b344acf95354053d65", size = 5155758, upload-time = "2026-07-16T19:35:45.687Z" },
+    { url = "https://files.pythonhosted.org/packages/df/da/b21fff2240b8185afcced69912db6231ff62545e428bc70248c196f73f48/awscrt-0.36.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b76cb47f2ed5c0bf989541ee80ab8f35d9a392d30b5de1e24b17d655e2f63da5", size = 4094173, upload-time = "2026-07-16T19:35:47.317Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9c/b4ecc77494e5930f0bca50ba9b8c9f973ac477e0233c83126cfb81c85327/awscrt-0.36.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bfc4039bc8ee9924d9dfc1558d073305d5d1f0046e87d7773826901d0f0f0792", size = 4384153, upload-time = "2026-07-16T19:35:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/48/ed0f2b0cb2cb5b7fbb89f14574c7b4bb5f7584072054523c3d4424be693e/awscrt-0.36.0-cp314-cp314t-win32.whl", hash = "sha256:2c8ebe57a6d8a329b57b480357767da1ae3af49d243727e826c3317da09397a5", size = 4301556, upload-time = "2026-07-16T19:35:50.48Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a3/9f36da2b735b896c4eb5455d858c4bca80eeadcf6bbfdfafd189de46830f/awscrt-0.36.0-cp314-cp314t-win_amd64.whl", hash = "sha256:edc9814c5ddf4b49e9b4dc5f424b7172afc07a2f7b655338a25d6c87620d2b89", size = 4479687, upload-time = "2026-07-16T19:35:52.014Z" },
 ]
 
 [[package]]
@@ -542,8 +540,8 @@ requires-dist = [
     { name = "a2a-sdk", extras = ["http-server"], marker = "extra == 'a2a-v1'", specifier = ">=1.0.1,<2.0" },
     { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.10" },
     { name = "autoevals", marker = "extra == 'autoevals'", specifier = ">=0.3.0,<1.0.0" },
-    { name = "boto3", specifier = ">=1.43.35" },
-    { name = "botocore", specifier = ">=1.43.35" },
+    { name = "boto3", specifier = ">=1.43.72" },
+    { name = "botocore", specifier = ">=1.43.72" },
     { name = "deepeval", marker = "extra == 'deepeval'", specifier = ">=3.5.0,<5.0.0" },
     { name = "httpx", marker = "extra == 'langgraph'", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'simulation'", specifier = ">=3.1.0" },
@@ -594,30 +592,30 @@ dev = [
 
 [[package]]
 name = "boto3"
-version = "1.43.36"
+version = "1.43.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/9f/897287e955db0f50b12fd69ef45956e4fd2c7ddb48c736872f7ea2314443/boto3-1.43.36.tar.gz", hash = "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28", size = 112690, upload-time = "2026-06-23T02:47:14.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/e4/139572e2459b7e10cd3409888a7312b8b5054c85ea41b28af417002af1c4/boto3-1.43.73.tar.gz", hash = "sha256:6e6c755e5039f204882c01d7936a46abce539b3f5bbb534a23a3f2afbc86f576", size = 112665, upload-time = "2026-08-17T20:39:43.686Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/f1/274303f52483ecf199eae6f8d9b6f5951670397ee4d72c06cfd4eb644612/boto3-1.43.36-py3-none-any.whl", hash = "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f", size = 140031, upload-time = "2026-06-23T02:47:13.178Z" },
+    { url = "https://files.pythonhosted.org/packages/97/20/e4a415a5a3185bd13aec89603917203ff0b274caa9f0b0329d12aa397ff0/boto3-1.43.73-py3-none-any.whl", hash = "sha256:5b54da301c387abe30c5b3a5335652f1ebd73e814c725ba805d27a2d477ce547", size = 140024, upload-time = "2026-08-17T20:39:41.636Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.36"
+version = "1.43.73"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/37/da9e7f6ca73ac73afd7f0bb7f238aa5daba35c081e98d7f48a7c399599c0/botocore-1.43.36.tar.gz", hash = "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205", size = 15625488, upload-time = "2026-06-23T02:47:03.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/c8482ada4f409c91e6f9d640ee15838975f2a7c481dff98419a6d176b81a/botocore-1.43.73.tar.gz", hash = "sha256:0fa1e63c24b3531be3e1bc1687a88b3be9e63a430153f24edd93efc162bb1c51", size = 15963105, upload-time = "2026-08-17T20:39:37.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/19/934f81592527a3f7f9b943c893e334c721a4644948642bc33885d584e9ec/botocore-1.43.36-py3-none-any.whl", hash = "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d", size = 15313630, upload-time = "2026-06-23T02:46:59.327Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/b0f2332029b4cc06281932f8e4908a9616ed756ad9da55fca07a949ea811/botocore-1.43.73-py3-none-any.whl", hash = "sha256:068433028e011ccbeab1dd7c46b1090c24e378397693c66e67ca571176498daa", size = 15653468, upload-time = "2026-08-17T20:39:34.332Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds three incremental payment capabilities to the AgentCore Python SDK.

### Machine Payments Protocol (MPP)

- Parses `WWW-Authenticate: Payment` challenges and selects one compatible with the configured payment instrument.
- Rejects malformed challenges before selection so they cannot suppress valid MPP or x402 alternatives.
- Supports EVM, Tempo, and Solana charge methods with network-preference and expiry handling.
- Routes MPP requests through `ProcessPayment` and returns `Authorization: Payment <credential>`.
- Supports optional `buyer_pays_gas_fees`.
- Falls back to x402 when a response advertises both protocols and no MPP challenge is satisfiable.
- Extends the Strands plugin and LangGraph middleware with automatic MPP detection, settlement, retry, and receipt handling.
- Reuses an already-generated credential when LangGraph retries the paid request, preventing duplicate payment submission.

### x402 `upto`

- Adds the optional `permit2_allowance_limit` integration setting.
- Passes the configured allowance as `cryptoX402.permit2AllowanceLimit` only for a selected `upto` requirement.
- Validates the Smithy-compatible positive ASCII integer shape and threads the setting through Strands and LangGraph.

### PaymentConnector Quick Create

- Adds `PaymentConnectorProvisionMode` with `MANUAL` and `QUICK_CREATE`.
- Accepts the exported enum directly and threads its value through `PaymentClient.create_payment_connector`.
- Supports an empty credential-provider configuration list for Quick Create.
- Surfaces the live `authorizationUrl` from create and get responses while the connector is `PENDING_AUTHENTICATION`.
- Rejects `wait_for_ready=True` for Quick Create because user consent must happen before the connector can become ready.
- Adds the Quick Create connector statuses `PENDING_AUTHENTICATION`, `PROVISIONING`, `AUTHENTICATION_EXPIRED`, and `AUTHENTICATION_FAILED`.
- Preserves existing manual behavior by omitting `provisionMode` when it is not supplied.
- Preserves positional compatibility for the existing wait configuration arguments.

## Release Dependencies

This change requires `boto3>=1.43.72` and `botocore>=1.43.72`, the first published model release containing:

- Native MPP input/output shapes.
- `permit2AllowanceLimit`.
- PaymentConnector `provisionMode`, Quick Create statuses, and `authorizationUrl`.

The package dependency floor and lockfile enforce that requirement.

## Verification

- Focused regression suite: `495 passed`.
- Full Payments suite: `901 passed, 9 skipped`.
- Full SDK suite: `3360 passed, 10 skipped, 4 xpassed`.
- Pre-commit and pre-push gates passed, including Bandit and full coverage.
- Live `mpp.dev` detection/header-preservation tests passed.
- MPP integration module with current Botocore models: `8 passed, 6 resource-dependent skipped`.
- `uv build` produced the wheel and source distribution.
- Final wheel installed successfully against the exact minimum Boto3/Botocore `1.43.72` versions.
- Local Griffe analysis found no breaking changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
