### PR TITLE
ci: use dedicated release runners

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     outputs:
       version: ${{ steps.bump.outputs.version }}
 
@@ -174,7 +174,7 @@ jobs:
   test-and-build:
     name: Test and Build
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Moves the manually triggered release preparation workflow to the dedicated `aws-release-4-core` GitHub-hosted runner group. This prevents release preparation from waiting behind the shared `ubuntu-latest` pool.

The `release-publish.yml` workflow is intentionally unchanged because it is triggered by `pull_request: closed`; the dedicated runner is restricted to release workflows triggered by `workflow_dispatch` or pushes to `main`.

## Testing

Parsed both release workflows as YAML, verified every job in `release-prepare.yml` uses `aws-release-4-core`, and verified the pull-request-triggered publish workflow does not use the dedicated runner. Source tests were not run because this change only updates workflow runner labels.

## Security

No permissions, triggers, dependencies, or secrets changed.
